### PR TITLE
fix: normalize org ID before integration sync on update

### DIFF
--- a/pkg/grpc/actions/organizations/update_integration.go
+++ b/pkg/grpc/actions/organizations/update_integration.go
@@ -37,6 +37,7 @@ func UpdateIntegration(
 	if err != nil {
 		return nil, err
 	}
+	orgID = org.String()
 
 	ID, err := uuid.Parse(integrationID)
 	if err != nil {

--- a/pkg/grpc/actions/organizations/update_integration_test.go
+++ b/pkg/grpc/actions/organizations/update_integration_test.go
@@ -287,4 +287,32 @@ func Test__UpdateIntegration(t *testing.T) {
 		_, exists = updateResponse.Integration.Spec.Configuration.AsMap()["adminKey"]
 		assert.False(t, exists, "serialized configuration must not return a redacted cleared secret")
 	})
+
+	t.Run("org slug in path -> sync receives the resolved org UUID", func(t *testing.T) {
+		//
+		// Sync must see the canonical org UUID even when the caller addresses
+		// the org by slug, matching CreateIntegrationWithUsage. Capture what
+		// the integration receives as SyncContext.OrganizationID.
+		//
+		var syncedOrgID string
+		r.Registry.Integrations["dummy"] = impl.NewDummyIntegration(impl.DummyIntegrationOptions{
+			OnSync: func(ctx core.SyncContext) error {
+				syncedOrgID = ctx.OrganizationID
+				ctx.Integration.Ready()
+				return nil
+			},
+		})
+
+		integrationName := support.RandomName("integration")
+		appConfig, err := structpb.NewStruct(map[string]any{"key": "value1"})
+		require.NoError(t, err)
+
+		createResponse, err := CreateIntegration(ctx, r.Registry, nil, baseURL, baseURL, r.Organization.ID.String(), "dummy", integrationName, appConfig)
+		require.NoError(t, err)
+		integrationID := createResponse.Integration.Metadata.Id
+
+		_, err = UpdateIntegration(ctx, r.Registry, nil, baseURL, baseURL, r.Organization.Slug, integrationID, map[string]any{"key": "value2"}, "")
+		require.NoError(t, err)
+		assert.Equal(t, r.Organization.ID.String(), syncedOrgID)
+	})
 }


### PR DESCRIPTION
UpdateIntegration resolves the org from a slug-or-UUID reference, then passes the raw client reference into integration.Sync. On the slug-routing path (added in #7046), that hands downstream Sync consumers the slug instead of the org UUID. Settings-URL builders and GitHub hosted-app detection (UseHostedApp(ctx.OrganizationID)) all read SyncContext.OrganizationID, so they see the wrong value.

CreateIntegrationWithUsage already reassigns orgID = org.String() right after resolving (create_integration.go:56). UpdateIntegration was missed. This mirrors it, one line.

The test passes the org slug to UpdateIntegration and asserts Sync receives the UUID. Without the change it fails: Sync sees org-<name>, the assertion expects the UUID.

Related to #7188, but I do not think it fixes the 500 reported there. That handler stores a failed Sync as integration state instead of returning it (update_integration.go:110-115), so the raw orgID reaching Sync cannot surface as an HTTP 500. I could not pin the actual 500 source from the code alone.