### PR TITLE
feat: Let Operators Pick a Draft Start Model

### DIFF
--- a/db/migrations/20260904070917_add-line-dispatch-model.up.sql
+++ b/db/migrations/20260904070917_add-line-dispatch-model.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE factory_work_order_line_dispatches
+  ADD COLUMN model TEXT NOT NULL DEFAULT '';

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -743,7 +743,8 @@ CREATE TABLE public.factory_work_order_line_dispatches (
     result character varying(32) DEFAULT ''::character varying NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    finished_at timestamp with time zone
+    finished_at timestamp with time zone,
+    model text DEFAULT ''::text NOT NULL
 );
 
 
@@ -4237,7 +4238,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260902175657	f
+20260904070917	f
 \.
 
 

--- a/pkg/authorization/gateway_auth_rules.go
+++ b/pkg/authorization/gateway_auth_rules.go
@@ -326,6 +326,12 @@ func DefaultAuthorizationRules() map[HTTPRoute]AuthorizationRule {
 			DomainType:                   models.DomainTypeOrganization,
 			RequiredExperimentalFeatures: []string{features.FeatureFactories},
 		},
+		{Method: "GET", Pattern: "/api/v1/factories/{factory_id}/line-runner-models"}: {
+			Resource:                     "factories",
+			Action:                       "read",
+			DomainType:                   models.DomainTypeOrganization,
+			RequiredExperimentalFeatures: []string{features.FeatureFactories},
+		},
 		{Method: "GET", Pattern: "/api/v1/factories/{factory_id}/orders/{order_id}/checks"}: {
 			Resource:                     "work_orders",
 			Action:                       "read",

--- a/pkg/authorization/http_route_match_test.go
+++ b/pkg/authorization/http_route_match_test.go
@@ -63,6 +63,12 @@ func TestMatchHTTPRoute(t *testing.T) {
 			want:   HTTPRoute{Method: http.MethodGet, Pattern: "/api/v1/me/notification-settings"},
 			wantOK: true,
 		},
+		{
+			method: http.MethodGet,
+			path:   "/api/v1/factories/factory-123/line-runner-models",
+			want:   HTTPRoute{Method: http.MethodGet, Pattern: "/api/v1/factories/{factory_id}/line-runner-models"},
+			wantOK: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/grpc/actions/factories/dispatch_work_order.go
+++ b/pkg/grpc/actions/factories/dispatch_work_order.go
@@ -3,6 +3,7 @@ package factories
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -80,6 +81,17 @@ func DispatchWorkOrder(ctx context.Context, organizationID string, req *pb.Dispa
 			return models.ErrFactoryLineHasNoSteps
 		}
 
+		model := strings.TrimSpace(req.GetModel())
+		if model != "" {
+			allowed, err := listLineRunnerModels(tx, orgID, factoryID, lineName)
+			if err != nil {
+				return err
+			}
+			if !slices.Contains(allowed, model) {
+				return invalidArgument("model is not available on this line")
+			}
+		}
+
 		startIndex := int(req.GetStartStepIndex())
 		fromState = order.State
 		if err := order.TransitionOnDispatch(tx, actor); err != nil {
@@ -110,7 +122,7 @@ func DispatchWorkOrder(ctx context.Context, organizationID string, req *pb.Dispa
 			return err
 		}
 
-		_, result, err := line.DispatchFrom(tx, order, startIndex)
+		_, result, err := line.DispatchFromWithModel(tx, order, startIndex, model)
 		if err != nil {
 			return err
 		}

--- a/pkg/grpc/actions/factories/dispatch_work_order_test.go
+++ b/pkg/grpc/actions/factories/dispatch_work_order_test.go
@@ -49,6 +49,7 @@ func Test__DispatchWorkOrder__CreatesLineDispatchWithSnapshot(t *testing.T) {
 	dispatch := resp.Order.LineDispatches[0]
 	assert.Equal(t, pb.WorkOrderLineDispatch_STATE_ACTIVE, dispatch.State)
 	assert.Equal(t, line.Name, dispatch.Line.Name)
+	assert.Empty(t, dispatch.Model)
 	require.Len(t, dispatch.Steps, 1)
 	assert.Equal(t, app.Name, dispatch.Steps[0].Name)
 	require.Len(t, dispatch.StepExecutions, 1)
@@ -310,4 +311,64 @@ func Test__DispatchWorkOrder__ReturnsOwnerNameAfterStart(t *testing.T) {
 	assert.Equal(t, r.User.String(), resp.Order.Assignees[0].Id)
 	assert.Equal(t, r.UserModel.Name, resp.Order.Assignees[0].Name)
 	assert.NotEqual(t, r.User.String(), resp.Order.Assignees[0].Name)
+}
+
+func Test__DispatchWorkOrder__PersistsChosenModel(t *testing.T) {
+	r := support.Setup(t)
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	db := database.DB(t.Context())
+
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	seedHostedModels(t, db, models.UsageProviderAnthropic, "claude-sonnet-4-6", "claude-opus-4-6")
+
+	app := createLineAppWithRunner(t, r, factoryModel.ID, runnerClaudeCode, "hosted", "claude-sonnet-4-6")
+	order, err := factoryModel.CreateWorkOrder(db, "Ship it", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	line, err := factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
+		{Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: "start"},
+	})
+	require.NoError(t, err)
+
+	resp, err := DispatchWorkOrder(ctx, r.Organization.ID.String(), &pb.DispatchWorkOrderRequest{
+		FactoryId: factoryModel.ID.String(),
+		OrderId:   order.ID.String(),
+		LineName:  line.Name,
+		Model:     "claude-opus-4-6",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Order.LineDispatches, 1)
+	assert.Equal(t, "claude-opus-4-6", resp.Order.LineDispatches[0].Model)
+
+	active, err := order.FindActiveLineDispatch(db)
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-6", active.Model)
+}
+
+func Test__DispatchWorkOrder__RejectsModelNotOnLine(t *testing.T) {
+	r := support.Setup(t)
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	db := database.DB(t.Context())
+
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	seedHostedModels(t, db, models.UsageProviderAnthropic, "claude-sonnet-4-6")
+	seedHostedModels(t, db, models.UsageProviderOpenAI, "gpt-5")
+
+	app := createLineAppWithRunner(t, r, factoryModel.ID, runnerClaudeCode, "hosted", "claude-sonnet-4-6")
+	order, err := factoryModel.CreateWorkOrder(db, "Ship it", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	line, err := factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
+		{Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: "start"},
+	})
+	require.NoError(t, err)
+
+	_, err = DispatchWorkOrder(ctx, r.Organization.ID.String(), &pb.DispatchWorkOrderRequest{
+		FactoryId: factoryModel.ID.String(),
+		OrderId:   order.ID.String(),
+		LineName:  line.Name,
+		Model:     "gpt-5",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, grpcerrors.Code(err))
 }

--- a/pkg/grpc/actions/factories/line_runner_models.go
+++ b/pkg/grpc/actions/factories/line_runner_models.go
@@ -1,0 +1,128 @@
+package factories
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"gorm.io/gorm"
+)
+
+const (
+	runnerClaudeCode = "runnerClaudeCode"
+	runnerCodex      = "runnerCodex"
+	runnerOpenRouter = "runnerOpenRouter"
+)
+
+func ListFactoryLineRunnerModels(
+	ctx context.Context,
+	organizationID string,
+	req *pb.ListFactoryLineRunnerModelsRequest,
+) (*pb.ListFactoryLineRunnerModelsResponse, error) {
+	orgID, err := parseOrganizationID(organizationID)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to list line runner models")
+	}
+	factoryID, err := parseFactoryID(req.GetFactoryId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to list line runner models")
+	}
+
+	ids, err := listLineRunnerModels(database.DB(ctx), orgID, factoryID, req.GetLineName())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to list line runner models")
+	}
+
+	return &pb.ListFactoryLineRunnerModelsResponse{
+		Models: serializeFactoryLLMModels(ids),
+	}, nil
+}
+
+func listLineRunnerModels(tx *gorm.DB, orgID, factoryID uuid.UUID, lineName string) ([]string, error) {
+	lineName = strings.TrimSpace(lineName)
+	if lineName == "" {
+		return nil, invalidArgument("line_name is required")
+	}
+
+	factory, err := models.FindFactory(tx, orgID, factoryID)
+	if err != nil {
+		return nil, err
+	}
+	line, err := factory.FindLineByName(tx, lineName)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]struct{}{}
+	var out []string
+	for _, step := range line.Steps {
+		if step.AppID == uuid.Nil {
+			continue
+		}
+		version, err := models.FindLiveCanvasVersionInTransaction(tx, step.AppID)
+		if err != nil {
+			return nil, err
+		}
+		for _, node := range []models.Node(version.Nodes) {
+			provider, ok := runnerComponentProvider(node.ComponentName())
+			if !ok {
+				continue
+			}
+			ids, err := models.ResolveSelectableLLMModels(
+				tx,
+				orgID,
+				&factoryID,
+				provider,
+				runnerFundingSource(node.Configuration),
+			)
+			if err != nil {
+				return nil, err
+			}
+			if stored := storedRunnerModel(node.Configuration); stored != "" {
+				ids = append(ids, stored)
+			}
+			for _, id := range ids {
+				if _, dup := seen[id]; dup {
+					continue
+				}
+				seen[id] = struct{}{}
+				out = append(out, id)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func runnerComponentProvider(component string) (string, bool) {
+	switch component {
+	case runnerClaudeCode:
+		return models.UsageProviderAnthropic, true
+	case runnerCodex:
+		return models.UsageProviderOpenAI, true
+	case runnerOpenRouter:
+		return models.UsageProviderOpenRouter, true
+	default:
+		return "", false
+	}
+}
+
+func storedRunnerModel(configuration map[string]any) string {
+	model, _ := configuration["model"].(string)
+	return strings.TrimSpace(model)
+}
+
+func runnerFundingSource(configuration map[string]any) string {
+	credentials, _ := configuration["credentials"].(map[string]any)
+	source, _ := credentials["source"].(string)
+	switch strings.TrimSpace(source) {
+	case "secret", "integration":
+		return models.UsageFundingSourceBYOK
+	default:
+		return models.UsageFundingSourceHosted
+	}
+}

--- a/pkg/grpc/actions/factories/line_runner_models_test.go
+++ b/pkg/grpc/actions/factories/line_runner_models_test.go
@@ -1,0 +1,238 @@
+package factories
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func Test__ListLineRunnerModels__ClaudeLineUsesAnthropicAllowlist(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	seedHostedModels(t, db, models.UsageProviderAnthropic, "claude-sonnet-4-6", "claude-opus-4-6")
+	seedHostedModels(t, db, models.UsageProviderOpenAI, "gpt-5")
+
+	app := createLineAppWithRunner(t, r, factoryModel.ID, runnerClaudeCode, "hosted", "claude-sonnet-4-6")
+	_, err = factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
+		{Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: "start"},
+	})
+	require.NoError(t, err)
+
+	ids, err := listLineRunnerModels(db, r.Organization.ID, factoryModel.ID, "ship")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"claude-opus-4-6", "claude-sonnet-4-6"}, ids)
+	assert.NotContains(t, ids, "gpt-5")
+}
+
+func Test__ListLineRunnerModels__CodexLineOmitsClaudeAliases(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	seedHostedModels(t, db, models.UsageProviderAnthropic, "sonnet", "opus")
+	seedHostedModels(t, db, models.UsageProviderOpenAI, "gpt-5", "gpt-5-mini")
+
+	app := createLineAppWithRunner(t, r, factoryModel.ID, runnerCodex, "hosted", "gpt-5")
+	_, err = factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
+		{Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: "start"},
+	})
+	require.NoError(t, err)
+
+	ids, err := listLineRunnerModels(db, r.Organization.ID, factoryModel.ID, "ship")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"gpt-5", "gpt-5-mini"}, ids)
+	assert.NotContains(t, ids, "sonnet")
+	assert.NotContains(t, ids, "opus")
+}
+
+func Test__ListLineRunnerModels__OpenRouterLineUsesOpenRouterIds(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	seedHostedModels(t, db, models.UsageProviderOpenRouter, "anthropic/claude-sonnet-4-6", "openai/gpt-5")
+
+	app := createLineAppWithRunner(t, r, factoryModel.ID, runnerOpenRouter, "hosted", "anthropic/claude-sonnet-4-6")
+	_, err = factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
+		{Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: "start"},
+	})
+	require.NoError(t, err)
+
+	ids, err := listLineRunnerModels(db, r.Organization.ID, factoryModel.ID, "ship")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"anthropic/claude-sonnet-4-6", "openai/gpt-5"}, ids)
+}
+
+func Test__ListLineRunnerModels__MixedLineUnionsProviders(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	seedHostedModels(t, db, models.UsageProviderAnthropic, "claude-sonnet-4-6")
+	seedHostedModels(t, db, models.UsageProviderOpenAI, "gpt-5")
+
+	claudeApp := createLineAppWithRunner(t, r, factoryModel.ID, runnerClaudeCode, "hosted", "claude-sonnet-4-6")
+	codexApp := createLineAppWithRunner(t, r, factoryModel.ID, runnerCodex, "hosted", "gpt-5")
+	_, err = factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
+		{Type: models.FactoryLineStepTypeRunApp, AppID: claudeApp.ID, Entrypoint: "start"},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: codexApp.ID, Entrypoint: "start"},
+	})
+	require.NoError(t, err)
+
+	ids, err := listLineRunnerModels(db, r.Organization.ID, factoryModel.ID, "ship")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"claude-sonnet-4-6", "gpt-5"}, ids)
+}
+
+func Test__ListLineRunnerModels__IncludesCanvasModelsWhenAllowlistEmpty(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+
+	planning := createLineAppWithRunner(t, r, factoryModel.ID, runnerClaudeCode, "integration", "opus")
+	implement := createLineAppWithRunner(t, r, factoryModel.ID, runnerClaudeCode, "integration", "sonnet")
+	_, err = factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
+		{Type: models.FactoryLineStepTypeRunApp, AppID: planning.ID, Entrypoint: "start"},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: implement.ID, Entrypoint: "start"},
+	})
+	require.NoError(t, err)
+
+	ids, err := listLineRunnerModels(db, r.Organization.ID, factoryModel.ID, "ship")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"opus", "sonnet"}, ids)
+}
+
+func Test__ListLineRunnerModels__NoRunnerNodesReturnsEmpty(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	seedHostedModels(t, db, models.UsageProviderAnthropic, "claude-sonnet-4-6")
+
+	app, entrypoint := support.CreateFactoryAppWithOnRunTrigger(t, r, factoryModel.ID, "plain", "start")
+	_, err = factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
+		{Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: entrypoint},
+	})
+	require.NoError(t, err)
+
+	ids, err := listLineRunnerModels(db, r.Organization.ID, factoryModel.ID, "ship")
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
+func seedHostedModels(t *testing.T, db *gorm.DB, provider string, modelsIDs ...string) {
+	t.Helper()
+	var previous models.HostedLLMProvider
+	hadPrevious := db.Where("provider = ?", provider).First(&previous).Error == nil
+	t.Cleanup(func() {
+		if hadPrevious {
+			_, _ = models.UpsertHostedLLMProvider(database.Conn(), previous)
+			return
+		}
+		_ = database.Conn().Where("provider = ?", provider).Delete(&models.HostedLLMProvider{})
+	})
+	_, err := models.UpsertHostedLLMProvider(db, models.HostedLLMProvider{
+		Provider:      provider,
+		Enabled:       true,
+		APIKey:        []byte("encrypted"),
+		AllowedModels: datatypes.JSONSlice[string](modelsIDs),
+	})
+	require.NoError(t, err)
+}
+
+func createLineAppWithRunner(
+	t *testing.T,
+	r *support.ResourceRegistry,
+	factoryID uuid.UUID,
+	component string,
+	credentialSource string,
+	model string,
+) *models.Canvas {
+	t.Helper()
+	now := time.Now()
+	liveVersionID := uuid.New()
+	canvas := &models.Canvas{
+		ID:             uuid.New(),
+		OrganizationID: r.Organization.ID,
+		LiveVersionID:  &liveVersionID,
+		FactoryID:      &factoryID,
+		Name:           support.RandomName("app"),
+		CreatedBy:      &r.User,
+		CreatedAt:      &now,
+		UpdatedAt:      &now,
+	}
+	require.NoError(t, database.Conn().Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(canvas).Error; err != nil {
+			return err
+		}
+		if err := tx.Create(&models.CanvasNode{
+			WorkflowID: canvas.ID,
+			NodeID:     "start",
+			Name:       "start",
+			Type:       models.NodeTypeTrigger,
+			State:      models.CanvasNodeStateReady,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Trigger: &models.TriggerRef{Name: "onRun"},
+			}),
+			CreatedAt: &now,
+			UpdatedAt: &now,
+		}).Error; err != nil {
+			return err
+		}
+		if err := tx.Create(&models.CanvasNode{
+			WorkflowID: canvas.ID,
+			NodeID:     "agent",
+			Name:       "agent",
+			Type:       models.NodeTypeComponent,
+			State:      models.CanvasNodeStateReady,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Component: &models.ComponentRef{Name: component},
+			}),
+			CreatedAt: &now,
+			UpdatedAt: &now,
+		}).Error; err != nil {
+			return err
+		}
+		return tx.Create(&models.CanvasVersion{
+			ID:         liveVersionID,
+			WorkflowID: canvas.ID,
+			OwnerID:    &r.User,
+			Nodes: datatypes.NewJSONSlice([]models.Node{
+				{
+					ID:   "start",
+					Name: "start",
+					Type: models.NodeTypeTrigger,
+					Ref:  models.NodeRef{Trigger: &models.TriggerRef{Name: "onRun"}},
+				},
+				{
+					ID:   "agent",
+					Name: "agent",
+					Type: models.NodeTypeComponent,
+					Ref:  models.NodeRef{Component: &models.ComponentRef{Name: component}},
+					Configuration: map[string]any{
+						"model": model,
+						"credentials": map[string]any{
+							"source": credentialSource,
+						},
+					},
+				},
+			}),
+			Edges:     datatypes.NewJSONSlice([]models.Edge{}),
+			CreatedAt: &now,
+			UpdatedAt: &now,
+		}).Error
+	}))
+	return canvas
+}

