### PR TITLE
feat: Gate Draft Start Model Behind a Flag

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -32,6 +32,10 @@ const FeatureFactorySentryIntake = "factory_sentry_intake"
 // page until it is ready for general use.
 const FeatureWorkspaceModels = "workspace_models"
 
+// FeatureFactoryDraftStartModel gates the model selector next to Start on
+// a draft task until the flow is generally available.
+const FeatureFactoryDraftStartModel = "factory_draft_start_model"
+
 func released() *bool {
 	v := true
 	return &v
@@ -43,6 +47,7 @@ var registry = []Feature{
 	{ID: FeatureNewIntegrationSetupFlow, Label: "New Integration Setup Flow", Description: "Use the multi-step SetupProvider wizard when connecting integrations such as GitHub"},
 	{ID: FeatureFactorySentryIntake, Label: "Factory Sentry Intake", Description: "Add Sentry intake from the Backlog column menu"},
 	{ID: FeatureWorkspaceModels, Label: "Workspace Models", Description: "Show the in-progress workspace Models settings page"},
+	{ID: FeatureFactoryDraftStartModel, Label: "Draft Start Model", Description: "Show a model selector next to Start on a draft task"},
 }
 
 func All() []Feature {

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -31,6 +31,14 @@ func Test__Get(t *testing.T) {
 		assert.Equal(t, "Show the in-progress workspace Models settings page", f.Description)
 	})
 
+	t.Run("known id returns draft start model feature", func(t *testing.T) {
+		f, ok := Get(FeatureFactoryDraftStartModel)
+		assert.True(t, ok)
+		assert.Equal(t, FeatureFactoryDraftStartModel, f.ID)
+		assert.Equal(t, "Draft Start Model", f.Label)
+		assert.Equal(t, "Show a model selector next to Start on a draft task", f.Description)
+	})
+
 	t.Run("unknown id returns zero value and false", func(t *testing.T) {
 		f, ok := Get("does-not-exist")
 		assert.False(t, ok)
@@ -48,6 +56,7 @@ func Test__Exists(t *testing.T) {
 	assert.True(t, Exists(FeatureFactories))
 	assert.True(t, Exists(FeatureFactorySentryIntake))
 	assert.True(t, Exists(FeatureWorkspaceModels))
+	assert.True(t, Exists(FeatureFactoryDraftStartModel))
 	assert.False(t, Exists("does-not-exist"))
 	assert.False(t, Exists(""))
 }

--- a/web_src/src/lib/experimentalFeatures.ts
+++ b/web_src/src/lib/experimentalFeatures.ts
@@ -12,3 +12,6 @@ export const FEATURE_FACTORY_SENTRY_INTAKE = "factory_sentry_intake";
 
 /** Organization experimental feature: in-progress workspace Models settings page. */
 export const FEATURE_WORKSPACE_MODELS = "workspace_models";
+
+/** Organization experimental feature: model selector next to Start on a draft task. */
+export const FEATURE_FACTORY_DRAFT_START_MODEL = "factory_draft_start_model";

--- a/web_src/src/pages/factories/pages/work-order-split-run/DraftStartModelSelect.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/DraftStartModelSelect.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
@@ -21,36 +23,58 @@ export function DraftStartModelSelect({
   disabled?: boolean;
 }) {
   const models = useFactoryLineRunnerModels(organizationId, factoryId, lineName);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
 
   return (
-    <HoverCard openDelay={150} closeDelay={100}>
-      <HoverCardTrigger asChild>
-        <div className="inline-flex" data-testid="split-run-draft-model-wrap">
-          <Select value={value} onValueChange={onChange} disabled={disabled}>
+    <Select
+      value={value}
+      onValueChange={onChange}
+      disabled={disabled}
+      open={pickerOpen}
+      onOpenChange={(open) => {
+        setPickerOpen(open);
+        if (open) {
+          setHelpOpen(false);
+        }
+      }}
+    >
+      <HoverCard
+        open={helpOpen && !pickerOpen}
+        onOpenChange={(open) => {
+          if (!pickerOpen) {
+            setHelpOpen(open);
+          }
+        }}
+        openDelay={150}
+        closeDelay={100}
+      >
+        <HoverCardTrigger asChild>
+          <div className="inline-flex" data-testid="split-run-draft-model-wrap">
             <SelectTrigger size="sm" className="w-[11.5rem]" aria-label="Model" data-testid="split-run-draft-model">
               <SelectValue placeholder="Auto" />
             </SelectTrigger>
-            <SelectContent position="popper" className="max-h-60">
-              <SelectItem value={DRAFT_START_MODEL_AUTO}>Auto</SelectItem>
-              {(models.data ?? []).map((model) => {
-                const id = model.id ?? "";
-                if (id === "") {
-                  return null;
-                }
-                return (
-                  <SelectItem key={id} value={id}>
-                    {model.name || id}
-                  </SelectItem>
-                );
-              })}
-            </SelectContent>
-          </Select>
-        </div>
-      </HoverCardTrigger>
-      <HoverCardContent side="top" align="end" className="w-64 space-y-1 p-3 text-sm">
-        <p data-testid="split-run-draft-model-help">{DRAFT_START_MODEL_HELP[0]}</p>
-        <p>{DRAFT_START_MODEL_HELP[1]}</p>
-      </HoverCardContent>
-    </HoverCard>
+          </div>
+        </HoverCardTrigger>
+        <HoverCardContent side="top" align="end" className="pointer-events-none w-64 space-y-1 p-3 text-sm">
+          <p data-testid="split-run-draft-model-help">{DRAFT_START_MODEL_HELP[0]}</p>
+          <p>{DRAFT_START_MODEL_HELP[1]}</p>
+        </HoverCardContent>
+      </HoverCard>
+      <SelectContent position="popper" className="max-h-60">
+        <SelectItem value={DRAFT_START_MODEL_AUTO}>Auto</SelectItem>
+        {(models.data ?? []).map((model) => {
+          const id = model.id ?? "";
+          if (id === "") {
+            return null;
+          }
+          return (
+            <SelectItem key={id} value={id}>
+              {model.name || id}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
   );
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.draftModel.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.draftModel.spec.tsx
@@ -89,4 +89,17 @@ describe("SplitRunReview draft model select", () => {
     expect(help).toHaveTextContent("Auto uses the default model on each automation.");
     expect(help.parentElement).toHaveTextContent("Pick a model to overwrite that default for this start.");
   });
+
+  it("hides the help when the picker is open", async () => {
+    const user = userEvent.setup();
+    renderDraftFooter(vi.fn());
+
+    await user.hover(screen.getByTestId("split-run-draft-model-wrap"));
+    expect(await screen.findByTestId("split-run-draft-model-help")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox", { name: "Model" }));
+    const option = await screen.findByRole("option", { name: "claude-opus-4-6" });
+    await user.hover(option);
+    expect(screen.queryByTestId("split-run-draft-model-help")).not.toBeInTheDocument();
+  });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -2,6 +2,9 @@ import { useEffect, useMemo, useState } from "react";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
+import { useExperimentalFeature } from "@/hooks/useExperimentalFeature";
+import { FEATURE_FACTORY_DRAFT_START_MODEL } from "@/lib/experimentalFeatures";
+
 import { CopyLinkButton } from "../../CopyLinkButton";
 import { workOrderDetailPath } from "../../lib/factoryPagePaths";
 import { OwnerTimeCostRow, PopupHeader, PopupShell } from "../work-order-popup-redesign/popupShared";
@@ -221,6 +224,7 @@ export function WorkOrderSplitRunPopup({
   canDispatch?: boolean;
   canUpdate?: boolean;
 }) {
+  const canPickDraftStartModel = useExperimentalFeature(organizationId).has(FEATURE_FACTORY_DRAFT_START_MODEL);
   const footerActions = useSplitRunFooterActions(organizationId, factoryId, orderId);
   const mutations = footerMutationHandlers(canUpdate, footerActions, fixture);
   const popupData = useSplitRunPopupData({ organizationId, factoryId, orderId, fixture });
@@ -296,7 +300,7 @@ export function WorkOrderSplitRunPopup({
         actionBusy={footerActions.busy}
         startDisabled={!canDispatch}
         modelSelect={
-          fixture.footer.kind === "draft" ? (
+          fixture.footer.kind === "draft" && canPickDraftStartModel ? (
             <DraftStartModelSelect
               organizationId={organizationId}
               factoryId={factoryId}

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunStop.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunStop.spec.tsx
@@ -5,10 +5,11 @@ import type { ComponentProps } from "react";
 import { MemoryRouter } from "react-router";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { handleStopMock, handleRejectMock, handleBackToDraftMock } = vi.hoisted(() => ({
+const { handleStopMock, handleRejectMock, handleBackToDraftMock, enabledExperimentalFeatures } = vi.hoisted(() => ({
   handleStopMock: vi.fn(),
   handleRejectMock: vi.fn(),
   handleBackToDraftMock: vi.fn(),
+  enabledExperimentalFeatures: new Set<string>(),
 }));
 
 vi.mock("./useSplitRunFooterActions", () => ({
@@ -18,6 +19,14 @@ vi.mock("./useSplitRunFooterActions", () => ({
     handleBackToDraft: handleBackToDraftMock,
     handleStopAutomation: vi.fn(),
     busy: false,
+  }),
+}));
+
+vi.mock("@/hooks/useExperimentalFeature", () => ({
+  useExperimentalFeature: () => ({
+    has: (featureId: string) => enabledExperimentalFeatures.has(featureId),
+    enabledExperimentalFeatures: [...enabledExperimentalFeatures],
+    isLoading: false,
   }),
 }));
 
@@ -36,6 +45,7 @@ beforeAll(() => {
 });
 
 import { ThemeProvider } from "@/contexts/ThemeProvider";
+import { FEATURE_FACTORY_DRAFT_START_MODEL } from "@/lib/experimentalFeatures";
 import { TooltipProvider } from "@/ui/tooltip";
 
 import { DRAFT_WORK_ORDER, FAILED_WORK_ORDER, OPEN_WORK_ORDER } from "../../__fixtures__/factoryPageResponses";
@@ -59,6 +69,7 @@ function renderPopup(fixture: ComponentProps<typeof WorkOrderSplitRunPopup>["fix
 
 describe("WorkOrderSplitRunPopup decision footer", () => {
   beforeEach(() => {
+    enabledExperimentalFeatures.clear();
     handleStopMock.mockReset();
     handleRejectMock.mockReset();
     handleBackToDraftMock.mockReset().mockResolvedValue(true);
@@ -88,7 +99,33 @@ describe("WorkOrderSplitRunPopup decision footer", () => {
     );
   });
 
+  it("hides the draft model select when the feature is off", async () => {
+    const user = userEvent.setup();
+    const onDispatch = vi.fn();
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter>
+          <ThemeProvider>
+            <TooltipProvider>
+              <WorkOrderSplitRunPopup
+                fixture={splitRunFixtureForWorkOrder(DRAFT_WORK_ORDER)}
+                onDispatch={onDispatch}
+                canDispatch
+              />
+            </TooltipProvider>
+          </ThemeProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const note = screen.getByTestId("split-run-attention-note");
+    expect(within(note).queryByTestId("split-run-draft-model")).not.toBeInTheDocument();
+    await user.click(within(note).getByRole("button", { name: "Start" }));
+    expect(onDispatch).toHaveBeenCalledWith(undefined);
+  });
+
   it("starts and rejects a draft from the note", async () => {
+    enabledExperimentalFeatures.add(FEATURE_FACTORY_DRAFT_START_MODEL);
     const user = userEvent.setup();
     const onDispatch = vi.fn();
     render(
@@ -119,6 +156,7 @@ describe("WorkOrderSplitRunPopup decision footer", () => {
   });
 
   it("starts a draft with the listed model", async () => {
+    enabledExperimentalFeatures.add(FEATURE_FACTORY_DRAFT_START_MODEL);
     const user = userEvent.setup();
     const onDispatch = vi.fn();
     render(


### PR DESCRIPTION
## Summary

The draft Start model selector is visible to every organization. This change hides it behind the Draft Start Model experimental feature.

Start still uses Auto when the flag is off. The help card closes when the picker opens so it cannot block a model click.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["feat: Gate Draft Start Model Behind a Fl..."](https://github.com/superplanehq/superplane/commit/b2d7b6c15f308b72874d2501459505f33c4674d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60388039)</sub>

<!-- /greptile_comment -->