### PR TITLE
fix: Announce the sorted Velocity column to screen readers

### DIFF
--- a/web_src/src/pages/factories/pages/VelocityAutomationsTable.spec.tsx
+++ b/web_src/src/pages/factories/pages/VelocityAutomationsTable.spec.tsx
@@ -75,13 +75,14 @@ describe("VelocityAutomationsTable", () => {
     const user = userEvent.setup();
     renderTable();
 
-    const failed = screen.getByRole("button", { name: "Failed" });
+    // `aria-sort` belongs on the column header, not on the button inside it.
+    const failed = screen.getByRole("columnheader", { name: "Failed" });
     expect(failed).toHaveAttribute("aria-sort", "none");
 
-    await user.click(failed);
+    await user.click(within(failed).getByRole("button"));
     expect(failed).toHaveAttribute("aria-sort", "descending");
 
-    await user.click(failed);
+    await user.click(within(failed).getByRole("button"));
     expect(failed).toHaveAttribute("aria-sort", "ascending");
   });
 

--- a/web_src/src/pages/factories/pages/VelocitySortableHeader.tsx
+++ b/web_src/src/pages/factories/pages/VelocitySortableHeader.tsx
@@ -27,12 +27,11 @@ export function VelocitySortableHeader({
   const Icon = isActive && direction === "asc" ? ArrowUp : ArrowDown;
 
   return (
-    <th scope="col" className="pb-2 pl-6 text-right text-[12px] font-normal">
+    <th scope="col" aria-sort={ariaSort} className="pb-2 pl-6 text-right text-[12px] font-normal">
       <button
         type="button"
         onClick={onSort}
         title={hint}
-        aria-sort={ariaSort}
         className={cn(
           "inline-flex items-center gap-1 transition-colors hover:text-foreground",
           isActive ? "text-foreground" : "text-muted-foreground",


### PR DESCRIPTION
## Summary

The sortable column header of the Velocity tables put `aria-sort` on the
button inside the cell. The attribute is only valid on an element with a
column header role, so a screen reader did not announce which column the
People table and the Automations table are sorted on, or in which
direction.

Put `aria-sort` on the `th` element that holds the button. Nothing
changes visually.

Follow-up to #7203, where the review found this.

## Test plan

- [ ] `npx vitest run src/pages/factories/pages/VelocityAutomationsTable.spec.tsx`
      asserts the sort state on the column header.
- [ ] Open the Velocity page. Confirm the People table and the
      Automations table still sort on a click and look unchanged.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["Move the velocity sort state to the colu..."](https://github.com/superplanehq/superplane/commit/26f942e9215b21efcad5768586c9438a934e2bdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60476235)</sub>

<!-- /greptile_comment -->