### PR TITLE
fix: Stop onboarding GitHub refresh loop

### DIFF
--- a/web_src/src/pages/auth/OrganizationOnboardingRedirect.component.spec.tsx
+++ b/web_src/src/pages/auth/OrganizationOnboardingRedirect.component.spec.tsx
@@ -1,21 +1,71 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AccountContextType } from "@/contexts/accountContextState";
 
 import { OrganizationOnboardingRedirect } from "./OrganizationOnboardingRedirect";
 
+const accountState = vi.hoisted(() => ({
+  account: {
+    id: "account-1",
+    name: "Dev User",
+    email: "dev@superplane.local",
+    avatar_url: "",
+    installation_admin: false,
+    has_password: true,
+    linked_accounts: [{ provider: "github", username: "dev-user" }],
+    providers: [],
+  } as NonNullable<AccountContextType["account"]>,
+}));
+
+const location = vi.hoisted(() => ({
+  replace: vi.fn(),
+  assign: vi.fn(),
+}));
+
 vi.mock("@/contexts/useAccount", () => ({
   useAccount: () => ({
-    account: {
-      id: "account-1",
-      linked_accounts: [{ provider: "github", username: "dev-user" }],
-      providers: [],
-    },
+    account: accountState.account,
   }),
 }));
 
+function renderOnboarding() {
+  return render(
+    <OrganizationOnboardingRedirect
+      renderWorkspace={(workspace, entryPath) => (
+        <div data-entry-path={entryPath} data-testid="internal-workspace-key">
+          {workspace.workspaceKey}
+        </div>
+      )}
+    />,
+  );
+}
+
 describe("OrganizationOnboardingRedirect", () => {
   beforeEach(() => {
+    accountState.account = {
+      id: "account-1",
+      name: "Dev User",
+      email: "dev@superplane.local",
+      avatar_url: "",
+      installation_admin: false,
+      has_password: true,
+      linked_accounts: [{ provider: "github", username: "dev-user" }],
+      providers: [],
+    };
+    location.replace.mockReset();
+    location.assign.mockReset();
     window.history.replaceState(null, "", "/onboarding");
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        pathname: "/onboarding",
+        search: "",
+        replace: location.replace,
+        assign: location.assign,
+      },
+    });
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -26,19 +76,75 @@ describe("OrganizationOnboardingRedirect", () => {
   });
 
   it("keeps the provisional workspace behind the onboarding route", async () => {
-    render(
-      <OrganizationOnboardingRedirect
-        renderWorkspace={(workspace, entryPath) => (
-          <div data-entry-path={entryPath} data-testid="internal-workspace-key">
-            {workspace.workspaceKey}
-          </div>
-        )}
-      />,
-    );
+    renderOnboarding();
 
     const workspace = await screen.findByTestId("internal-workspace-key");
     expect(workspace).toHaveTextContent("NEWWO");
     expect(workspace.dataset.entryPath).toMatch(/^\/onboarding\?attempt=[0-9a-f-]+$/);
-    expect(window.location.pathname).toBe("/onboarding");
+    expect(location.replace).not.toHaveBeenCalled();
+  });
+
+  it("connects GitHub when the account has no GitHub identity", async () => {
+    accountState.account.linked_accounts = [];
+    accountState.account.providers = [];
+
+    renderOnboarding();
+
+    await waitFor(() => {
+      expect(location.replace).toHaveBeenCalledWith("/auth/github?intent=connect&redirect=%2Fonboarding");
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("shows a sign-in conflict and does not restart GitHub", async () => {
+    accountState.account.linked_accounts = [];
+    accountState.account.providers = [];
+    window.history.replaceState(
+      null,
+      "",
+      "/onboarding?auth_error=signin_method_in_use&provider=github&attempt=42d6ce14-6153-4390-85fe-3d15e9df53c9",
+    );
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        pathname: "/onboarding",
+        search: "?auth_error=signin_method_in_use&provider=github&attempt=42d6ce14-6153-4390-85fe-3d15e9df53c9",
+        replace: location.replace,
+        assign: location.assign,
+      },
+    });
+
+    renderOnboarding();
+
+    expect(
+      await screen.findByText(
+        "This GitHub identity already belongs to another SuperPlane account. Delete that account first.",
+      ),
+    ).toBeInTheDocument();
+    expect(location.replace).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Connect GitHub" }));
+    expect(location.assign).toHaveBeenCalledWith("/auth/github?intent=connect&redirect=%2Fonboarding");
+  });
+
+  it("shows a linked-account conflict and does not restart GitHub", async () => {
+    accountState.account.linked_accounts = [];
+    accountState.account.providers = [];
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        pathname: "/onboarding",
+        search: "?auth_error=linked_account_in_use&provider=github&attempt=42d6ce14-6153-4390-85fe-3d15e9df53c9",
+        replace: location.replace,
+        assign: location.assign,
+      },
+    });
+
+    renderOnboarding();
+
+    expect(await screen.findByText("Another SuperPlane account already uses this GitHub account.")).toBeInTheDocument();
+    expect(location.replace).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/web_src/src/pages/auth/OrganizationOnboardingRedirect.spec.ts
+++ b/web_src/src/pages/auth/OrganizationOnboardingRedirect.spec.ts
@@ -1,9 +1,31 @@
 import { describe, expect, it } from "vitest";
 
-import { getGitHubAccountLinkHref } from "./githubAccountLinkHref";
+import { linkedAccountConnectHref } from "@/lib/accountSettings";
 
-describe("getGitHubAccountLinkHref", () => {
-  it("links GitHub to the current account before resuming onboarding", () => {
-    expect(getGitHubAccountLinkHref()).toBe("/auth/github?intent=link&redirect=%2Fonboarding");
+import { getGitHubAccountConnectHref, githubOnboardingAuthErrorMessage } from "./githubAccountLinkHref";
+
+describe("getGitHubAccountConnectHref", () => {
+  it("connects GitHub as a linked account before resuming onboarding", () => {
+    expect(getGitHubAccountConnectHref()).toBe(linkedAccountConnectHref("github", "/onboarding"));
+    expect(getGitHubAccountConnectHref()).toBe("/auth/github?intent=connect&redirect=%2Fonboarding");
+  });
+});
+
+describe("githubOnboardingAuthErrorMessage", () => {
+  it("explains when the GitHub identity is already a sign-in method", () => {
+    expect(githubOnboardingAuthErrorMessage("signin_method_in_use")).toBe(
+      "This GitHub identity already belongs to another SuperPlane account. Delete that account first.",
+    );
+  });
+
+  it("explains when another account already linked this GitHub identity", () => {
+    expect(githubOnboardingAuthErrorMessage("linked_account_in_use")).toBe(
+      "Another SuperPlane account already uses this GitHub account.",
+    );
+  });
+
+  it("gives a recovery message for an unknown auth error", () => {
+    expect(githubOnboardingAuthErrorMessage("unknown")).toBe("We could not connect GitHub. Try again.");
+    expect(githubOnboardingAuthErrorMessage(null)).toBeNull();
   });
 });

--- a/web_src/src/pages/auth/OrganizationOnboardingRedirect.tsx
+++ b/web_src/src/pages/auth/OrganizationOnboardingRedirect.tsx
@@ -1,6 +1,8 @@
+import { Button } from "@/components/ui/button";
 import { useAccount } from "@/contexts/useAccount";
-import { getGitHubAccountLinkHref } from "./githubAccountLinkHref";
 import { useEffect, useRef, useState, type ReactNode } from "react";
+
+import { getGitHubAccountConnectHref, githubOnboardingAuthErrorMessage } from "./githubAccountLinkHref";
 
 export type ProvisionedWorkspace = {
   organizationSlug: string;
@@ -15,7 +17,8 @@ interface OrganizationOnboardingRedirectProps {
 export function OrganizationOnboardingRedirect({ renderWorkspace }: OrganizationOnboardingRedirectProps) {
   const { account } = useAccount();
   const hasStartedProvisioning = useRef(false);
-  const [error, setError] = useState<string | null>(null);
+  const githubAuthError = useRef(consumeOnboardingAuthError()).current;
+  const [error, setError] = useState<string | null>(githubOnboardingAuthErrorMessage(githubAuthError));
   const [workspace, setWorkspace] = useState<ProvisionedWorkspace | null>(null);
   const githubAccount = account?.linked_accounts?.find((candidate) => candidate.provider === "github");
   const githubProvider = account?.providers?.find((candidate) => candidate.provider === "github");
@@ -23,10 +26,10 @@ export function OrganizationOnboardingRedirect({ renderWorkspace }: Organization
   const onboardingAttempt = useRef(getOnboardingAttempt());
 
   useEffect(() => {
-    if (!account || hasStartedProvisioning.current) return;
+    if (!account || hasStartedProvisioning.current || githubAuthError) return;
 
     if (!owner) {
-      window.location.replace(getGitHubAccountLinkHref());
+      window.location.replace(getGitHubAccountConnectHref());
       return;
     }
 
@@ -36,7 +39,7 @@ export function OrganizationOnboardingRedirect({ renderWorkspace }: Organization
       .catch((provisioningError: unknown) => {
         setError(provisioningError instanceof Error ? provisioningError.message : "Could not start workspace setup.");
       });
-  }, [account, owner]);
+  }, [account, githubAuthError, owner]);
 
   if (workspace) {
     return renderWorkspace(workspace, onboardingAttempt.current.entryPath);
@@ -45,10 +48,31 @@ export function OrganizationOnboardingRedirect({ renderWorkspace }: Organization
   if (!error) return null;
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-background px-6 text-foreground">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background px-6 text-foreground">
       <p className="text-sm text-destructive">{error}</p>
+      {githubAuthError ? (
+        <Button type="button" onClick={() => window.location.assign(getGitHubAccountConnectHref())}>
+          Connect GitHub
+        </Button>
+      ) : null}
     </main>
   );
+}
+
+function consumeOnboardingAuthError(): string | null {
+  const searchParams = new URLSearchParams(window.location.search);
+  const error = searchParams.get("auth_error");
+  if (!error) {
+    return null;
+  }
+
+  searchParams.delete("auth_error");
+  searchParams.delete("auth_link_result");
+  searchParams.delete("linked_account");
+  searchParams.delete("provider");
+  const search = searchParams.toString();
+  window.history.replaceState(null, "", search ? `${window.location.pathname}?${search}` : window.location.pathname);
+  return error;
 }
 
 function getOnboardingAttempt(): { id: string; entryPath: string } {

--- a/web_src/src/pages/auth/githubAccountLinkHref.ts
+++ b/web_src/src/pages/auth/githubAccountLinkHref.ts
@@ -1,8 +1,18 @@
-export function getGitHubAccountLinkHref(): string {
-  const params = new URLSearchParams({
-    intent: "link",
-    redirect: "/onboarding",
-  });
+import { linkedAccountConnectHref } from "@/lib/accountSettings";
 
-  return `/auth/github?${params}`;
+export function getGitHubAccountConnectHref(): string {
+  return linkedAccountConnectHref("github", "/onboarding");
+}
+
+export function githubOnboardingAuthErrorMessage(error: string | null | undefined): string | null {
+  if (error === "signin_method_in_use") {
+    return "This GitHub identity already belongs to another SuperPlane account. Delete that account first.";
+  }
+  if (error === "linked_account_in_use") {
+    return "Another SuperPlane account already uses this GitHub account.";
+  }
+  if (error) {
+    return "We could not connect GitHub. Try again.";
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

Create organization opened `/onboarding`, which started GitHub sign-in linking whenever the account had no GitHub owner name. A failed link returned `auth_error=signin_method_in_use`, and the page ignored that query and started OAuth again. That produced a refresh loop, often without a GitHub prompt.

This change stops automatic OAuth after an auth error, shows the same conflict copy as account settings, and connects GitHub as a linked identity (`intent=connect`) instead of a sign-in method.

## Test plan

- [ ] Run the OrganizationOnboardingRedirect unit tests
- [ ] Open Create new organization on an account that already has a GitHub linked account or sign-in username
- [ ] Open Create new organization on an account with no GitHub identity and confirm the browser goes to `intent=connect`
- [ ] Open `/onboarding?auth_error=signin_method_in_use&provider=github` and confirm the page shows the error and does not refresh
- [ ] Click Connect GitHub on that error page and confirm OAuth starts only from that action


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["fix: Stop onboarding GitHub refresh loop"](https://github.com/superplanehq/superplane/commit/f72f23bc6bb28ffd195324b8ad93d4a43f57805a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60271150)</sub>

<!-- /greptile_comment -->