### PR TITLE
fix: Flush Radix Focus After Dialog Tests

### DIFF
--- a/web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.spec.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChangeEvent } from "react";
 
 import type { ConfigurationField } from "@/api-client";
@@ -83,6 +83,16 @@ function ControlledText({
     />
   );
 }
+
+afterEach(async () => {
+  // Radix FocusScope schedules setTimeout(0) on unmount to restore focus.
+  // Flush that timer while this file's jsdom is still alive. If it fires
+  // during environment teardown, dispatchEvent throws and fails the shard.
+  cleanup();
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+});
 
 describe("TextFieldRenderer plain textarea expansion", () => {
   it("shows an accessible expand button next to plain multiline inputs", () => {


### PR DESCRIPTION
## Summary

Main CI failed after #7183. Every test in `TextFieldRenderer.spec.tsx` passed, but Vitest still reported an unhandled `dispatchEvent` TypeError.

Radix FocusScope restores focus on a zero-delay timer after the dialog unmounts. That timer can fire during jsdom teardown. This change flushes the timer in the spec after each test, the same way other dialog specs already do.

This failure is not caused by the onboarding name change.

## Test plan

- [ ] Run `npx vitest run src/ui/configurationFieldRenderer/TextFieldRenderer.spec.tsx`.
- [ ] Confirm the file reports 16 passed tests and no unhandled errors.
- [ ] Confirm `ci/semaphoreci/pr: CI` is green.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["fix: Flush Radix focus after dialog test..."](https://github.com/superplanehq/superplane/commit/a1ada5160171fe89183f2f09d16d8dfd688b296e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60290027)</sub>

<!-- /greptile_comment -->