--- a/pkg/grpc/actions/factories/serialization.go
+++ b/pkg/grpc/actions/factories/serialization.go
@@ -448,6 +448,7 @@ func serializeWorkOrderLineDispatch(dispatch models.FactoryWorkOrderLineDispatch
 		Result:         serializeLineDispatchResult(dispatch.Result),
 		CreatedAt:      timestamppb.New(dispatch.CreatedAt),
 		StepExecutions: serializeWorkOrderExecutions(dispatch.Executions),
+		Model:          dispatch.Model,
 	}
 	if dispatch.FinishedAt != nil {
 		item.FinishedAt = timestamppb.New(*dispatch.FinishedAt)

--- a/pkg/grpc/factory_service.go
+++ b/pkg/grpc/factory_service.go
@@ -268,6 +268,11 @@ func (s *FactoryService) ListFactoryLLMModels(ctx context.Context, req *pb.ListF
 	return actions.ListFactoryLLMModels(ctx, organizationID, req)
 }
 
+func (s *FactoryService) ListFactoryLineRunnerModels(ctx context.Context, req *pb.ListFactoryLineRunnerModelsRequest) (*pb.ListFactoryLineRunnerModelsResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return actions.ListFactoryLineRunnerModels(ctx, organizationID, req)
+}
+
 func (s *FactoryService) UpdateFactoryLLMModels(ctx context.Context, req *pb.UpdateFactoryLLMModelsRequest) (*pb.UpdateFactoryLLMModelsResponse, error) {
 	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
 	return actions.UpdateFactoryLLMModels(ctx, organizationID, req)

--- a/pkg/models/factory_work_order_line_dispatch.go
+++ b/pkg/models/factory_work_order_line_dispatch.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -43,9 +44,12 @@ type FactoryWorkOrderLineDispatch struct {
 	Steps          datatypes.JSONSlice[FactoryLineStep]
 	State          string
 	Result         string
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	FinishedAt     *time.Time
+	// Model is the optional Start override for this traversal. Empty means
+	// Auto: each runner keeps the model stored on the live canvas.
+	Model      string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	FinishedAt *time.Time
 }
 
 func (FactoryWorkOrderLineDispatch) TableName() string {
@@ -70,8 +74,14 @@ func (l *FactoryLine) Dispatch(tx *gorm.DB, order *FactoryWorkOrder) (*FactoryWo
 
 // DispatchFrom creates a line dispatch and starts (or queues) the step at
 // startIndex. Rerun from the start uses 0. Rerun this step uses the
-// current step.
+// current step. The model stays Auto.
 func (l *FactoryLine) DispatchFrom(tx *gorm.DB, order *FactoryWorkOrder, startIndex int) (*FactoryWorkOrderLineDispatch, *FactoryLineStepResult, error) {
+	return l.DispatchFromWithModel(tx, order, startIndex, "")
+}
+
+// DispatchFromWithModel is DispatchFrom with an optional Start model
+// override. Empty model means Auto.
+func (l *FactoryLine) DispatchFromWithModel(tx *gorm.DB, order *FactoryWorkOrder, startIndex int, model string) (*FactoryWorkOrderLineDispatch, *FactoryLineStepResult, error) {
 	if len(l.Steps) == 0 {
 		return nil, nil, ErrFactoryLineHasNoSteps
 	}
@@ -90,6 +100,7 @@ func (l *FactoryLine) DispatchFrom(tx *gorm.DB, order *FactoryWorkOrder, startIn
 		Steps:          l.Steps,
 		State:          FactoryWorkOrderLineDispatchStateActive,
 		Result:         "",
+		Model:          strings.TrimSpace(model),
 		CreatedAt:      now,
 		UpdatedAt:      now,
 	}

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -87,16 +87,20 @@ func (b *NodeConfigurationBuilder) WithConfigurationFields(fields []configuratio
 }
 
 func (b *NodeConfigurationBuilder) Build(configuration map[string]any) (map[string]any, error) {
+	var (
+		resolved map[string]any
+		err      error
+	)
 	if len(b.configurationFields) > 0 {
-		return b.resolveWithSchema(configuration, b.configurationFields)
+		resolved, err = b.resolveWithSchema(configuration, b.configurationFields)
+	} else {
+		resolved, err = b.resolve(configuration)
 	}
-
-	resolved, err := b.resolve(configuration)
 	if err != nil {
 		return nil, err
 	}
 
-	return resolved, nil
+	return b.applyLineDispatchModel(resolved)
 }
 
 func WithoutRunTitleConfiguration(configuration map[string]any) map[string]any {
@@ -2199,4 +2203,168 @@ func (b *NodeConfigurationBuilder) listDirectUpstreamExecutions() ([]models.Canv
 	}
 
 	return executions, nil
+}
+
+func (b *NodeConfigurationBuilder) applyLineDispatchModel(resolved map[string]any) (map[string]any, error) {
+	if _, hasModel := resolved["model"]; !hasModel {
+		return resolved, nil
+	}
+
+	dispatch, err := b.lineDispatch()
+	if err != nil || dispatch == nil {
+		return resolved, err
+	}
+	override := strings.TrimSpace(dispatch.Model)
+	if override == "" {
+		return resolved, nil
+	}
+
+	ok, err := b.nodeAcceptsDispatchModel(resolved, override, dispatch)
+	if err != nil || !ok {
+		return resolved, err
+	}
+
+	resolved["model"] = override
+	return resolved, nil
+}
+
+func (b *NodeConfigurationBuilder) lineDispatch() (*models.FactoryWorkOrderLineDispatch, error) {
+	if b.rootEventID == nil || b.tx == nil {
+		return nil, nil
+	}
+
+	run, err := models.FindCanvasRunByRootEventInTransaction(b.tx, *b.rootEventID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	execution, err := models.FindWorkOrderExecutionByRunID(b.tx, run.ID)
+	if err != nil {
+		if errors.Is(err, models.ErrFactoryWorkOrderExecutionNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	dispatch, err := models.FindWorkOrderLineDispatch(b.tx, execution.LineDispatchID)
+	if err != nil {
+		if errors.Is(err, models.ErrFactoryWorkOrderLineDispatchNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return dispatch, nil
+}
+
+func (b *NodeConfigurationBuilder) nodeAcceptsDispatchModel(
+	resolved map[string]any,
+	model string,
+	dispatch *models.FactoryWorkOrderLineDispatch,
+) (bool, error) {
+	if b.nodeID == "" {
+		return false, nil
+	}
+
+	node, err := models.FindCanvasNode(b.tx, b.workflowID, b.nodeID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	provider, ok := runnerProviderForComponent(node.ComponentName())
+	if !ok {
+		return false, nil
+	}
+
+	workflow, err := models.FindCanvasWithoutOrgScopeInTransaction(b.tx, b.workflowID)
+	if err != nil {
+		return false, err
+	}
+
+	selectable, err := models.ModelIsSelectable(
+		b.tx,
+		workflow.OrganizationID,
+		workflow.FactoryID,
+		provider,
+		runnerFundingSourceFromConfig(resolved),
+		model,
+	)
+	if err != nil || selectable {
+		return selectable, err
+	}
+
+	return b.sameProviderLineStoresModel(dispatch, provider, model)
+}
+
+func (b *NodeConfigurationBuilder) sameProviderLineStoresModel(
+	dispatch *models.FactoryWorkOrderLineDispatch,
+	provider string,
+	model string,
+) (bool, error) {
+	if dispatch == nil {
+		return false, nil
+	}
+
+	var line models.FactoryLine
+	err := b.tx.Where("id = ?", dispatch.LineID).First(&line).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	for _, step := range line.Steps {
+		if step.AppID == uuid.Nil {
+			continue
+		}
+		version, err := models.FindLiveCanvasVersionInTransaction(b.tx, step.AppID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				continue
+			}
+			return false, err
+		}
+		for _, node := range []models.Node(version.Nodes) {
+			nodeProvider, ok := runnerProviderForComponent(node.ComponentName())
+			if !ok || nodeProvider != provider {
+				continue
+			}
+			stored, _ := node.Configuration["model"].(string)
+			if strings.TrimSpace(stored) == model {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func runnerProviderForComponent(component string) (string, bool) {
+	switch component {
+	case "runnerClaudeCode":
+		return models.UsageProviderAnthropic, true
+	case "runnerCodex":
+		return models.UsageProviderOpenAI, true
+	case "runnerOpenRouter":
+		return models.UsageProviderOpenRouter, true
+	default:
+		return "", false
+	}
+}
+
+func runnerFundingSourceFromConfig(configuration map[string]any) string {
+	credentials, _ := configuration["credentials"].(map[string]any)
+	source, _ := credentials["source"].(string)
+	switch strings.TrimSpace(source) {
+	case "secret", "integration":
+		return models.UsageFundingSourceBYOK
+	default:
+		return models.UsageFundingSourceHosted
+	}
 }

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -2219,7 +2219,7 @@ func (b *NodeConfigurationBuilder) applyLineDispatchModel(resolved map[string]an
 		return resolved, nil
 	}
 
-	ok, err := b.nodeAcceptsDispatchModel(resolved, override, dispatch)
+	ok, err := b.nodeAcceptsDispatchModel(resolved, override)
 	if err != nil || !ok {
 		return resolved, err
 	}
@@ -2263,7 +2263,6 @@ func (b *NodeConfigurationBuilder) lineDispatch() (*models.FactoryWorkOrderLineD
 func (b *NodeConfigurationBuilder) nodeAcceptsDispatchModel(
 	resolved map[string]any,
 	model string,
-	dispatch *models.FactoryWorkOrderLineDispatch,
 ) (bool, error) {
 	if b.nodeID == "" {
 		return false, nil
@@ -2287,7 +2286,7 @@ func (b *NodeConfigurationBuilder) nodeAcceptsDispatchModel(
 		return false, err
 	}
 
-	selectable, err := models.ModelIsSelectable(
+	return models.ModelIsSelectable(
 		b.tx,
 		workflow.OrganizationID,
 		workflow.FactoryID,
@@ -2295,54 +2294,6 @@ func (b *NodeConfigurationBuilder) nodeAcceptsDispatchModel(
 		runnerFundingSourceFromConfig(resolved),
 		model,
 	)
-	if err != nil || selectable {
-		return selectable, err
-	}
-
-	return b.sameProviderLineStoresModel(dispatch, provider, model)
-}
-
-func (b *NodeConfigurationBuilder) sameProviderLineStoresModel(
-	dispatch *models.FactoryWorkOrderLineDispatch,
-	provider string,
-	model string,
-) (bool, error) {
-	if dispatch == nil {
-		return false, nil
-	}
-
-	var line models.FactoryLine
-	err := b.tx.Where("id = ?", dispatch.LineID).First(&line).Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	for _, step := range line.Steps {
-		if step.AppID == uuid.Nil {
-			continue
-		}
-		version, err := models.FindLiveCanvasVersionInTransaction(b.tx, step.AppID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				continue
-			}
-			return false, err
-		}
-		for _, node := range []models.Node(version.Nodes) {
-			nodeProvider, ok := runnerProviderForComponent(node.ComponentName())
-			if !ok || nodeProvider != provider {
-				continue
-			}
-			stored, _ := node.Configuration["model"].(string)
-			if strings.TrimSpace(stored) == model {
-				return true, nil
-			}
-		}
-	}
-	return false, nil
 }
 
 func runnerProviderForComponent(component string) (string, bool) {

--- a/pkg/workers/contexts/node_configuration_builder_dispatch_model_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_dispatch_model_test.go
@@ -1,0 +1,280 @@
+package contexts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/gorm"
+)
+
+func Test__Build__OverlaysLineDispatchModelOnMatchingRunner(t *testing.T) {
+	r := support.Setup(t)
+	db := database.Conn()
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	_, err = models.UpsertHostedLLMProvider(db, models.HostedLLMProvider{
+		Provider:      models.UsageProviderAnthropic,
+		Enabled:       true,
+		APIKey:        []byte("encrypted"),
+		AllowedModels: datatypes.JSONSlice[string]{"claude-sonnet-4-6", "claude-opus-4-6"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Where("provider = ?", models.UsageProviderAnthropic).Delete(&models.HostedLLMProvider{})
+	})
+
+	canvas, rootEvent, run := setupRunnerAppExecution(t, r, factoryModel.ID, "runnerClaudeCode")
+	order, err := factoryModel.CreateWorkOrder(db, "Ship it", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	line, err := factoryModel.CreateLine(db, "ship", nil)
+	require.NoError(t, err)
+	dispatch := support.CreateFactoryLineDispatch(t, r.Organization.ID, factoryModel.ID, order.ID, line.ID, line.Name, nil)
+	require.NoError(t, db.Model(dispatch).Update("model", "claude-opus-4-6").Error)
+
+	now := time.Now()
+	require.NoError(t, db.Create(&models.FactoryWorkOrderExecution{
+		ID:             uuid.New(),
+		OrganizationID: r.Organization.ID,
+		FactoryID:      factoryModel.ID,
+		WorkOrderID:    order.ID,
+		LineID:         line.ID,
+		LineDispatchID: dispatch.ID,
+		StepIndex:      0,
+		StepName:       "agent",
+		RunID:          &run.ID,
+		Status:         models.FactoryWorkOrderExecutionStatusRunning,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}).Error)
+
+	builder := NewNodeConfigurationBuilder(db, canvas.ID).
+		WithNodeID("agent").
+		WithRootEvent(&rootEvent.ID)
+
+	resolved, err := builder.Build(map[string]any{
+		"model": "claude-sonnet-4-6",
+		"credentials": map[string]any{
+			"source": "hosted",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-6", resolved["model"])
+}
+
+func Test__Build__KeepsCanvasModelWhenDispatchIsAuto(t *testing.T) {
+	r := support.Setup(t)
+	db := database.Conn()
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+
+	canvas, rootEvent, run := setupRunnerAppExecution(t, r, factoryModel.ID, "runnerClaudeCode")
+	order, err := factoryModel.CreateWorkOrder(db, "Ship it", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	linkRunToWorkOrder(t, r, factoryModel, order.ID, run.ID)
+
+	builder := NewNodeConfigurationBuilder(db, canvas.ID).
+		WithNodeID("agent").
+		WithRootEvent(&rootEvent.ID)
+
+	resolved, err := builder.Build(map[string]any{
+		"model": "claude-sonnet-4-6",
+		"credentials": map[string]any{
+			"source": "hosted",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-4-6", resolved["model"])
+}
+
+func Test__Build__SkipsOverrideWhenModelIsNotOnNodeProvider(t *testing.T) {
+	r := support.Setup(t)
+	db := database.Conn()
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	_, err = models.UpsertHostedLLMProvider(db, models.HostedLLMProvider{
+		Provider:      models.UsageProviderAnthropic,
+		Enabled:       true,
+		APIKey:        []byte("encrypted"),
+		AllowedModels: datatypes.JSONSlice[string]{"claude-sonnet-4-6"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Where("provider = ?", models.UsageProviderAnthropic).Delete(&models.HostedLLMProvider{})
+	})
+
+	canvas, rootEvent, run := setupRunnerAppExecution(t, r, factoryModel.ID, "runnerClaudeCode")
+	order, err := factoryModel.CreateWorkOrder(db, "Ship it", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	line, err := factoryModel.CreateLine(db, "ship", nil)
+	require.NoError(t, err)
+	dispatch := support.CreateFactoryLineDispatch(t, r.Organization.ID, factoryModel.ID, order.ID, line.ID, line.Name, nil)
+	require.NoError(t, db.Model(dispatch).Update("model", "gpt-5").Error)
+
+	now := time.Now()
+	require.NoError(t, db.Create(&models.FactoryWorkOrderExecution{
+		ID:             uuid.New(),
+		OrganizationID: r.Organization.ID,
+		FactoryID:      factoryModel.ID,
+		WorkOrderID:    order.ID,
+		LineID:         line.ID,
+		LineDispatchID: dispatch.ID,
+		StepIndex:      0,
+		StepName:       "agent",
+		RunID:          &run.ID,
+		Status:         models.FactoryWorkOrderExecutionStatusRunning,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}).Error)
+
+	builder := NewNodeConfigurationBuilder(db, canvas.ID).
+		WithNodeID("agent").
+		WithRootEvent(&rootEvent.ID)
+
+	resolved, err := builder.Build(map[string]any{
+		"model": "claude-sonnet-4-6",
+		"credentials": map[string]any{
+			"source": "hosted",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-4-6", resolved["model"])
+}
+
+func Test__Build__OverlaysCanvasModelFromSameProviderOnTheLine(t *testing.T) {
+	r := support.Setup(t)
+	db := database.Conn()
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+
+	canvas, rootEvent, run := setupRunnerAppExecution(t, r, factoryModel.ID, "runnerClaudeCode")
+	sibling := createFactoryRunnerApp(t, r, factoryModel.ID, "runnerClaudeCode", "sonnet")
+	order, err := factoryModel.CreateWorkOrder(db, "Ship it", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	line, err := factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
+		{Type: models.FactoryLineStepTypeRunApp, AppID: canvas.ID, Entrypoint: "start"},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: sibling.ID, Entrypoint: "start"},
+	})
+	require.NoError(t, err)
+	dispatch := support.CreateFactoryLineDispatch(t, r.Organization.ID, factoryModel.ID, order.ID, line.ID, line.Name, line.Steps)
+	require.NoError(t, db.Model(dispatch).Update("model", "sonnet").Error)
+
+	now := time.Now()
+	require.NoError(t, db.Create(&models.FactoryWorkOrderExecution{
+		ID:             uuid.New(),
+		OrganizationID: r.Organization.ID,
+		FactoryID:      factoryModel.ID,
+		WorkOrderID:    order.ID,
+		LineID:         line.ID,
+		LineDispatchID: dispatch.ID,
+		StepIndex:      0,
+		StepName:       "agent",
+		RunID:          &run.ID,
+		Status:         models.FactoryWorkOrderExecutionStatusRunning,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}).Error)
+
+	builder := NewNodeConfigurationBuilder(db, canvas.ID).
+		WithNodeID("agent").
+		WithRootEvent(&rootEvent.ID)
+
+	resolved, err := builder.Build(map[string]any{
+		"model": "opus",
+		"credentials": map[string]any{
+			"source": "integration",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "sonnet", resolved["model"])
+}
+
+func setupRunnerAppExecution(
+	t *testing.T,
+	r *support.ResourceRegistry,
+	factoryID uuid.UUID,
+	component string,
+) (*models.Canvas, *models.CanvasEvent, *models.CanvasRun) {
+	t.Helper()
+	const nodeID = "agent"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: nodeID,
+				Name:   "agent",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: component},
+				}),
+			},
+		},
+		nil,
+	)
+	require.NoError(t, database.Conn().Model(canvas).Update("factory_id", factoryID).Error)
+	canvas.FactoryID = &factoryID
+
+	triggerEvent := support.EmitCanvasEventForNodeWithData(t, canvas.ID, nodeID, "default", nil, map[string]any{"key": "value"})
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), triggerEvent)
+	require.NoError(t, err)
+	return canvas, triggerEvent, run
+}
+
+func createFactoryRunnerApp(
+	t *testing.T,
+	r *support.ResourceRegistry,
+	factoryID uuid.UUID,
+	component string,
+	model string,
+) *models.Canvas {
+	t.Helper()
+	now := time.Now()
+	liveVersionID := uuid.New()
+	canvas := &models.Canvas{
+		ID:             uuid.New(),
+		OrganizationID: r.Organization.ID,
+		LiveVersionID:  &liveVersionID,
+		FactoryID:      &factoryID,
+		Name:           support.RandomName("app"),
+		CreatedBy:      &r.User,
+		CreatedAt:      &now,
+		UpdatedAt:      &now,
+	}
+	require.NoError(t, database.Conn().Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(canvas).Error; err != nil {
+			return err
+		}
+		return tx.Create(&models.CanvasVersion{
+			ID:         liveVersionID,
+			WorkflowID: canvas.ID,
+			OwnerID:    &r.User,
+			Nodes: datatypes.NewJSONSlice([]models.Node{
+				{
+					ID:   "agent",
+					Name: "agent",
+					Type: models.NodeTypeComponent,
+					Ref:  models.NodeRef{Component: &models.ComponentRef{Name: component}},
+					Configuration: map[string]any{
+						"model": model,
+						"credentials": map[string]any{
+							"source": "integration",
+						},
+					},
+				},
+			}),
+			Edges:     datatypes.NewJSONSlice([]models.Edge{}),
+			CreatedAt: &now,
+			UpdatedAt: &now,
+		}).Error
+	}))
+	return canvas
+}

--- a/pkg/workers/contexts/node_configuration_builder_dispatch_model_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_dispatch_model_test.go
@@ -148,7 +148,7 @@ func Test__Build__SkipsOverrideWhenModelIsNotOnNodeProvider(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-4-6", resolved["model"])
 }
 
-func Test__Build__OverlaysCanvasModelFromSameProviderOnTheLine(t *testing.T) {
+func Test__Build__DoesNotOverlaySiblingCanvasModel(t *testing.T) {
 	r := support.Setup(t)
 	db := database.Conn()
 	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
@@ -193,7 +193,7 @@ func Test__Build__OverlaysCanvasModelFromSameProviderOnTheLine(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "sonnet", resolved["model"])
+	assert.Equal(t, "opus", resolved["model"])
 }
 
 func setupRunnerAppExecution(

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -561,6 +561,17 @@ service Factories {
     };
   }
 
+  rpc ListFactoryLineRunnerModels(ListFactoryLineRunnerModelsRequest) returns (ListFactoryLineRunnerModelsResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/factories/{factory_id}/line-runner-models"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List line runner models";
+      description: "Returns the models a draft task can pick for the runner agents on one factory line";
+      tags: "Factory";
+    };
+  }
+
   rpc UpdateFactoryLLMModels(UpdateFactoryLLMModelsRequest) returns (UpdateFactoryLLMModelsResponse) {
     option (google.api.http) = {
       put: "/api/v1/factories/{factory_id}/llm-models"
@@ -1435,6 +1446,9 @@ message WorkOrderLineDispatch {
   // its maxParallelism. A dispatch waits at no more than one step at a
   // time; no run or step execution exists for a queued step yet.
   optional WorkOrderQueueItem queue_item = 9;
+  // Model chosen at Start. Empty means Auto: each runner keeps the model
+  // stored on the live automation canvas.
+  string model = 10;
 }
 
 // WorkOrderQueueItem is a line dispatch waiting for admission into a step
@@ -1538,6 +1552,8 @@ message DispatchWorkOrderRequest {
   string line_name = 3;
   int32 start_step_index = 4;
   bool replace_active = 5;
+  // Optional model override for this start. Empty means Auto.
+  string model = 6;
 }
 
 message DispatchWorkOrderResponse {
@@ -1946,6 +1962,15 @@ message DescribeFactoryUsageResponse {
   bool factory_remaining_credit_warning = 12;
   int64 total_duration_seconds = 13;
   repeated UsageByMachineType by_machine_type = 14;
+}
+
+message ListFactoryLineRunnerModelsRequest {
+  string factory_id = 1;
+  string line_name = 2;
+}
+
+message ListFactoryLineRunnerModelsResponse {
+  repeated FactoryLLMModel models = 1;
 }
 
 message ListFactoryLLMModelsRequest {

--- a/web_src/src/hooks/useFactoryData.ts
+++ b/web_src/src/hooks/useFactoryData.ts
@@ -446,6 +446,7 @@ export function useDispatchWorkOrder(organizationId: string, factoryId: string) 
       lineName: string;
       startStepIndex?: number;
       replaceActive?: boolean;
+      model?: string;
     }) => {
       const response = await factoriesDispatchWorkOrder(
         withOrganizationHeader({
@@ -455,6 +456,7 @@ export function useDispatchWorkOrder(organizationId: string, factoryId: string) 
             lineName: input.lineName,
             startStepIndex: input.startStepIndex,
             replaceActive: input.replaceActive,
+            model: input.model,
           },
         }),
       );

--- a/web_src/src/hooks/useFactoryLineRunnerModels.ts
+++ b/web_src/src/hooks/useFactoryLineRunnerModels.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { factoriesListFactoryLineRunnerModels } from "@/api-client";
+import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
+
+export function factoryLineRunnerModelsQueryKey(organizationId: string, factoryId: string, lineName: string) {
+  return ["factories", organizationId, factoryId, "line-runner-models", lineName] as const;
+}
+
+export function useFactoryLineRunnerModels(
+  organizationId: string | undefined,
+  factoryId: string | undefined,
+  lineName: string | undefined,
+  enabled = true,
+) {
+  const org = organizationId ?? "";
+  const factory = factoryId ?? "";
+  const line = lineName?.trim() ?? "";
+
+  return useQuery({
+    queryKey: factoryLineRunnerModelsQueryKey(org, factory, line),
+    queryFn: async () => {
+      const response = await factoriesListFactoryLineRunnerModels(
+        withOrganizationHeader({
+          organizationId: org,
+          path: { factoryId: factory },
+          query: { lineName: line },
+        }),
+      );
+      return response.data?.models ?? [];
+    },
+    enabled: Boolean(org && factory && line && enabled),
+    staleTime: 30 * 1000,
+  });
+}

--- a/web_src/src/hooks/useWorkOrderCardActions.ts
+++ b/web_src/src/hooks/useWorkOrderCardActions.ts
@@ -14,14 +14,14 @@ export function useWorkOrderCardActions(organizationId: string, factoryId: strin
   const [dispatchingOrderIds, setDispatchingOrderIds] = useState<ReadonlySet<string>>(NO_ORDERS);
 
   const onDispatch = useCallback(
-    async (orderId: string, input: { lineName: string }) => {
+    async (orderId: string, input: { lineName: string; model?: string }) => {
       setDispatchingOrderIds((current) => withOrderId(current, orderId));
       try {
         // mutateAsync runs the mutation's onMutate before the request
         // resolves, which patches the work-orders cache so the card moves
         // to the line's first phase column right away — see
         // useDispatchWorkOrder.
-        await dispatchWorkOrder.mutateAsync({ orderId, lineName: input.lineName });
+        await dispatchWorkOrder.mutateAsync({ orderId, lineName: input.lineName, model: input.model });
         showSuccessToast(`Dispatched to ${input.lineName}.`);
       } catch {
         showErrorToast("Failed to dispatch task.");

--- a/web_src/src/pages/factories/__fixtures__/factoryPageWorkOrders.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageWorkOrders.ts
@@ -193,17 +193,20 @@ export const RUNNING_WORK_ORDER: FactoriesWorkOrder = {
   origin: githubOrigin(103),
   assignees: [{ id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME }],
   lineDispatches: [
-    planLineDispatch([
-      planLineExecution("implement", {
-        id: "2",
-        state: "STATE_STARTED",
-        result: "RESULT_UNKNOWN",
-        run: { id: LINE_RUN_IMPLEMENT_ID, appId: "app-refund-implementer", appName: "Implementation" },
-        updatedAt: HOUR_AGO,
-        totalTokens: "900",
-        costCents: "28",
-      }),
-    ]),
+    planLineDispatch(
+      [
+        planLineExecution("implement", {
+          id: "2",
+          state: "STATE_STARTED",
+          result: "RESULT_UNKNOWN",
+          run: { id: LINE_RUN_IMPLEMENT_ID, appId: "app-refund-implementer", appName: "Implementation" },
+          updatedAt: HOUR_AGO,
+          totalTokens: "900",
+          costCents: "28",
+        }),
+      ],
+      { model: "anthropic/claude-sonnet-4-6" },
+    ),
   ],
   totalTokens: "2700",
   totalCostCents: "73",

--- a/web_src/src/pages/factories/__fixtures__/handlers.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.ts
@@ -70,6 +70,7 @@ interface RequestBody {
   start_step_index?: unknown;
   replaceActive?: unknown;
   replace_active?: unknown;
+  model?: unknown;
   result?: unknown;
   state?: unknown;
   steps?: unknown;
@@ -234,6 +235,17 @@ function factoryDetailRoutes(fixture: FactoriesFixture): FactoriesRoute[] {
         velocitySynced(match[1]);
         return { json: { started: true } };
       },
+    },
+    {
+      pattern: re("/api/v1/factories/([^/]+)/line-runner-models"),
+      resolve: () => ({
+        json: {
+          models: [
+            { id: "claude-sonnet-4-6", name: "claude-sonnet-4-6" },
+            { id: "claude-opus-4-6", name: "claude-opus-4-6" },
+          ],
+        },
+      }),
     },
     {
       pattern: re("/api/v1/factories/([^/]+)/llm-models"),
@@ -402,6 +414,7 @@ function buildDispatchedLineDispatch(
   now: string,
   apps: Array<{ id?: string; name?: string }> = [],
   startStepIndex = 0,
+  model = "",
 ): FactoriesWorkOrderLineDispatch {
   const stepIndex = Math.max(0, startStepIndex);
   const firstStep = line?.steps?.[stepIndex] ?? line?.steps?.[0];
@@ -417,6 +430,7 @@ function buildDispatchedLineDispatch(
     state: "STATE_ACTIVE",
     result: "RESULT_UNKNOWN",
     createdAt: now,
+    model,
     stepExecutions: [
       {
         id: `exec-${Date.now()}`,
@@ -449,6 +463,7 @@ function dispatchRequestOptions(request: RequestBody) {
     lineName: stringOrEmpty(request.lineName ?? request.line_name),
     startStepIndex: Number(request.startStepIndex ?? request.start_step_index ?? 0) || 0,
     replaceActive: request.replaceActive === true || request.replace_active === true,
+    model: stringOrEmpty(request.model),
   };
 }
 
@@ -468,7 +483,14 @@ function dispatchOrder(fixture: FactoriesFixture, factoryId: string, orderId: st
   if (options.replaceActive) {
     cancelActiveDispatches(order, now);
   }
-  const newDispatch = buildDispatchedLineDispatch(line, options.lineName, now, apps, options.startStepIndex);
+  const newDispatch = buildDispatchedLineDispatch(
+    line,
+    options.lineName,
+    now,
+    apps,
+    options.startStepIndex,
+    options.model,
+  );
   order.lineDispatches = [...(order.lineDispatches ?? []), newDispatch];
   return { json: { order } };
 }

--- a/web_src/src/pages/factories/__fixtures__/handlers.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.ts
@@ -414,7 +414,6 @@ function buildDispatchedLineDispatch(
   now: string,
   apps: Array<{ id?: string; name?: string }> = [],
   startStepIndex = 0,
-  model = "",
 ): FactoriesWorkOrderLineDispatch {
   const stepIndex = Math.max(0, startStepIndex);
   const firstStep = line?.steps?.[stepIndex] ?? line?.steps?.[0];
@@ -430,7 +429,6 @@ function buildDispatchedLineDispatch(
     state: "STATE_ACTIVE",
     result: "RESULT_UNKNOWN",
     createdAt: now,
-    model,
     stepExecutions: [
       {
         id: `exec-${Date.now()}`,
@@ -483,14 +481,10 @@ function dispatchOrder(fixture: FactoriesFixture, factoryId: string, orderId: st
   if (options.replaceActive) {
     cancelActiveDispatches(order, now);
   }
-  const newDispatch = buildDispatchedLineDispatch(
-    line,
-    options.lineName,
-    now,
-    apps,
-    options.startStepIndex,
-    options.model,
-  );
+  const newDispatch = {
+    ...buildDispatchedLineDispatch(line, options.lineName, now, apps, options.startStepIndex),
+    model: options.model,
+  };
   order.lineDispatches = [...(order.lineDispatches ?? []), newDispatch];
   return { json: { order } };
 }

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -656,7 +656,7 @@ function LineBoardSplitRunPopup({
   canDispatch: boolean;
   canUpdate: boolean;
   isDispatching: boolean;
-  onDispatch: (orderId: string, input: { lineName: string }) => Promise<void>;
+  onDispatch: (orderId: string, input: { lineName: string; model?: string }) => Promise<void>;
   analysisRuns: BacklogAnalysisRun[];
   onClose: () => void;
 }) {
@@ -680,6 +680,7 @@ function LineBoardSplitRunPopup({
       fixture={splitRunFixtureForWorkOrder(peekOrder, {
         checks: peekChecks,
         lineId,
+        lineName: resolvedLineName,
         demoArtifacts: false,
         prFeedbackRuns,
         analysisRuns,
@@ -689,7 +690,9 @@ function LineBoardSplitRunPopup({
       canDispatch={canDispatch && Boolean(resolvedLineName)}
       canUpdate={canUpdate}
       isDispatching={isDispatching}
-      onDispatch={resolvedLineName ? () => onDispatch(peekOrderId, { lineName: resolvedLineName }) : undefined}
+      onDispatch={
+        resolvedLineName ? (model) => onDispatch(peekOrderId, { lineName: resolvedLineName, model }) : undefined
+      }
       onClose={onClose}
       fixed
     />

--- a/web_src/src/pages/factories/pages/work-order-split-run/DraftStartModelSelect.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/DraftStartModelSelect.tsx
@@ -1,8 +1,9 @@
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 import { useFactoryLineRunnerModels } from "@/hooks/useFactoryLineRunnerModels";
 
-import { DRAFT_START_MODEL_AUTO } from "./draftStartModel";
+import { DRAFT_START_MODEL_AUTO, DRAFT_START_MODEL_HELP } from "./draftStartModel";
 
 export function DraftStartModelSelect({
   organizationId,
@@ -22,24 +23,34 @@ export function DraftStartModelSelect({
   const models = useFactoryLineRunnerModels(organizationId, factoryId, lineName);
 
   return (
-    <Select value={value} onValueChange={onChange} disabled={disabled}>
-      <SelectTrigger size="sm" className="w-[11.5rem]" aria-label="Model" data-testid="split-run-draft-model">
-        <SelectValue placeholder="Auto" />
-      </SelectTrigger>
-      <SelectContent position="popper" className="max-h-60">
-        <SelectItem value={DRAFT_START_MODEL_AUTO}>Auto</SelectItem>
-        {(models.data ?? []).map((model) => {
-          const id = model.id ?? "";
-          if (id === "") {
-            return null;
-          }
-          return (
-            <SelectItem key={id} value={id}>
-              {model.name || id}
-            </SelectItem>
-          );
-        })}
-      </SelectContent>
-    </Select>
+    <HoverCard openDelay={150} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <div className="inline-flex" data-testid="split-run-draft-model-wrap">
+          <Select value={value} onValueChange={onChange} disabled={disabled}>
+            <SelectTrigger size="sm" className="w-[11.5rem]" aria-label="Model" data-testid="split-run-draft-model">
+              <SelectValue placeholder="Auto" />
+            </SelectTrigger>
+            <SelectContent position="popper" className="max-h-60">
+              <SelectItem value={DRAFT_START_MODEL_AUTO}>Auto</SelectItem>
+              {(models.data ?? []).map((model) => {
+                const id = model.id ?? "";
+                if (id === "") {
+                  return null;
+                }
+                return (
+                  <SelectItem key={id} value={id}>
+                    {model.name || id}
+                  </SelectItem>
+                );
+              })}
+            </SelectContent>
+          </Select>
+        </div>
+      </HoverCardTrigger>
+      <HoverCardContent side="top" align="end" className="w-64 space-y-1 p-3 text-sm">
+        <p data-testid="split-run-draft-model-help">{DRAFT_START_MODEL_HELP[0]}</p>
+        <p>{DRAFT_START_MODEL_HELP[1]}</p>
+      </HoverCardContent>
+    </HoverCard>
   );
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/DraftStartModelSelect.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/DraftStartModelSelect.tsx
@@ -1,0 +1,45 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+import { useFactoryLineRunnerModels } from "@/hooks/useFactoryLineRunnerModels";
+
+import { DRAFT_START_MODEL_AUTO } from "./draftStartModel";
+
+export function DraftStartModelSelect({
+  organizationId,
+  factoryId,
+  lineName,
+  value,
+  onChange,
+  disabled = false,
+}: {
+  organizationId?: string;
+  factoryId?: string;
+  lineName?: string;
+  value: string;
+  onChange: (next: string) => void;
+  disabled?: boolean;
+}) {
+  const models = useFactoryLineRunnerModels(organizationId, factoryId, lineName);
+
+  return (
+    <Select value={value} onValueChange={onChange} disabled={disabled}>
+      <SelectTrigger size="sm" className="w-[11.5rem]" aria-label="Model" data-testid="split-run-draft-model">
+        <SelectValue placeholder="Auto" />
+      </SelectTrigger>
+      <SelectContent position="popper" className="max-h-60">
+        <SelectItem value={DRAFT_START_MODEL_AUTO}>Auto</SelectItem>
+        {(models.data ?? []).map((model) => {
+          const id = model.id ?? "";
+          if (id === "") {
+            return null;
+          }
+          return (
+            <SelectItem key={id} value={id}>
+              {model.name || id}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { FactoryAppCanvasHeader } from "../FactoryAppCanvasHeader";
 import { CompactLineCanvas } from "./CompactLineCanvas";
 import { JumpToLatestPill } from "./JumpToLatestPill";
+import { phaseWithRunnerModel } from "./draftStartModel";
 import { PhaseLogCard } from "./PhaseLogCard";
 import { SplitRunLogHeader } from "./SplitRunLogHeader";
 import { runningSplitRunPhaseId } from "./followLogScroll";
@@ -101,7 +102,7 @@ function SplitRunLoadedPage({ model }: { model: ReturnType<typeof useFactoryAppS
             >
               <li className="min-w-0">
                 <PhaseLogCard
-                  phase={model.phase}
+                  phase={phaseWithRunnerModel(model.phase, model.canvas?.nodes)}
                   expanded
                   collapsible={false}
                   stream={model.stream}

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.titleLine.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.titleLine.spec.tsx
@@ -60,6 +60,19 @@ describe("PhaseLogCard title line", () => {
     expect(screen.getByTestId("split-run-phase-duration-plan")).toHaveTextContent("1.2k · 01:00");
   });
 
+  it("shows the used model next to spend", () => {
+    render(
+      <PhaseLogCard
+        phase={{ ...PHASE, costCents: "45", totalTokens: "1200", model: "anthropic/claude-opus-4-6" }}
+        expanded={false}
+      />,
+    );
+
+    expect(screen.getByTestId("split-run-phase-duration-plan")).toHaveTextContent(
+      "$0.45 · 1.2k · claude-opus-4-6 · 01:00",
+    );
+  });
+
   it("uses one mono face and size on the name and artifact", () => {
     render(
       <PhaseLogCard

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
@@ -15,6 +15,7 @@ import { formatUsdCents, parseWorkOrderMetric } from "../../lib/workOrderUsage";
 import { WorkOrderArtifactInline } from "../../WorkOrderArtifactInline";
 import { WorkOrderPullRequestInline } from "../../WorkOrderPullRequestInline";
 import { PhaseGlyph } from "../linePhaseGlyph";
+import { displayRunnerModel } from "./draftStartModel";
 import { logStatusTimeLabel, tickingRunningClock } from "./logStatusTime";
 import { SplitRunCheckPills } from "./SplitRunReview";
 import { type SplitRunPhase, type SplitRunPhaseStatus, type SplitRunStreamLine } from "./splitRunMocks";
@@ -759,12 +760,16 @@ function PhaseMetrics({ phase }: { phase: SplitRunPhase }) {
     : formatClockDurationLabel(phase.duration);
   const tokens = parseWorkOrderMetric(phase.totalTokens);
   const cents = parseWorkOrderMetric(phase.costCents);
+  const model = displayRunnerModel(phase.model ?? "");
   const parts: string[] = [];
   if (cents > 0) {
     parts.push(formatUsdCents(cents));
   }
   if (tokens > 0) {
     parts.push(formatCompactTokenValue(tokens));
+  }
+  if (model) {
+    parts.push(model);
   }
   if (clock && clock !== "—") {
     parts.push(clock);

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunAttentionNote.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunAttentionNote.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { Bug, CheckCircle2, CircleX, ExternalLink, FileText, Hourglass, Loader2, RotateCcw, Undo2 } from "lucide-react";
 
 import { Link } from "@/components/Link/link";
@@ -65,6 +66,7 @@ export function SplitRunAttentionNote({
   actionBusy = false,
   startBusy = false,
   startDisabled = false,
+  modelSelect,
   onAction,
 }: {
   note: SplitRunFooterNote;
@@ -74,6 +76,7 @@ export function SplitRunAttentionNote({
   actionBusy?: boolean;
   startBusy?: boolean;
   startDisabled?: boolean;
+  modelSelect?: ReactNode;
   onAction?: (action: SplitRunFooterAction) => void;
 }) {
   const visual = TONE[tone];
@@ -110,6 +113,7 @@ export function SplitRunAttentionNote({
           actionBusy={actionBusy}
           startBusy={startBusy}
           startDisabled={startDisabled}
+          modelSelect={modelSelect}
           onAction={onAction}
         />
       </div>
@@ -124,6 +128,7 @@ function NoteActionRow({
   actionBusy,
   startBusy,
   startDisabled,
+  modelSelect,
   onAction,
 }: {
   note: SplitRunFooterNote;
@@ -132,16 +137,18 @@ function NoteActionRow({
   actionBusy: boolean;
   startBusy: boolean;
   startDisabled: boolean;
+  modelSelect?: ReactNode;
   onAction?: (action: SplitRunFooterAction) => void;
 }) {
   const href = note.cta?.href ?? runHref ?? undefined;
   const showCta = Boolean(note.cta && href);
-  if (!showCta && actions.length === 0) {
+  if (!showCta && actions.length === 0 && !modelSelect) {
     return null;
   }
 
   return (
     <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+      {modelSelect}
       {showCta && href && note.cta ? <NoteCta label={note.cta.label} href={href} icon={note.cta.icon} /> : null}
       {actions.map((action) => (
         <NoteAction

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.draftModel.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.draftModel.spec.tsx
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { DRAFT_WORK_ORDER, OPEN_WORK_ORDER } from "../../__fixtures__/factoryPageResponses";
+import { SplitRunReview } from "./SplitRunReview";
+import { DraftStartModelSelect } from "./DraftStartModelSelect";
+import { DRAFT_START_MODEL_AUTO, draftStartModelPayload } from "./draftStartModel";
+import { splitRunFixtureForWorkOrder } from "./splitRunMocks";
+
+vi.mock("@/hooks/useFactoryLineRunnerModels", () => ({
+  useFactoryLineRunnerModels: () => ({
+    data: [{ id: "claude-opus-4-6", name: "claude-opus-4-6" }],
+    isLoading: false,
+  }),
+}));
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+function renderDraftFooter(onStart: () => void, selectedModel = DRAFT_START_MODEL_AUTO, onChange = vi.fn()) {
+  const footer = splitRunFixtureForWorkOrder(DRAFT_WORK_ORDER).footer;
+  return render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <SplitRunReview
+        footer={footer}
+        onStart={onStart}
+        modelSelect={
+          <DraftStartModelSelect
+            organizationId="org-1"
+            factoryId="factory-1"
+            lineName="ship"
+            value={selectedModel}
+            onChange={onChange}
+          />
+        }
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("SplitRunReview draft model select", () => {
+  it("shows Auto on the draft footer", () => {
+    renderDraftFooter(vi.fn());
+
+    const note = screen.getByTestId("split-run-attention-note");
+    expect(within(note).getByTestId("split-run-draft-model")).toHaveTextContent("Auto");
+    expect(within(note).getByRole("button", { name: "Start" })).toBeInTheDocument();
+    expect(within(note).getByRole("button", { name: "Reject" })).toBeInTheDocument();
+  });
+
+  it("keeps the model select off a waiting footer", () => {
+    render(<SplitRunReview footer={splitRunFixtureForWorkOrder(OPEN_WORK_ORDER).footer} onStart={vi.fn()} />);
+
+    expect(screen.queryByTestId("split-run-draft-model")).not.toBeInTheDocument();
+  });
+
+  it("starts with Auto without a model id", async () => {
+    const user = userEvent.setup();
+    const onStart = vi.fn();
+    renderDraftFooter(onStart);
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(draftStartModelPayload(DRAFT_START_MODEL_AUTO)).toBeUndefined();
+  });
+
+  it("lists a runner model the user can pick", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderDraftFooter(vi.fn(), DRAFT_START_MODEL_AUTO, onChange);
+
+    await user.click(screen.getByRole("combobox", { name: "Model" }));
+    await user.click(await screen.findByRole("option", { name: "claude-opus-4-6" }));
+    expect(onChange).toHaveBeenCalledWith("claude-opus-4-6");
+  });
+});

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.draftModel.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.draftModel.spec.tsx
@@ -79,4 +79,14 @@ describe("SplitRunReview draft model select", () => {
     await user.click(await screen.findByRole("option", { name: "claude-opus-4-6" }));
     expect(onChange).toHaveBeenCalledWith("claude-opus-4-6");
   });
+
+  it("explains Auto on hover", async () => {
+    const user = userEvent.setup();
+    renderDraftFooter(vi.fn());
+
+    await user.hover(screen.getByTestId("split-run-draft-model-wrap"));
+    const help = await screen.findByTestId("split-run-draft-model-help");
+    expect(help).toHaveTextContent("Auto uses the default model on each automation.");
+    expect(help.parentElement).toHaveTextContent("Pick a model to overwrite that default for this start.");
+  });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { CircleAlert, CircleCheck, Minus, TriangleAlert } from "lucide-react";
@@ -62,6 +63,7 @@ export function SplitRunReview({
   startBusy = false,
   actionBusy = false,
   startDisabled = false,
+  modelSelect,
 }: {
   footer: SplitRunFooter;
   className?: string;
@@ -76,6 +78,7 @@ export function SplitRunReview({
   startBusy?: boolean;
   actionBusy?: boolean;
   startDisabled?: boolean;
+  modelSelect?: ReactNode;
 }) {
   if (!footer.attentionCard || !footer.note) {
     return null;
@@ -118,6 +121,7 @@ export function SplitRunReview({
         actionBusy={actionBusy}
         startBusy={startBusy}
         startDisabled={startDisabled}
+        modelSelect={modelSelect}
         onAction={onAction}
       />
     </div>

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -116,7 +116,9 @@ describe("WorkOrderSplitRunPopup", () => {
   it("shows tokens and cost on a line-step phase", () => {
     renderPopup({ fixture: splitRunFixtureForWorkOrder(RUNNING_WORK_ORDER, { demoArtifacts: false }) });
 
-    expect(screen.getByTestId("split-run-phase-duration-implement-0")).toHaveTextContent("$0.28 · 900 ·");
+    expect(screen.getByTestId("split-run-phase-duration-implement-0")).toHaveTextContent(
+      "$0.28 · 900 · claude-sonnet-4-6 ·",
+    );
   });
 
   it("does not put an Open task link next to close", () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -8,7 +8,7 @@ import { OwnerTimeCostRow, PopupHeader, PopupShell } from "../work-order-popup-r
 import { JumpToLatestPill } from "./JumpToLatestPill";
 import { PhaseLogCard } from "./PhaseLogCard";
 import { DraftStartModelSelect } from "./DraftStartModelSelect";
-import { DRAFT_START_MODEL_AUTO, draftStartModelPayload } from "./draftStartModel";
+import { DRAFT_START_MODEL_AUTO, draftStartModelPayload, phaseWithRunnerModel } from "./draftStartModel";
 import { SplitRunReview } from "./SplitRunReview";
 import { attachArtifactsToStream } from "./attachStreamArtifacts";
 import { emptySplitRunCanvas } from "./splitRunCanvases";
@@ -167,7 +167,7 @@ export function WorkOrderSplitRunBody({
         {fixture.phases.map((entry) => (
           <li key={entry.id} className="min-w-0 first:mt-3">
             <PhaseLogCard
-              phase={entry}
+              phase={phaseWithRunnerModel(entry, entry.id === selectedPhase?.id ? live.canvas?.nodes : undefined)}
               expanded={entry.id === openPhaseId}
               stream={streams.get(entry.id) ?? entry.stream}
               selectedNodeId={nodeId}

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -7,6 +7,8 @@ import { workOrderDetailPath } from "../../lib/factoryPagePaths";
 import { OwnerTimeCostRow, PopupHeader, PopupShell } from "../work-order-popup-redesign/popupShared";
 import { JumpToLatestPill } from "./JumpToLatestPill";
 import { PhaseLogCard } from "./PhaseLogCard";
+import { DraftStartModelSelect } from "./DraftStartModelSelect";
+import { DRAFT_START_MODEL_AUTO, draftStartModelPayload } from "./draftStartModel";
 import { SplitRunReview } from "./SplitRunReview";
 import { attachArtifactsToStream } from "./attachStreamArtifacts";
 import { emptySplitRunCanvas } from "./splitRunCanvases";
@@ -214,7 +216,7 @@ export function WorkOrderSplitRunPopup({
 }: Omit<WorkOrderSplitRunBodyProps, "footerActions"> & {
   onClose?: () => void;
   fixed?: boolean;
-  onDispatch?: () => Promise<void>;
+  onDispatch?: (model?: string) => Promise<void>;
   isDispatching?: boolean;
   canDispatch?: boolean;
   canUpdate?: boolean;
@@ -236,7 +238,8 @@ export function WorkOrderSplitRunPopup({
   const initialTab = defaultSplitRunPopupTab(fixture);
   const [tab, setTab] = useState(initialTab);
   const [fullPage, setFullPage] = useState(false);
-  const draftStart = draftStartAction(fixture.footer.kind, onDispatch, () => setTab("log"));
+  const [draftModel, setDraftModel] = useState(DRAFT_START_MODEL_AUTO);
+  const draftStart = draftStartAction(fixture.footer.kind, onDispatch, () => setTab("log"), draftModel);
   const backToDraft = returnToBacklogAction(mutations.onBackToDraft, () => setTab("description"));
 
   return (
@@ -292,6 +295,18 @@ export function WorkOrderSplitRunPopup({
         startBusy={isDispatching}
         actionBusy={footerActions.busy}
         startDisabled={!canDispatch}
+        modelSelect={
+          fixture.footer.kind === "draft" ? (
+            <DraftStartModelSelect
+              organizationId={organizationId}
+              factoryId={factoryId}
+              lineName={fixture.lineName}
+              value={draftModel}
+              onChange={setDraftModel}
+              disabled={isDispatching}
+            />
+          ) : undefined
+        }
       />
     </PopupShell>
   );
@@ -299,14 +314,15 @@ export function WorkOrderSplitRunPopup({
 
 function draftStartAction(
   kind: SplitRunFixture["footer"]["kind"],
-  onDispatch: (() => Promise<void>) | undefined,
+  onDispatch: ((model?: string) => Promise<void>) | undefined,
   openAutomations: () => void,
+  selectedModel: string,
 ) {
   if (kind !== "draft") {
     return undefined;
   }
   return async () => {
-    await onDispatch?.();
+    await onDispatch?.(draftStartModelPayload(selectedModel));
     openAutomations();
   };
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunStop.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunStop.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { MemoryRouter } from "react-router";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { handleStopMock, handleRejectMock, handleBackToDraftMock } = vi.hoisted(() => ({
   handleStopMock: vi.fn(),
@@ -20,6 +20,20 @@ vi.mock("./useSplitRunFooterActions", () => ({
     busy: false,
   }),
 }));
+
+vi.mock("@/hooks/useFactoryLineRunnerModels", () => ({
+  useFactoryLineRunnerModels: () => ({
+    data: [{ id: "claude-opus-4-6", name: "claude-opus-4-6" }],
+    isLoading: false,
+  }),
+}));
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+});
 
 import { ThemeProvider } from "@/contexts/ThemeProvider";
 import { TooltipProvider } from "@/ui/tooltip";
@@ -95,11 +109,39 @@ describe("WorkOrderSplitRunPopup decision footer", () => {
 
     const note = screen.getByTestId("split-run-attention-note");
     expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
+    expect(within(note).getByTestId("split-run-draft-model")).toHaveTextContent("Auto");
     await user.click(within(note).getByRole("button", { name: "Start" }));
     expect(onDispatch).toHaveBeenCalledTimes(1);
+    expect(onDispatch).toHaveBeenCalledWith(undefined);
     expect(screen.getByRole("tab", { name: "Automations" })).toHaveAttribute("data-state", "active");
     await user.click(within(note).getByRole("button", { name: "Reject" }));
     expect(handleRejectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts a draft with the listed model", async () => {
+    const user = userEvent.setup();
+    const onDispatch = vi.fn();
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter>
+          <ThemeProvider>
+            <TooltipProvider>
+              <WorkOrderSplitRunPopup
+                fixture={splitRunFixtureForWorkOrder(DRAFT_WORK_ORDER)}
+                onDispatch={onDispatch}
+                canDispatch
+              />
+            </TooltipProvider>
+          </ThemeProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const note = screen.getByTestId("split-run-attention-note");
+    await user.click(within(note).getByRole("combobox", { name: "Model" }));
+    await user.click(await screen.findByRole("option", { name: "claude-opus-4-6" }));
+    await user.click(within(note).getByRole("button", { name: "Start" }));
+    expect(onDispatch).toHaveBeenCalledWith("claude-opus-4-6");
   });
 
   it("opens Description after To Backlog", async () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { DRAFT_START_MODEL_AUTO, draftStartModelPayload } from "./draftStartModel";
+
+describe("draftStartModelPayload", () => {
+  it("sends no model for Auto", () => {
+    expect(draftStartModelPayload(DRAFT_START_MODEL_AUTO)).toBeUndefined();
+    expect(draftStartModelPayload("")).toBeUndefined();
+    expect(draftStartModelPayload("  ")).toBeUndefined();
+  });
+
+  it("sends the listed id", () => {
+    expect(draftStartModelPayload("claude-opus-4-6")).toBe("claude-opus-4-6");
+  });
+});

--- a/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.spec.ts
@@ -50,4 +50,20 @@ describe("phaseWithRunnerModel", () => {
   it("fills Auto from the canvas when the phase has no model", () => {
     expect(phaseWithRunnerModel({}, [{ configuration: { model: "opus" } }]).model).toBe("opus");
   });
+
+  it("keeps a start model the canvas runners can use", () => {
+    expect(
+      phaseWithRunnerModel({ model: "claude-opus-4-6" }, [
+        { component: "runnerClaudeCode", configuration: { model: "claude-sonnet-4-6" } },
+      ]).model,
+    ).toBe("claude-opus-4-6");
+  });
+
+  it("uses the canvas model when the start model is for another runner", () => {
+    expect(
+      phaseWithRunnerModel({ model: "claude-opus-4-6" }, [
+        { component: "runnerCodex", configuration: { model: "gpt-5" } },
+      ]).model,
+    ).toBe("gpt-5");
+  });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { DRAFT_START_MODEL_AUTO, draftStartModelPayload } from "./draftStartModel";
+import {
+  DRAFT_START_MODEL_AUTO,
+  displayRunnerModel,
+  draftStartModelPayload,
+  phaseWithRunnerModel,
+  runnerModelsFromCanvasNodes,
+} from "./draftStartModel";
 
 describe("draftStartModelPayload", () => {
   it("sends no model for Auto", () => {
@@ -11,5 +17,37 @@ describe("draftStartModelPayload", () => {
 
   it("sends the listed id", () => {
     expect(draftStartModelPayload("claude-opus-4-6")).toBe("claude-opus-4-6");
+  });
+});
+
+describe("displayRunnerModel", () => {
+  it("keeps a short alias", () => {
+    expect(displayRunnerModel("opus")).toBe("opus");
+  });
+
+  it("keeps the last path segment of an OpenRouter id", () => {
+    expect(displayRunnerModel("anthropic/claude-opus-4-6")).toBe("claude-opus-4-6");
+  });
+});
+
+describe("runnerModelsFromCanvasNodes", () => {
+  it("joins distinct runner models from canvas nodes", () => {
+    expect(
+      runnerModelsFromCanvasNodes([
+        { configuration: { model: "anthropic/claude-opus-4-6" } },
+        { configuration: { model: "anthropic/claude-opus-4-6" } },
+        { configuration: { model: "anthropic/claude-sonnet-4-6" } },
+      ]),
+    ).toBe("anthropic/claude-opus-4-6 · anthropic/claude-sonnet-4-6");
+  });
+});
+
+describe("phaseWithRunnerModel", () => {
+  it("keeps a model already on the phase", () => {
+    expect(phaseWithRunnerModel({ model: "opus" }, [{ configuration: { model: "sonnet" } }]).model).toBe("opus");
+  });
+
+  it("fills Auto from the canvas when the phase has no model", () => {
+    expect(phaseWithRunnerModel({}, [{ configuration: { model: "opus" } }]).model).toBe("opus");
   });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.spec.ts
@@ -48,7 +48,7 @@ describe("phaseWithRunnerModel", () => {
   });
 
   it("fills Auto from the canvas when the phase has no model", () => {
-    expect(phaseWithRunnerModel({}, [{ configuration: { model: "opus" } }]).model).toBe("opus");
+    expect(phaseWithRunnerModel({ model: undefined }, [{ configuration: { model: "opus" } }]).model).toBe("opus");
   });
 
   it("keeps a start model the canvas runners can use", () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.ts
@@ -1,9 +1,54 @@
 export const DRAFT_START_MODEL_AUTO = "auto";
 
+export const DRAFT_START_MODEL_HELP = [
+  "Auto uses the default model on each automation.",
+  "Pick a model to overwrite that default for this start.",
+] as const;
+
 export function draftStartModelPayload(selected: string): string | undefined {
   const trimmed = selected.trim();
   if (trimmed === "" || trimmed === DRAFT_START_MODEL_AUTO) {
     return undefined;
   }
   return trimmed;
+}
+
+/** Short label for a stored runner model id. */
+export function displayRunnerModel(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed === "") {
+    return "";
+  }
+  const slash = trimmed.lastIndexOf("/");
+  if (slash >= 0 && slash < trimmed.length - 1) {
+    return trimmed.slice(slash + 1);
+  }
+  return trimmed;
+}
+
+export function joinRunnerModels(ids: Array<string | undefined>): string {
+  const unique = [...new Set(ids.map((id) => id?.trim() ?? "").filter(Boolean))];
+  return unique.join(" · ");
+}
+
+export function runnerModelsFromCanvasNodes(
+  nodes?: Array<{ configuration?: { model?: unknown } | Record<string, unknown> }>,
+): string {
+  return joinRunnerModels(
+    (nodes ?? []).map((node) => {
+      const model = node.configuration && "model" in node.configuration ? node.configuration.model : undefined;
+      return typeof model === "string" ? model : undefined;
+    }),
+  );
+}
+
+export function phaseWithRunnerModel<T extends { model?: string }>(
+  phase: T,
+  nodes?: Array<{ configuration?: { model?: unknown } | Record<string, unknown> }>,
+): T {
+  if (phase.model?.trim()) {
+    return phase;
+  }
+  const fromCanvas = runnerModelsFromCanvasNodes(nodes);
+  return fromCanvas ? { ...phase, model: fromCanvas } : phase;
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.ts
@@ -31,9 +31,18 @@ export function joinRunnerModels(ids: Array<string | undefined>): string {
   return unique.join(" · ");
 }
 
-export function runnerModelsFromCanvasNodes(
-  nodes?: Array<{ configuration?: { model?: unknown } | Record<string, unknown> }>,
-): string {
+type RunnerCanvasNode = {
+  component?: string;
+  configuration?: { model?: unknown } | Record<string, unknown>;
+};
+
+const RUNNER_PROVIDER: Record<string, string> = {
+  runnerClaudeCode: "anthropic",
+  runnerCodex: "openai",
+  runnerOpenRouter: "openrouter",
+};
+
+export function runnerModelsFromCanvasNodes(nodes?: RunnerCanvasNode[]): string {
   return joinRunnerModels(
     (nodes ?? []).map((node) => {
       const model = node.configuration && "model" in node.configuration ? node.configuration.model : undefined;
@@ -42,13 +51,55 @@ export function runnerModelsFromCanvasNodes(
   );
 }
 
-export function phaseWithRunnerModel<T extends { model?: string }>(
-  phase: T,
-  nodes?: Array<{ configuration?: { model?: unknown } | Record<string, unknown> }>,
-): T {
-  if (phase.model?.trim()) {
+function runnerAcceptsStartModel(component: string | undefined, model: string): boolean {
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const runner = RUNNER_PROVIDER[component ?? ""];
+  if (!runner) {
+    return false;
+  }
+  if (runner === "openrouter") {
+    return true;
+  }
+  const hint = startModelProvider(trimmed);
+  return hint == null || hint === runner;
+}
+
+export function phaseWithRunnerModel<T extends { model?: string }>(phase: T, nodes?: RunnerCanvasNode[]): T {
+  const start = phase.model?.trim();
+  const fromCanvas = runnerModelsFromCanvasNodes(nodes);
+  if (start && canvasRunnersAcceptStartModel(nodes, start)) {
     return phase;
   }
-  const fromCanvas = runnerModelsFromCanvasNodes(nodes);
-  return fromCanvas ? { ...phase, model: fromCanvas } : phase;
+  if (fromCanvas) {
+    return { ...phase, model: fromCanvas };
+  }
+  if (start) {
+    return { ...phase, model: undefined };
+  }
+  return phase;
+}
+
+function canvasRunnersAcceptStartModel(nodes: RunnerCanvasNode[] | undefined, model: string): boolean {
+  const runners = (nodes ?? []).filter((node) => RUNNER_PROVIDER[node.component ?? ""]);
+  if (runners.length === 0) {
+    return true;
+  }
+  return runners.some((node) => runnerAcceptsStartModel(node.component, model));
+}
+
+function startModelProvider(model: string): string | undefined {
+  const id = model.toLowerCase();
+  if (id.startsWith("anthropic/") || id.includes("claude")) {
+    return "anthropic";
+  }
+  if (id.startsWith("openai/") || id.includes("codex") || /(^|\/)gpt-/.test(id) || /(^|\/)o[1-9]/.test(id)) {
+    return "openai";
+  }
+  if (id.includes("/")) {
+    return "openrouter";
+  }
+  return undefined;
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.ts
@@ -1,0 +1,9 @@
+export const DRAFT_START_MODEL_AUTO = "auto";
+
+export function draftStartModelPayload(selected: string): string | undefined {
+  const trimmed = selected.trim();
+  if (trimmed === "" || trimmed === DRAFT_START_MODEL_AUTO) {
+    return undefined;
+  }
+  return trimmed;
+}

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
@@ -96,6 +96,7 @@ describe("splitRunFixtureForWorkOrder", () => {
     expect(implement?.status).toBe("running");
     expect(implement?.costCents).toBe("28");
     expect(implement?.totalTokens).toBe("900");
+    expect(implement?.model).toBe("anthropic/claude-sonnet-4-6");
     expect(implement?.componentName).toBe("Implementation");
     expect(implement?.appId).toBe("app-refund-implementer");
     expect(implement?.runId).toBe(RUNNING_WORK_ORDER.lineDispatches?.[0]?.stepExecutions?.[0]?.run?.id);

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
@@ -128,6 +128,8 @@ export interface SplitRunPhase {
   costCents?: string;
   /** Ledger token count for this phase. Hidden when zero. */
   totalTokens?: string;
+  /** Runner model this automation used. Hidden when empty. */
+  model?: string;
 }
 
 export type { SplitRunFooter, SplitRunFooterKind, SplitRunFooterTone };
@@ -576,7 +578,16 @@ function phasesForOrder(
   return [
     ...sourcePhasesForOrder(order, executions.length > 0, demoArtifacts),
     ...phasesForAnalysisRuns(options?.analysisRuns ?? [], apiChecks),
-    ...executions.map((execution) => executionToPhase(order, execution, apiChecks, demoArtifacts, executions)),
+    ...executions.map((execution) =>
+      executionToPhase(
+        order,
+        execution,
+        apiChecks,
+        demoArtifacts,
+        executions,
+        dispatchModelForExecution(order, execution),
+      ),
+    ),
     ...phasesForPRFeedbackRuns(options?.prFeedbackRuns ?? []),
   ];
 }
@@ -932,6 +943,7 @@ function executionToPhase(
   apiChecks?: FactoriesWorkOrderCheck[],
   demoArtifacts = true,
   peers: FactoriesWorkOrderExecution[] = [],
+  dispatchModel?: string,
 ): SplitRunPhase {
   const status = statusForExecution(execution);
   const { name, componentName } = lineAutomationPresentation(execution.run, execution.step);
@@ -967,6 +979,7 @@ function executionToPhase(
     stepIndex: execution.stepIndex,
     costCents: execution.costCents,
     totalTokens: execution.totalTokens,
+    model: dispatchModel?.trim() || undefined,
   };
 }
 
@@ -1087,6 +1100,17 @@ function streamLineToCanvasStep(line: SplitRunStreamLine, provider: RunOverlayPr
 function canvasStatus(status: SplitRunPhaseStatus): RunOverlayStepStatus {
   if (status === "waiting" || status === "cancelled") return "pending";
   return status;
+}
+
+function dispatchModelForExecution(
+  order: FactoriesWorkOrder,
+  execution: FactoriesWorkOrderExecution,
+): string | undefined {
+  const owner = (order.lineDispatches ?? []).find((dispatch) =>
+    (dispatch.stepExecutions ?? []).some((step) => step.id && step.id === execution.id),
+  );
+  const value = owner?.model?.trim();
+  return value || undefined;
 }
 
 function statusForExecution(execution: FactoriesWorkOrderExecution): SplitRunPhaseStatus {

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
@@ -305,6 +305,7 @@ export function splitRunStatusLabel(status: SplitRunPhaseStatus): string {
 export type SplitRunFixtureOptions = {
   checks?: FactoriesWorkOrderCheck[];
   lineId?: string | null;
+  lineName?: string;
   /** Storybook keeps invented files and pull requests. Live orders do not. */
   demoArtifacts?: boolean;
   /** PR-feedback canvas runs for this task, shown as extra Log phases. */
@@ -343,7 +344,10 @@ function mappedWorkOrderFixture(order: FactoriesWorkOrder, options?: SplitRunFix
     startedLabel: startedLabelForOrder(order),
     costUsd: costUsdForDisplay(order),
     tokensLabel: tokensLabelForDisplay(order),
-    lineName: visibleDispatchForLine(order, options?.lineId)?.line?.name ?? SPLIT_RUN_RUNNING.lineName,
+    lineName:
+      options?.lineName?.trim() ||
+      visibleDispatchForLine(order, options?.lineId)?.line?.name ||
+      SPLIT_RUN_RUNNING.lineName,
     currentStepIndex: current?.stepIndex ?? 0,
     lineStatus: lineStatusForDisplay(displayStatus),
     currentPhaseId: activeAutomationId ?? (current ? phaseIdForExecution(current, executions) : (phases[0]?.id ?? "")),

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
@@ -578,16 +578,7 @@ function phasesForOrder(
   return [
     ...sourcePhasesForOrder(order, executions.length > 0, demoArtifacts),
     ...phasesForAnalysisRuns(options?.analysisRuns ?? [], apiChecks),
-    ...executions.map((execution) =>
-      executionToPhase(
-        order,
-        execution,
-        apiChecks,
-        demoArtifacts,
-        executions,
-        dispatchModelForExecution(order, execution),
-      ),
-    ),
+    ...executions.map((execution) => executionToPhase(order, execution, apiChecks, demoArtifacts, executions)),
     ...phasesForPRFeedbackRuns(options?.prFeedbackRuns ?? []),
   ];
 }
@@ -943,7 +934,6 @@ function executionToPhase(
   apiChecks?: FactoriesWorkOrderCheck[],
   demoArtifacts = true,
   peers: FactoriesWorkOrderExecution[] = [],
-  dispatchModel?: string,
 ): SplitRunPhase {
   const status = statusForExecution(execution);
   const { name, componentName } = lineAutomationPresentation(execution.run, execution.step);
@@ -979,7 +969,7 @@ function executionToPhase(
     stepIndex: execution.stepIndex,
     costCents: execution.costCents,
     totalTokens: execution.totalTokens,
-    model: dispatchModel?.trim() || undefined,
+    model: dispatchModelForExecution(order, execution),
   };
 }
 


### PR DESCRIPTION
## Summary

Operators could not pick a model for one draft start. The start used the stored canvas model only.

This change adds a model selector next to Start on the draft task popup. Auto keeps each runner's stored model. A selected model overlays matching runners for that start only.

Board-card Start stays Auto. Live canvases do not change.


Made with [Cursor](https://cursor.com)







<!-- greptile_comment -->

<sub>Reviews (4): Last reviewed commit: ["fix: Keep Draft Start Model Under Lint B..."](https://github.com/superplanehq/superplane/commit/edb1927bcae262c2b129caf4ef6c3b351b090de5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60365252)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->