### PR TITLE
feat: Split Velocity spend into tokens and compute

### DIFF
--- a/pkg/grpc/actions/factories/describe_factory_velocity.go
+++ b/pkg/grpc/actions/factories/describe_factory_velocity.go
@@ -69,7 +69,7 @@ func DescribeFactoryVelocity(
 	currentOrders := collectVelocityOrders(rows, current)
 	previousOrders := collectVelocityOrders(rows, previous)
 
-	usage, err := models.SumUsageForWorkOrders(db, append(velocityOrderIDs(currentOrders), velocityOrderIDs(previousOrders)...))
+	usage, err := models.SumUsageForWorkOrdersByKind(db, append(velocityOrderIDs(currentOrders), velocityOrderIDs(previousOrders)...))
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to describe factory velocity")
 	}
@@ -118,15 +118,19 @@ func DescribeFactoryVelocity(
 	for i := range buckets {
 		b := &buckets[i]
 		points = append(points, &pb.DescribeFactoryVelocityDay{
-			Day:              dayLabel(b.start),
-			Date:             timestamppb.New(b.start),
-			SuperplaneMerged: int32(b.superplaneMerged),
-			PeopleMerged:     int32(b.peopleMerged),
-			Waste:            int32(b.waste),
-			Intake:           serializeVelocityIntakeCounts(b.intake),
-			CostCents:        b.costCents,
-			Tokens:           b.tokens,
-			WasteCostCents:   b.wasteCostCents,
+			Day:                        dayLabel(b.start),
+			Date:                       timestamppb.New(b.start),
+			SuperplaneMerged:           int32(b.superplaneMerged),
+			PeopleMerged:               int32(b.peopleMerged),
+			Waste:                      int32(b.waste),
+			Intake:                     serializeVelocityIntakeCounts(b.intake),
+			CostCents:                  b.costCents,
+			ModelCostCents:             b.modelCostCents,
+			ComputeCostCents:           b.computeCostCents,
+			Tokens:                     b.tokens,
+			WasteCostCents:             b.wasteCostCents,
+			MedianTaskModelCostCents:   medianCents(b.taskModelCostCents),
+			MedianTaskComputeCostCents: medianCents(b.taskComputeCostCents),
 		})
 	}
 
@@ -408,14 +412,20 @@ type dayBucket struct {
 	peopleMerged     int
 	waste            int
 	// Merged SuperPlane pull requests of the day, keyed by intake source.
-	intake         map[string]int
-	costCents      int64
-	tokens         int64
-	wasteCostCents int64
+	intake           map[string]int
+	costCents        int64
+	modelCostCents   int64
+	computeCostCents int64
+	tokens           int64
+	wasteCostCents   int64
 	// Work orders reported on the day. A work order counts once here, however
 	// many pull requests it opened.
 	tasksClosed int
 	tasksWaste  int
+	// Spend of every work order reported on the day, one entry per order and
+	// band. The median needs the whole sample, not a running sum.
+	taskModelCostCents   []int64
+	taskComputeCostCents []int64
 }
 
 // dayLabel names the axis tick of a day, as a weekday and a date.
@@ -572,8 +582,12 @@ func fillBuckets(
 			continue
 		}
 		buckets[idx].costCents += order.costCents
+		buckets[idx].modelCostCents += order.modelCostCents
+		buckets[idx].computeCostCents += order.computeCostCents
 		buckets[idx].tokens += order.tokens
 		buckets[idx].tasksClosed++
+		buckets[idx].taskModelCostCents = append(buckets[idx].taskModelCostCents, order.modelCostCents)
+		buckets[idx].taskComputeCostCents = append(buckets[idx].taskComputeCostCents, order.computeCostCents)
 		if !order.merged {
 			buckets[idx].tasksWaste++
 			buckets[idx].wasteCostCents += order.costCents
@@ -602,7 +616,7 @@ func fillBuckets(
 func aggregateTotals(buckets []dayBucket, hasPeople bool) *pb.DescribeFactoryVelocityTotals {
 	sp, people, waste := 0, 0, 0
 	tasksClosed, tasksWaste := 0, 0
-	var costCents, tokens, wasteCostCents int64
+	var costCents, modelCostCents, computeCostCents, tokens, wasteCostCents int64
 	for _, b := range buckets {
 		sp += b.superplaneMerged
 		if hasPeople {
@@ -610,6 +624,8 @@ func aggregateTotals(buckets []dayBucket, hasPeople bool) *pb.DescribeFactoryVel
 		}
 		waste += b.waste
 		costCents += b.costCents
+		modelCostCents += b.modelCostCents
+		computeCostCents += b.computeCostCents
 		tokens += b.tokens
 		wasteCostCents += b.wasteCostCents
 		tasksClosed += b.tasksClosed
@@ -621,6 +637,8 @@ func aggregateTotals(buckets []dayBucket, hasPeople bool) *pb.DescribeFactoryVel
 		PeopleMerged:     int32(people),
 		Waste:            int32(waste),
 		CostCents:        costCents,
+		ModelCostCents:   modelCostCents,
+		ComputeCostCents: computeCostCents,
 		Tokens:           tokens,
 		WasteCostCents:   wasteCostCents,
 		TasksClosed:      int32(tasksClosed),

--- a/pkg/grpc/actions/factories/describe_factory_velocity_test.go
+++ b/pkg/grpc/actions/factories/describe_factory_velocity_test.go
@@ -542,10 +542,38 @@ func TestFillBuckets_ChargesWasteCost(t *testing.T) {
 	assert.Equal(t, 1, last.tasksWaste, "a task that closed without a merge is waste")
 }
 
+func TestFillBuckets_SplitsSpendAndKeepsTaskSamples(t *testing.T) {
+	loc := time.Local
+	now := time.Date(2026, 8, 17, 15, 0, 0, 0, loc)
+	buckets := buildDayBuckets(now, 7)
+	window := velocityWindow{start: buckets[0].start, end: buckets[len(buckets)-1].end}
+
+	today := localMidnight(now)
+	cheap, expensive := uuid.New(), uuid.New()
+
+	fillBuckets(
+		buckets,
+		nil,
+		map[uuid.UUID]*velocityOrder{
+			cheap:     {id: cheap, day: today, merged: true, costCents: 120, modelCostCents: 100, computeCostCents: 20},
+			expensive: {id: expensive, day: today, merged: true, costCents: 1100, modelCostCents: 900, computeCostCents: 200},
+		},
+		nil,
+		window,
+	)
+
+	last := buckets[len(buckets)-1]
+	assert.Equal(t, int64(1000), last.modelCostCents)
+	assert.Equal(t, int64(220), last.computeCostCents)
+	assert.Equal(t, last.costCents, last.modelCostCents+last.computeCostCents, "the bands add up to the day")
+	assert.ElementsMatch(t, []int64{100, 900}, last.taskModelCostCents, "the median needs one sample per task")
+	assert.ElementsMatch(t, []int64{20, 200}, last.taskComputeCostCents)
+}
+
 func TestAggregateTotals(t *testing.T) {
 	buckets := []dayBucket{
-		{superplaneMerged: 3, peopleMerged: 1, waste: 1, costCents: 400, tokens: 900, wasteCostCents: 100, tasksClosed: 3, tasksWaste: 1},
-		{superplaneMerged: 1, peopleMerged: 3, waste: 0, costCents: 200, tokens: 300, tasksClosed: 1},
+		{superplaneMerged: 3, peopleMerged: 1, waste: 1, costCents: 400, modelCostCents: 320, computeCostCents: 80, tokens: 900, wasteCostCents: 100, tasksClosed: 3, tasksWaste: 1},
+		{superplaneMerged: 1, peopleMerged: 3, waste: 0, costCents: 200, modelCostCents: 150, computeCostCents: 50, tokens: 300, tasksClosed: 1},
 	}
 	got := aggregateTotals(buckets, true)
 	assert.Equal(t, int32(4), got.SuperplaneMerged)
@@ -554,6 +582,8 @@ func TestAggregateTotals(t *testing.T) {
 	assert.Equal(t, int32(50), got.SuperplaneSharePct)
 	assert.Equal(t, int32(20), got.WastePct, "waste is 1 of 5 SuperPlane closures")
 	assert.Equal(t, int64(600), got.CostCents)
+	assert.Equal(t, int64(470), got.ModelCostCents)
+	assert.Equal(t, int64(130), got.ComputeCostCents)
 	assert.Equal(t, int64(1200), got.Tokens)
 	assert.Equal(t, int64(100), got.WasteCostCents)
 	assert.Equal(t, int32(4), got.TasksClosed)
@@ -878,6 +908,99 @@ func TestDescribeFactoryVelocity_CountsTasksApartFromPullRequests(t *testing.T) 
 	assert.Equal(t, int32(1), resp.Totals.Waste)
 	assert.Equal(t, int32(2), resp.Totals.TasksClosed, "the merged order counts once, however many pull requests it opened")
 	assert.Equal(t, int32(1), resp.Totals.TasksWaste)
+}
+
+func TestDescribeFactoryVelocity_ReportsSpendPerBandAndMedianTask(t *testing.T) {
+	r := support.Setup(t)
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	db := database.DB(t.Context())
+
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+
+	now := time.Now()
+	mergedAt := now.Add(-3 * time.Hour)
+
+	// Two tasks that closed today. Their spend differs, so the median is not
+	// the mean and a wrong aggregation shows.
+	seedVelocityOrderSpend(t, factoryModel, 1, mergedAt, 1_000_000, 200_000)
+	seedVelocityOrderSpend(t, factoryModel, 2, mergedAt, 5_000_000, 400_000)
+
+	resp, err := DescribeFactoryVelocity(ctx, r.Organization.ID.String(), &pb.DescribeFactoryVelocityRequest{
+		FactoryId:  factoryModel.ID.String(),
+		PeriodDays: 7,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(600), resp.Totals.ModelCostCents, "6 million micros of model spend is 600 cents")
+	assert.Equal(t, int64(60), resp.Totals.ComputeCostCents)
+	assert.Equal(t, resp.Totals.ModelCostCents+resp.Totals.ComputeCostCents, resp.Totals.CostCents,
+		"the bands add up to the reported total")
+
+	today := resp.Points[len(resp.Points)-1]
+	assert.Equal(t, int64(600), today.ModelCostCents)
+	assert.Equal(t, int64(60), today.ComputeCostCents)
+	assert.Equal(t, int64(300), today.MedianTaskModelCostCents, "the middle of 100 and 500 cents")
+	assert.Equal(t, int64(30), today.MedianTaskComputeCostCents)
+
+	quiet := resp.Points[0]
+	assert.Zero(t, quiet.MedianTaskModelCostCents, "a day with no tasks reports no median")
+	assert.Zero(t, quiet.MedianTaskComputeCostCents)
+}
+
+// seedVelocityOrderSpend creates a merged work order and charges it the given
+// model and compute spend, in micros.
+func seedVelocityOrderSpend(
+	t *testing.T,
+	factoryModel *models.Factory,
+	number int,
+	mergedAt time.Time,
+	modelMicros, computeMicros int64,
+) {
+	t.Helper()
+
+	db := database.DB(t.Context())
+	order, err := factoryModel.CreateWorkOrder(db, "Spending order", "", nil, nil, nil)
+	require.NoError(t, err)
+	_, err = order.CreatePullRequest(db, models.FactoryPullRequestParams{
+		URL:      fmt.Sprintf("https://github.com/example/repo/pull/%d", number),
+		State:    models.FactoryPullRequestStateMerged,
+		MergedAt: &mergedAt,
+	})
+	require.NoError(t, err)
+
+	events := []models.WorkspaceUsageEvent{
+		{
+			Provider:    models.UsageProviderAnthropic,
+			Model:       "claude-sonnet-4-6",
+			UsageKind:   models.UsageKindModel,
+			TotalTokens: 1_000,
+			CostMicros:  modelMicros,
+		},
+		{
+			Provider:        models.UsageProviderRunner,
+			Model:           "e1-large-amd64",
+			UsageKind:       models.UsageKindCompute,
+			MachineType:     "e1-large-amd64",
+			DurationSeconds: 900,
+			CostMicros:      computeMicros,
+		},
+	}
+	for _, event := range events {
+		event.ID = uuid.New()
+		event.OrganizationID = factoryModel.OrganizationID
+		event.FactoryID = &factoryModel.ID
+		event.WorkOrderID = &order.ID
+		event.CanvasRunID = uuid.New()
+		event.NodeExecutionID = uuid.New()
+		event.NodeID = "prompt"
+		event.FundingSource = models.UsageFundingSourceBYOK
+		event.Currency = "usd"
+		event.PriceBookVersion = "test"
+		event.IdempotencyKey = uuid.NewString()
+		event.OccurredAt = mergedAt
+		require.NoError(t, db.Create(&event).Error)
+	}
 }
 
 func seedPRArtifact(t *testing.T, factoryModel *models.Factory, url string, state string, at time.Time) *models.FactoryPullRequest {

--- a/pkg/grpc/actions/factories/describe_factory_velocity_test.go
+++ b/pkg/grpc/actions/factories/describe_factory_velocity_test.go
@@ -543,8 +543,7 @@ func TestFillBuckets_ChargesWasteCost(t *testing.T) {
 }
 
 func TestFillBuckets_SplitsSpendAndKeepsTaskSamples(t *testing.T) {
-	loc := time.Local
-	now := time.Date(2026, 8, 17, 15, 0, 0, 0, loc)
+	now := time.Now().In(time.Local)
 	buckets := buildDayBuckets(now, 7)
 	window := velocityWindow{start: buckets[0].start, end: buckets[len(buckets)-1].end}
 

--- a/pkg/grpc/actions/factories/factory_velocity_report.go
+++ b/pkg/grpc/actions/factories/factory_velocity_report.go
@@ -1,6 +1,7 @@
 package factories
 
 import (
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -62,7 +63,11 @@ type velocityOrder struct {
 	merged     bool
 	cycleHours *float64
 	costCents  int64
-	tokens     int64
+	// Bands of costCents: what the order spent on model tokens and on runner
+	// compute.
+	modelCostCents   int64
+	computeCostCents int64
+	tokens           int64
 }
 
 // collectVelocityOrders attributes every work order with pull request activity
@@ -140,15 +145,21 @@ func velocityIntakeLabel(key string) string {
 	return key
 }
 
-// applyVelocityOrderUsage fills tracked model spend on each order.
-func applyVelocityOrderUsage(orders map[uuid.UUID]*velocityOrder, usage map[uuid.UUID]models.UsageTotals) {
+// applyVelocityOrderUsage fills tracked spend on each order, in both bands.
+//
+// The total is the sum of the two rounded bands rather than the rounded sum,
+// so a stacked chart of the bands always adds up to the total it is drawn
+// against. The two can differ by a cent.
+func applyVelocityOrderUsage(orders map[uuid.UUID]*velocityOrder, usage map[uuid.UUID]models.UsageSplit) {
 	for id, order := range orders {
-		totals, ok := usage[id]
+		split, ok := usage[id]
 		if !ok {
 			continue
 		}
-		order.costCents = totals.CostCents()
-		order.tokens = totals.TotalTokens
+		order.modelCostCents = split.Model.CostCents()
+		order.computeCostCents = split.Compute.CostCents()
+		order.costCents = order.modelCostCents + order.computeCostCents
+		order.tokens = split.Total().TotalTokens
 	}
 }
 
@@ -399,6 +410,22 @@ func medianFloats(values []float64) float64 {
 	}
 	sorted := append([]float64(nil), values...)
 	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
+}
+
+// medianCents returns the middle value of a cent sample. An even sample
+// averages the two middle values and truncates, because a cent is the smallest
+// amount the report shows.
+func medianCents(values []int64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := slices.Clone(values)
+	slices.Sort(sorted)
 	mid := len(sorted) / 2
 	if len(sorted)%2 == 1 {
 		return sorted[mid]

--- a/pkg/grpc/actions/factories/factory_velocity_report_test.go
+++ b/pkg/grpc/actions/factories/factory_velocity_report_test.go
@@ -114,12 +114,39 @@ func TestApplyVelocityOrderUsage(t *testing.T) {
 	orderID := uuid.New()
 	orders := map[uuid.UUID]*velocityOrder{orderID: {id: orderID}}
 
-	applyVelocityOrderUsage(orders, map[uuid.UUID]models.UsageTotals{
-		orderID: {TotalTokens: 4200, CostMicros: 2_500_000},
+	applyVelocityOrderUsage(orders, map[uuid.UUID]models.UsageSplit{
+		orderID: {
+			Model:   models.UsageTotals{TotalTokens: 4200, CostMicros: 2_500_000},
+			Compute: models.UsageTotals{DurationSeconds: 900, CostMicros: 500_000},
+		},
 	})
 
-	assert.Equal(t, int64(4200), orders[orderID].tokens)
-	assert.Equal(t, int64(250), orders[orderID].costCents, "2.5 million micros is 250 cents")
+	order := orders[orderID]
+	assert.Equal(t, int64(4200), order.tokens)
+	assert.Equal(t, int64(250), order.modelCostCents, "2.5 million micros is 250 cents")
+	assert.Equal(t, int64(50), order.computeCostCents)
+	assert.Equal(t, int64(300), order.costCents, "the total is the two bands together")
+}
+
+func TestApplyVelocityOrderUsage_LeavesOrdersWithoutSpendAtZero(t *testing.T) {
+	orderID := uuid.New()
+	orders := map[uuid.UUID]*velocityOrder{orderID: {id: orderID}}
+
+	applyVelocityOrderUsage(orders, map[uuid.UUID]models.UsageSplit{})
+
+	assert.Zero(t, orders[orderID].costCents)
+	assert.Zero(t, orders[orderID].modelCostCents)
+	assert.Zero(t, orders[orderID].computeCostCents)
+}
+
+func TestMedianCents(t *testing.T) {
+	assert.Zero(t, medianCents(nil), "a day with no tasks has no median")
+	assert.Equal(t, int64(180), medianCents([]int64{900, 180, 20}), "the middle of an odd sample")
+	assert.Equal(t, int64(150), medianCents([]int64{100, 200, 900, 20}), "the two middle values, averaged")
+
+	values := []int64{300, 100, 200}
+	medianCents(values)
+	assert.Equal(t, []int64{300, 100, 200}, values, "the sample keeps its order")
 }
 
 func TestVelocityIntakeTotals_KeepsSeriesOrderAndDropsWaste(t *testing.T) {

--- a/pkg/models/workspace_usage_event.go
+++ b/pkg/models/workspace_usage_event.go
@@ -308,6 +308,14 @@ type UsageByMachineType struct {
 	CostMicros      int64
 }
 
+// UsageSplit is the ledger of one subject, divided by what the spend paid for.
+type UsageSplit struct {
+	// Model is spend on model tokens.
+	Model UsageTotals
+	// Compute is spend on runner machine time.
+	Compute UsageTotals
+}
+
 func (t UsageTotals) CostCents() int64 {
 	return pricebook.MicrosToCents(t.CostMicros)
 }
@@ -329,8 +337,21 @@ func (r UsageByMachineType) CostCents() int64 {
 	return pricebook.MicrosToCents(r.CostMicros)
 }
 
+// Total is the whole ledger of the subject, both bands together.
+func (s UsageSplit) Total() UsageTotals {
+	return s.Model.Add(s.Compute)
+}
+
 type usageSumRow struct {
 	ID              uuid.UUID
+	TotalTokens     int64
+	DurationSeconds int64
+	CostMicros      int64
+}
+
+type usageKindSumRow struct {
+	ID              uuid.UUID
+	UsageKind       string
 	TotalTokens     int64
 	DurationSeconds int64
 	CostMicros      int64
@@ -367,6 +388,45 @@ func SumUsageForWorkOrders(tx *gorm.DB, workOrderIDs []uuid.UUID) (map[uuid.UUID
 		return nil, err
 	}
 	return scanUsageSums(rows), nil
+}
+
+// SumUsageForWorkOrdersByKind returns ledger totals keyed by work order, with
+// model spend and compute spend reported apart. Missing IDs are absent from
+// the map (zero value).
+//
+// Anything that is not compute counts as model spend, so the two bands always
+// add up to what the work order cost.
+func SumUsageForWorkOrdersByKind(tx *gorm.DB, workOrderIDs []uuid.UUID) (map[uuid.UUID]UsageSplit, error) {
+	if len(workOrderIDs) == 0 {
+		return map[uuid.UUID]UsageSplit{}, nil
+	}
+
+	var rows []usageKindSumRow
+	err := tx.Model(&WorkspaceUsageEvent{}).
+		Select("work_order_id AS id, usage_kind, "+usageSumSelect).
+		Where("work_order_id IN ?", workOrderIDs).
+		Group("work_order_id, usage_kind").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[uuid.UUID]UsageSplit, len(rows))
+	for _, row := range rows {
+		totals := UsageTotals{
+			TotalTokens:     row.TotalTokens,
+			DurationSeconds: row.DurationSeconds,
+			CostMicros:      row.CostMicros,
+		}
+		split := result[row.ID]
+		if row.UsageKind == UsageKindCompute {
+			split.Compute = split.Compute.Add(totals)
+		} else {
+			split.Model = split.Model.Add(totals)
+		}
+		result[row.ID] = split
+	}
+	return result, nil
 }
 
 // SumUsageForRunTrees returns ledger totals for each root run, including

--- a/pkg/models/workspace_usage_event_test.go
+++ b/pkg/models/workspace_usage_event_test.go
@@ -327,6 +327,48 @@ func Test__SumUsageForWorkOrders__SumsLedgerByWorkOrder(t *testing.T) {
 	assert.Equal(t, int64(300), sums[order.ID].CostCents())
 }
 
+func Test__SumUsageForWorkOrdersByKind__ReportsModelAndComputeApart(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, order := createFactoryOrder(t, r)
+	run := startFactoryCanvasRun(t, r, factory.ID, map[string]any{
+		"type": "workOrder.created",
+		"data": map[string]any{
+			"workOrder": map[string]any{"id": order.ID.String()},
+		},
+	})
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, run.ID)))
+	require.NoError(t, models.RecordComputeUsage(db, models.ComputeUsageEventInput{
+		OrganizationID:  r.Organization.ID,
+		CanvasRunID:     run.ID,
+		NodeExecutionID: uuid.New(),
+		NodeID:          "runner",
+		MachineType:     "e1-large-amd64",
+		FleetID:         "e1-large-amd64",
+		DurationSeconds: 900,
+		IdempotencyKey:  "runner:compute:" + run.ID.String(),
+	}))
+
+	sums, err := models.SumUsageForWorkOrdersByKind(db, []uuid.UUID{order.ID})
+	require.NoError(t, err)
+
+	split := sums[order.ID]
+	assert.Equal(t, int64(1_000_000), split.Model.TotalTokens)
+	assert.Equal(t, int64(300), split.Model.CostCents())
+	assert.Zero(t, split.Model.DurationSeconds)
+	assert.Equal(t, int64(900), split.Compute.DurationSeconds)
+	assert.Positive(t, split.Compute.CostMicros, "runner time is charged")
+	assert.Equal(t, split.Model.CostMicros+split.Compute.CostMicros, split.Total().CostMicros)
+}
+
+func Test__SumUsageForWorkOrdersByKind__ReportsNothingForNoOrders(t *testing.T) {
+	support.Setup(t)
+
+	sums, err := models.SumUsageForWorkOrdersByKind(database.DB(t.Context()), nil)
+	require.NoError(t, err)
+	assert.Empty(t, sums)
+}
+
 func Test__RecordUsage__SameIdempotencyKeyRecordsOnce(t *testing.T) {
 	r := support.Setup(t)
 	db := database.DB(t.Context())

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -1844,13 +1844,24 @@ message DescribeFactoryVelocityDay {
   int32 waste = 5;
   // Merged SuperPlane pull requests grouped by intake source.
   repeated DescribeFactoryVelocityIntakeCount intake = 6;
-  // Tracked model spend of the work orders that closed on this day. A work
-  // order counts on the day its pull request merged, or on the day its last
-  // pull request closed when none merged.
+  // Tracked spend of the work orders that closed on this day. A work order
+  // counts on the day its pull request merged, or on the day its last pull
+  // request closed when none merged.
   int64 cost_cents = 7;
   int64 tokens = 8;
   // Part of `cost_cents` spent on work orders that closed without a merge.
   int64 waste_cost_cents = 9;
+  // Part of `cost_cents` spent on model tokens. Adds up to `cost_cents`
+  // together with `compute_cost_cents`.
+  int64 model_cost_cents = 10;
+  // Part of `cost_cents` spent on runner compute.
+  int64 compute_cost_cents = 11;
+  // Median model spend of one work order reported on this day. Medians of the
+  // two bands do not add up to the median of the total, so these two describe
+  // one typical work order per band rather than one typical total.
+  int64 median_task_model_cost_cents = 12;
+  // Median runner compute spend of one work order reported on this day.
+  int64 median_task_compute_cost_cents = 13;
 }
 
 // DescribeFactoryVelocityIntakeSource names one intake series and its total.
@@ -1921,7 +1932,7 @@ message DescribeFactoryVelocityTotals {
   int32 superplane_share_pct = 4;
   // Waste as a percentage of SuperPlane closes (merged + waste), 0-100.
   int32 waste_pct = 5;
-  // Tracked model spend of the work orders that closed in the window.
+  // Tracked spend of the work orders that closed in the window.
   int64 cost_cents = 6;
   int64 tokens = 7;
   // Part of `cost_cents` spent on work orders that closed without a merge.
@@ -1932,6 +1943,11 @@ message DescribeFactoryVelocityTotals {
   int32 tasks_closed = 9;
   // Part of `tasks_closed` whose pull requests all closed without a merge.
   int32 tasks_waste = 10;
+  // Part of `cost_cents` spent on model tokens. Adds up to `cost_cents`
+  // together with `compute_cost_cents`.
+  int64 model_cost_cents = 11;
+  // Part of `cost_cents` spent on runner compute.
+  int64 compute_cost_cents = 12;
 }
 
 // Trailing 30-day line summary nested on FactoryLine.

--- a/web_src/src/pages/factories/__fixtures__/velocityReportFixtures.ts
+++ b/web_src/src/pages/factories/__fixtures__/velocityReportFixtures.ts
@@ -2,6 +2,14 @@ import type { FactoriesDescribeFactoryVelocityResponse } from "@/api-client";
 import { peoplePageSizeForOffset } from "../lib/velocityPeopleSort";
 
 /**
+ * The velocity response, carrying the per-day cost fields the API does not
+ * report yet. The generated client parses the body as raw JSON, so the extra
+ * fields on each day reach the page unchanged and let the cost chart be
+ * designed before the ledger is split by usage kind.
+ */
+type VelocityResponse = FactoriesDescribeFactoryVelocityResponse;
+
+/**
  * Storybook payloads for the workspace Velocity report. The series drift on
  * purpose: SuperPlane output climbs while review time grows, so the page shows
  * a mixed result instead of every metric improving at once.
@@ -103,6 +111,18 @@ function intakeCounts(superplane: number) {
 
 function buildDay({ index, periodDays, people, superplane, waste }: VelocityDaySeed) {
   const costCents = Math.round(superplane * 214 + waste * 185);
+  /* Compute takes a bigger cut on days with long reruns, so the band breathes. */
+  const computeShare = 0.18 + (index % 4) * 0.03;
+  const computeCostCents = Math.round(costCents * computeShare);
+
+  /* Medians move day to day, so neither line reads as a constant. */
+  const drift = 1 + 0.18 * Math.sin(index * 0.7);
+
+  /* A few long reruns pull the mean above the median, so the median sits under it. */
+  const tasksClosed = superplane + waste;
+  const medianTaskCostCents = tasksClosed > 0 ? Math.round((costCents / tasksClosed) * 0.78 * drift) : 0;
+  const medianTaskComputeCostCents = Math.round(medianTaskCostCents * computeShare);
+
   return {
     day: dayLabel(index, periodDays),
     superplaneMerged: superplane,
@@ -110,6 +130,10 @@ function buildDay({ index, periodDays, people, superplane, waste }: VelocityDayS
     waste,
     intake: intakeCounts(superplane),
     costCents: String(costCents),
+    modelCostCents: String(costCents - computeCostCents),
+    computeCostCents: String(computeCostCents),
+    medianTaskModelCostCents: String(medianTaskCostCents - medianTaskComputeCostCents),
+    medianTaskComputeCostCents: String(medianTaskComputeCostCents),
     tokens: String(superplane * 18_500 + waste * 12_400),
     wasteCostCents: String(waste * 185),
   };
@@ -132,6 +156,8 @@ function sumTotals(points: Point[]) {
   const peopleMerged = points.reduce((total, point) => total + point.peopleMerged, 0);
   const waste = points.reduce((total, point) => total + point.waste, 0);
   const costCents = points.reduce((total, point) => total + Number(point.costCents), 0);
+  const modelCostCents = points.reduce((total, point) => total + Number(point.modelCostCents ?? 0), 0);
+  const computeCostCents = points.reduce((total, point) => total + Number(point.computeCostCents ?? 0), 0);
   const tokens = points.reduce((total, point) => total + Number(point.tokens), 0);
   const wasteCostCents = points.reduce((total, point) => total + Number(point.wasteCostCents), 0);
   const merged = superplaneMerged + peopleMerged;
@@ -143,6 +169,8 @@ function sumTotals(points: Point[]) {
     superplaneSharePct: merged > 0 ? Math.round((superplaneMerged / merged) * 100) : 0,
     wastePct: superplaneMerged + waste > 0 ? Math.round((waste / (superplaneMerged + waste)) * 100) : 0,
     costCents: String(costCents),
+    modelCostCents: String(modelCostCents),
+    computeCostCents: String(computeCostCents),
     tokens: String(tokens),
     wasteCostCents: String(wasteCostCents),
     // Every pull request of these payloads comes from a task of its own.
@@ -224,7 +252,7 @@ function buildReport(
   periodDays: number,
   withComparison: boolean,
   authors: Author[] = PEOPLE_AUTHORS,
-): FactoriesDescribeFactoryVelocityResponse {
+): VelocityResponse {
   const points = buildPoints(periodDays, periodDays);
   const totals = sumTotals(points);
   const previous = sumTotals(buildPoints(periodDays, 0));
@@ -246,13 +274,13 @@ function buildReport(
   };
 }
 
-export const DEFAULT_FACTORY_VELOCITY: Record<number, FactoriesDescribeFactoryVelocityResponse> = {
+export const DEFAULT_FACTORY_VELOCITY: Record<number, VelocityResponse> = {
   14: buildReport(14, true),
   30: buildReport(30, true),
 };
 
 /** A new workspace: nothing merged, nothing closed, nothing spent. */
-export const EMPTY_FACTORY_VELOCITY: FactoriesDescribeFactoryVelocityResponse = {
+export const EMPTY_FACTORY_VELOCITY: VelocityResponse = {
   yesterday: { superplaneMerged: 0, waste: 0 },
   totals: {
     superplaneMerged: 0,
@@ -284,7 +312,7 @@ export const EMPTY_FACTORY_VELOCITY: FactoriesDescribeFactoryVelocityResponse = 
  * the whole period, because Velocity reads repository history, but SuperPlane
  * has one day of output. There is no earlier period to compare with.
  */
-export const EARLY_USAGE_FACTORY_VELOCITY: FactoriesDescribeFactoryVelocityResponse = (() => {
+export const EARLY_USAGE_FACTORY_VELOCITY: VelocityResponse = (() => {
   const report = buildReport(14, false);
   const points = (report.points ?? []).map((point, index, all) => {
     const isLastDay = index === all.length - 1;
@@ -295,6 +323,10 @@ export const EARLY_USAGE_FACTORY_VELOCITY: FactoriesDescribeFactoryVelocityRespo
       waste: 0,
       intake: [],
       costCents: "0",
+      modelCostCents: "0",
+      computeCostCents: "0",
+      medianTaskModelCostCents: "0",
+      medianTaskComputeCostCents: "0",
       tokens: "0",
       wasteCostCents: "0",
     };
@@ -317,7 +349,7 @@ export const EARLY_USAGE_FACTORY_VELOCITY: FactoriesDescribeFactoryVelocityRespo
  * there, but the background sync has not stored the repository history yet, so
  * the People series and the SuperPlane share are withheld.
  */
-export const PEOPLE_SYNC_PENDING_FACTORY_VELOCITY: FactoriesDescribeFactoryVelocityResponse = (() => {
+export const PEOPLE_SYNC_PENDING_FACTORY_VELOCITY: VelocityResponse = (() => {
   const report = buildReport(14, true);
   const points = (report.points ?? []).map((point) => ({ ...point, peopleMerged: 0 }));
   const totals = sumTotals(points as Point[]);
@@ -338,7 +370,7 @@ export const PEOPLE_SYNC_PENDING_FACTORY_VELOCITY: FactoriesDescribeFactoryVeloc
  * something to load. Every other fixture keeps the small default cohort so its
  * story keeps rendering one page with no control.
  */
-export const PEOPLE_LOAD_MORE_FACTORY_VELOCITY: Record<number, FactoriesDescribeFactoryVelocityResponse> = {
+export const PEOPLE_LOAD_MORE_FACTORY_VELOCITY: Record<number, VelocityResponse> = {
   14: buildReport(14, true, MANY_PEOPLE_AUTHORS),
   30: buildReport(30, true, MANY_PEOPLE_AUTHORS),
 };
@@ -362,10 +394,7 @@ const PEOPLE_SORT_VALUE: Partial<Record<string, (person: VelocityPerson) => numb
  * `peopleOffset`/`peoplePageSize`, so Storybook and the mock server exercise
  * the same "Show more" contract the real API does.
  */
-export function paginateVelocityPeople(
-  report: FactoriesDescribeFactoryVelocityResponse,
-  url: URL,
-): FactoriesDescribeFactoryVelocityResponse {
+export function paginateVelocityPeople(report: VelocityResponse, url: URL): VelocityResponse {
   const people = [...(report.people ?? [])];
   const valueOf = PEOPLE_SORT_VALUE[url.searchParams.get("peopleSort") ?? ""] ?? totalMergedOf;
   const ascending = url.searchParams.get("peopleSortDirection") === "SORT_DIRECTION_ASC";

--- a/web_src/src/pages/factories/__fixtures__/velocityReportFixtures.ts
+++ b/web_src/src/pages/factories/__fixtures__/velocityReportFixtures.ts
@@ -1,12 +1,6 @@
 import type { FactoriesDescribeFactoryVelocityResponse } from "@/api-client";
 import { peoplePageSizeForOffset } from "../lib/velocityPeopleSort";
 
-/**
- * The velocity response, carrying the per-day cost fields the API does not
- * report yet. The generated client parses the body as raw JSON, so the extra
- * fields on each day reach the page unchanged and let the cost chart be
- * designed before the ledger is split by usage kind.
- */
 type VelocityResponse = FactoriesDescribeFactoryVelocityResponse;
 
 /**

--- a/web_src/src/pages/factories/lib/factoryVelocityReport.ts
+++ b/web_src/src/pages/factories/lib/factoryVelocityReport.ts
@@ -162,48 +162,24 @@ function centsToUsd(value: string | number | undefined): number {
   return parseWorkOrderMetric(value) / 100;
 }
 
-/**
- * Reads a field the generated response type does not declare yet. The API
- * client parses the body as raw JSON, so a field the backend starts to send
- * arrives here before the client is regenerated.
- */
-function readOptional(source: object, key: string): unknown {
-  return Reflect.get(source, key);
-}
-
-function readCents(source: object, key: string): number | undefined {
-  const value = readOptional(source, key);
-  if (typeof value !== "string" && typeof value !== "number") return undefined;
-  return centsToUsd(value);
-}
-
-function readCostSplit(source: object | undefined, prefix: string): VelocityCostSplit {
-  if (!source) return { modelCostUsd: 0, computeCostUsd: 0 };
-
-  return {
-    modelCostUsd: readCents(source, `${prefix}ModelCostCents`) ?? 0,
-    computeCostUsd: readCents(source, `${prefix}ComputeCostCents`) ?? 0,
-  };
-}
+/** The spend bands a day or a window reports. */
+type CostSplitSource = Pick<FactoriesDescribeFactoryVelocityDay, "modelCostCents" | "computeCostCents">;
 
 /**
- * Splits a tracked cost into model spend and runner compute. While the API
- * reports one number for both, the whole amount counts as model spend, so the
- * total a stacked band adds up to stays right and the compute band reads as
- * unknown rather than invented.
+ * Splits a tracked cost into model spend and runner compute.
+ *
+ * A response that reports neither band comes from a server older than the
+ * split, so the whole amount counts as model spend. The stacked bands still
+ * add up to the total, and no compute spend is invented.
  */
-function toCostSplit(source: object | undefined, costUsd: number): VelocityCostSplit {
-  if (!source) return { modelCostUsd: costUsd, computeCostUsd: 0 };
-
-  const computeCostUsd = readCents(source, "computeCostCents");
-  const modelCostUsd = readCents(source, "modelCostCents");
-  if (modelCostUsd === undefined && computeCostUsd === undefined) {
+function toCostSplit(source: CostSplitSource | undefined, costUsd: number): VelocityCostSplit {
+  if (!source || (source.modelCostCents === undefined && source.computeCostCents === undefined)) {
     return { modelCostUsd: costUsd, computeCostUsd: 0 };
   }
 
   return {
-    modelCostUsd: modelCostUsd ?? Math.max(0, costUsd - (computeCostUsd ?? 0)),
-    computeCostUsd: computeCostUsd ?? 0,
+    modelCostUsd: centsToUsd(source.modelCostCents),
+    computeCostUsd: centsToUsd(source.computeCostCents),
   };
 }
 
@@ -258,7 +234,10 @@ function toPoint(point: FactoriesDescribeFactoryVelocityDay): VelocityPoint {
     wasteCostUsd: centsToUsd(point.wasteCostCents),
     tokens: parseWorkOrderMetric(point.tokens),
     cost: toCostSplit(point, costUsd),
-    medianTaskCost: readCostSplit(point, "medianTask"),
+    medianTaskCost: {
+      modelCostUsd: centsToUsd(point.medianTaskModelCostCents),
+      computeCostUsd: centsToUsd(point.medianTaskComputeCostCents),
+    },
     intake,
   };
 }

--- a/web_src/src/pages/factories/lib/factoryVelocityReport.ts
+++ b/web_src/src/pages/factories/lib/factoryVelocityReport.ts
@@ -38,6 +38,27 @@ export const VELOCITY_BREAKDOWN_COPY: Record<VelocityBreakdown, { title: string;
   },
 };
 
+/** How the cost chart adds up the period. */
+export type VelocityCostMode = "daily" | "cumulative";
+
+export const VELOCITY_COST_MODE_OPTIONS: { value: VelocityCostMode; label: string }[] = [
+  { value: "daily", label: "Daily" },
+  { value: "cumulative", label: "Cumulative" },
+];
+
+export const VELOCITY_COST_MODE_COPY: Record<VelocityCostMode, string> = {
+  daily: "Spend of the tasks that closed each day, split between tokens and compute.",
+  cumulative: "Spend of the tasks that closed, added up over the period, split between tokens and compute.",
+};
+
+/** Spend of one thing, split by what the money paid for. */
+export interface VelocityCostSplit {
+  /** Model tokens. */
+  modelCostUsd: number;
+  /** Runner time a run used. */
+  computeCostUsd: number;
+}
+
 export interface VelocityPoint {
   day: string;
   people: number;
@@ -48,6 +69,10 @@ export interface VelocityPoint {
   costUsd: number;
   wasteCostUsd: number;
   tokens: number;
+  /** Spend of the day, which adds up to `costUsd`. */
+  cost: VelocityCostSplit;
+  /** Median spend of one task that closed on this day. */
+  medianTaskCost: VelocityCostSplit;
   /** Merged SuperPlane pull requests of the day, keyed by intake source. */
   intake: Record<string, number>;
 }
@@ -60,6 +85,10 @@ export interface VelocityTotals {
   costUsd: number;
   wasteCostUsd: number;
   tokens: number;
+  /** Part of `costUsd` spent on models. */
+  modelCostUsd: number;
+  /** Part of `costUsd` spent on runner compute. */
+  computeCostUsd: number;
   /**
    * Tasks that closed in the window, with or without a merge. A task counts
    * once, however many pull requests it opened, so this differs from the pull
@@ -133,6 +162,51 @@ function centsToUsd(value: string | number | undefined): number {
   return parseWorkOrderMetric(value) / 100;
 }
 
+/**
+ * Reads a field the generated response type does not declare yet. The API
+ * client parses the body as raw JSON, so a field the backend starts to send
+ * arrives here before the client is regenerated.
+ */
+function readOptional(source: object, key: string): unknown {
+  return Reflect.get(source, key);
+}
+
+function readCents(source: object, key: string): number | undefined {
+  const value = readOptional(source, key);
+  if (typeof value !== "string" && typeof value !== "number") return undefined;
+  return centsToUsd(value);
+}
+
+function readCostSplit(source: object | undefined, prefix: string): VelocityCostSplit {
+  if (!source) return { modelCostUsd: 0, computeCostUsd: 0 };
+
+  return {
+    modelCostUsd: readCents(source, `${prefix}ModelCostCents`) ?? 0,
+    computeCostUsd: readCents(source, `${prefix}ComputeCostCents`) ?? 0,
+  };
+}
+
+/**
+ * Splits a tracked cost into model spend and runner compute. While the API
+ * reports one number for both, the whole amount counts as model spend, so the
+ * total a stacked band adds up to stays right and the compute band reads as
+ * unknown rather than invented.
+ */
+function toCostSplit(source: object | undefined, costUsd: number): VelocityCostSplit {
+  if (!source) return { modelCostUsd: costUsd, computeCostUsd: 0 };
+
+  const computeCostUsd = readCents(source, "computeCostCents");
+  const modelCostUsd = readCents(source, "modelCostCents");
+  if (modelCostUsd === undefined && computeCostUsd === undefined) {
+    return { modelCostUsd: costUsd, computeCostUsd: 0 };
+  }
+
+  return {
+    modelCostUsd: modelCostUsd ?? Math.max(0, costUsd - (computeCostUsd ?? 0)),
+    computeCostUsd: computeCostUsd ?? 0,
+  };
+}
+
 /** Rounded share of `whole` that `part` holds, 0-100. */
 function sharePct(part: number, whole: number): number {
   if (whole <= 0) return 0;
@@ -155,6 +229,7 @@ function toTotals(totals: FactoriesDescribeFactoryVelocityTotals | undefined): V
     costUsd,
     wasteCostUsd: centsToUsd(totals?.wasteCostCents),
     tokens: parseWorkOrderMetric(totals?.tokens),
+    ...toCostSplit(totals, costUsd),
     tasksClosed,
     tasksWaste,
     taskWasteRate: sharePct(tasksWaste, tasksClosed),
@@ -171,15 +246,19 @@ function toPoint(point: FactoriesDescribeFactoryVelocityDay): VelocityPoint {
     if (count.key) intake[count.key] = count.merged ?? 0;
   }
 
+  const costUsd = centsToUsd(point.costCents);
+
   return {
     day: point.day ?? "",
     people,
     superplane,
     merged: people + superplane,
     waste: point.waste ?? 0,
-    costUsd: centsToUsd(point.costCents),
+    costUsd,
     wasteCostUsd: centsToUsd(point.wasteCostCents),
     tokens: parseWorkOrderMetric(point.tokens),
+    cost: toCostSplit(point, costUsd),
+    medianTaskCost: readCostSplit(point, "medianTask"),
     intake,
   };
 }

--- a/web_src/src/pages/factories/lib/velocitySeriesColors.ts
+++ b/web_src/src/pages/factories/lib/velocitySeriesColors.ts
@@ -18,7 +18,14 @@ export const VELOCITY_TIME_COLORS = {
   waiting: "#f59e0b",
 } as const;
 
-export const VELOCITY_COST_COLOR = "#6366f1";
+/**
+ * The two things spend goes to. Both bands keep one hue in two tints, so a
+ * stacked cost bar reads as one total before it reads as a split.
+ */
+export const VELOCITY_COST_COLORS = {
+  model: "#6366f1",
+  compute: "#a5b4fc",
+} as const;
 
 /**
  * Colors of the intake bands. Known sources keep one color across workspaces so

--- a/web_src/src/pages/factories/pages/VelocityCharts.tsx
+++ b/web_src/src/pages/factories/pages/VelocityCharts.tsx
@@ -1,4 +1,4 @@
-import { Area, AreaChart, Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
 
 import {
   ChartContainer,
@@ -14,11 +14,12 @@ import { formatDurationHours, pickVelocityChartUnit, type FactoryVelocityFlow } 
 import {
   velocityBreakdownSeries,
   type VelocityBreakdown,
+  type VelocityCostMode,
   type VelocityIntakeSeries,
   type VelocityPoint,
 } from "../lib/factoryVelocityReport";
 import { pickVelocityAxisTicks } from "../lib/velocityAxisTicks";
-import { VELOCITY_COST_COLOR, VELOCITY_TIME_COLORS } from "../lib/velocitySeriesColors";
+import { VELOCITY_COST_COLORS, VELOCITY_TIME_COLORS } from "../lib/velocitySeriesColors";
 
 const flowChartConfig = {
   runningHours: { label: "Time running", color: VELOCITY_TIME_COLORS.running },
@@ -26,12 +27,17 @@ const flowChartConfig = {
 } satisfies ChartConfig;
 
 const costChartConfig = {
-  costUsd: { label: "Tracked cost", color: VELOCITY_COST_COLOR },
+  modelCostUsd: { label: "Tokens", color: VELOCITY_COST_COLORS.model },
+  computeCostUsd: { label: "Compute", color: VELOCITY_COST_COLORS.compute },
 } satisfies ChartConfig;
 
-/** Both area charts sit side by side, so they must read as one visual family. */
+/** Both area charts span a full row, one above the other, so they must read as one visual family. */
 const AREA_FILL_OPACITY = 0.3;
 const AREA_STROKE_WIDTH = 1.5;
+const AREA_CHART_HEIGHT = 220;
+
+/** Width assumed before the container reports its own, matching a full-row card. */
+const AREA_CHART_FALLBACK_WIDTH = 1160;
 
 /** Row of the delivery chart: one day, one value per visible band. */
 type DeliveryRow = Record<string, string | number>;
@@ -127,7 +133,7 @@ function formatFlowTooltip(value: unknown, name: unknown) {
 
 export function FlowChart({ trend }: { trend: FactoryVelocityFlow["timeTrend"] }) {
   const chartUnit = pickVelocityChartUnit(trend.map((point) => point.runningHours + point.waitingHours));
-  const { ref, width } = useElementWidth<HTMLDivElement>(500);
+  const { ref, width } = useElementWidth<HTMLDivElement>(AREA_CHART_FALLBACK_WIDTH);
   const ticks = pickVelocityAxisTicks(
     trend.map((point) => point.day),
     width,
@@ -137,8 +143,8 @@ export function FlowChart({ trend }: { trend: FactoryVelocityFlow["timeTrend"] }
     <div ref={ref} className="w-full">
       <ChartContainer
         config={flowChartConfig}
-        className="aspect-auto h-[180px] w-full"
-        initialDimension={{ width: 500, height: 180 }}
+        className="aspect-auto h-[220px] w-full"
+        initialDimension={{ width: AREA_CHART_FALLBACK_WIDTH, height: AREA_CHART_HEIGHT }}
       >
         <AreaChart data={trend} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
           <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
@@ -184,49 +190,160 @@ export function FlowChart({ trend }: { trend: FactoryVelocityFlow["timeTrend"] }
   );
 }
 
-export function CostChart({ points }: { points: VelocityPoint[] }) {
-  const { ref, width } = useElementWidth<HTMLDivElement>(500);
+function formatCostTooltip(value: unknown, name: unknown) {
+  const usd = Array.isArray(value) ? Number(value[0]) : Number(value);
+  const key = String(name);
+  const label = key in costChartConfig ? costChartConfig[key as keyof typeof costChartConfig].label : key;
+
+  return (
+    <div className="flex w-full items-center justify-between gap-8">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-mono font-medium text-foreground tabular-nums">
+        {Number.isFinite(usd) ? formatUsd(usd) : String(value)}
+      </span>
+    </div>
+  );
+}
+
+function formatUsd(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+/**
+ * Cents matter on a median task that cost a few dollars, whole dollars are
+ * enough on a month of spend, so the axis follows the numbers it labels.
+ */
+function costTickFormatter(rows: CostRow[]): (value: number) => string {
+  const max = Math.max(0, ...rows.map((row) => row.modelCostUsd + row.computeCostUsd));
+  const digits = max < 10 ? 1 : 0;
+  return (value: number) => `$${Number(value).toFixed(digits)}`;
+}
+
+/** Row of a cost chart: one day, split into both bands. */
+interface CostRow {
+  day: string;
+  modelCostUsd: number;
+  computeCostUsd: number;
+}
+
+/** Grid, axes, tooltip, and legend shared by both cost charts. */
+function useCostChartAxes(rows: CostRow[]) {
+  const { ref, width } = useElementWidth<HTMLDivElement>(AREA_CHART_FALLBACK_WIDTH);
   const ticks = pickVelocityAxisTicks(
-    points.map((point) => point.day),
+    rows.map((row) => row.day),
     width,
   );
 
+  const axes = (
+    <>
+      <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+      <XAxis
+        dataKey="day"
+        tickLine={false}
+        axisLine={false}
+        tickMargin={8}
+        interval={0}
+        ticks={ticks}
+        className="text-[11px]"
+      />
+      <YAxis
+        tickLine={false}
+        axisLine={false}
+        width={44}
+        className="text-[11px]"
+        tickFormatter={costTickFormatter(rows)}
+      />
+      <ChartTooltip content={<ChartTooltipContent formatter={formatCostTooltip} />} />
+      <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" />
+    </>
+  );
+
+  return { ref, axes };
+}
+
+const costChartContainerProps = {
+  config: costChartConfig,
+  className: "aspect-auto h-[220px] w-full",
+  initialDimension: { width: AREA_CHART_FALLBACK_WIDTH, height: AREA_CHART_HEIGHT },
+};
+
+/** Running totals, so the reader sees what the period has cost by each day. */
+function cumulativeCostRows(points: VelocityPoint[]): CostRow[] {
+  let modelCostUsd = 0;
+  let computeCostUsd = 0;
+
+  return points.map((point) => {
+    modelCostUsd += point.cost.modelCostUsd;
+    computeCostUsd += point.cost.computeCostUsd;
+    return { day: point.day, modelCostUsd, computeCostUsd };
+  });
+}
+
+/** Spend, stacked, because the two bands add up to the total they sit under. */
+export function CostChart({ points, mode }: { points: VelocityPoint[]; mode: VelocityCostMode }) {
+  const rows: CostRow[] =
+    mode === "cumulative" ? cumulativeCostRows(points) : points.map((point) => ({ day: point.day, ...point.cost }));
+  const { ref, axes } = useCostChartAxes(rows);
+
   return (
     <div ref={ref} className="w-full">
-      <ChartContainer
-        config={costChartConfig}
-        className="aspect-auto h-[180px] w-full"
-        initialDimension={{ width: 500, height: 180 }}
-      >
-        <AreaChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
-          <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
-          <XAxis
-            dataKey="day"
-            tickLine={false}
-            axisLine={false}
-            tickMargin={8}
-            interval={0}
-            ticks={ticks}
-            className="text-[11px]"
-          />
-          <YAxis
-            tickLine={false}
-            axisLine={false}
-            width={38}
-            className="text-[11px]"
-            tickFormatter={(value: number) => `$${Number(value).toFixed(0)}`}
-          />
-          <ChartTooltip content={<ChartTooltipContent />} />
-          {/* No legend: one band, already named by the total above the chart. */}
+      <ChartContainer {...costChartContainerProps}>
+        <AreaChart data={rows} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+          {axes}
           <Area
             type="monotone"
-            dataKey="costUsd"
-            stroke={VELOCITY_COST_COLOR}
-            fill={VELOCITY_COST_COLOR}
+            dataKey="computeCostUsd"
+            stackId="cost"
+            stroke={VELOCITY_COST_COLORS.compute}
+            fill={VELOCITY_COST_COLORS.compute}
+            fillOpacity={AREA_FILL_OPACITY}
+            strokeWidth={AREA_STROKE_WIDTH}
+          />
+          <Area
+            type="monotone"
+            dataKey="modelCostUsd"
+            stackId="cost"
+            stroke={VELOCITY_COST_COLORS.model}
+            fill={VELOCITY_COST_COLORS.model}
             fillOpacity={AREA_FILL_OPACITY}
             strokeWidth={AREA_STROKE_WIDTH}
           />
         </AreaChart>
+      </ChartContainer>
+    </div>
+  );
+}
+
+/**
+ * Median spend of one task, by day.
+ *
+ * Lines, not stacked bands: a median of the parts does not add up to the median
+ * of the whole, so a stack here would draw a total that no task ever cost.
+ */
+export function TaskCostChart({ points }: { points: VelocityPoint[] }) {
+  const rows: CostRow[] = points.map((point) => ({ day: point.day, ...point.medianTaskCost }));
+  const { ref, axes } = useCostChartAxes(rows);
+
+  return (
+    <div ref={ref} className="w-full">
+      <ChartContainer {...costChartContainerProps}>
+        <LineChart data={rows} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+          {axes}
+          <Line
+            type="monotone"
+            dataKey="modelCostUsd"
+            stroke={VELOCITY_COST_COLORS.model}
+            strokeWidth={AREA_STROKE_WIDTH}
+            dot={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="computeCostUsd"
+            stroke={VELOCITY_COST_COLORS.compute}
+            strokeWidth={AREA_STROKE_WIDTH}
+            dot={false}
+          />
+        </LineChart>
       </ChartContainer>
     </div>
   );

--- a/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
@@ -558,14 +558,16 @@ describe("VelocityPage shell", () => {
     expect(taskTime).toHaveTextContent("We could not load task time.");
   });
 
-  it("reports tracked spend and the part of it that went to waste", () => {
+  it("reports tracked spend split between tokens and compute", () => {
     resetState();
     velocityHookState.data = populatedResponse();
 
     renderShell();
 
     const cost = screen.getByTestId("velocity-cost");
+    expect(cost).toHaveTextContent("Total cost");
     expect(cost).toHaveTextContent("$42.00");
-    expect(cost).toHaveTextContent("$9.00 of this went to tasks that closed without a merge.");
+    expect(cost).toHaveTextContent("Tokens");
+    expect(cost).toHaveTextContent("Compute");
   });
 });

--- a/web_src/src/pages/factories/pages/VelocityPage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.tsx
@@ -18,7 +18,7 @@ import {
 } from "../lib/factoryVelocityReport";
 import { factoryCenteredSectionBodyClassName, factoryCenteredSectionHeaderClassName } from "./factoryPageLayoutStyles";
 import { VelocityAutomationsTable } from "./VelocityAutomationsTable";
-import { CostCard, DeliveryCard, SummaryCard, TaskTimeCard } from "./velocityCards";
+import { CostCard, DeliveryCard, SummaryCard, TaskCostCard, TaskTimeCard } from "./velocityCards";
 import { VelocityPeopleTable } from "./VelocityPeopleTable";
 import { VelocityZeroState } from "./VelocityZeroState";
 import { useVelocityPageModel, type VelocityPageModel } from "./useVelocityPageModel";
@@ -125,10 +125,9 @@ function VelocityReportView({
           periodLabel={model.periodLabel}
         />
       ) : null}
-      <div className="grid gap-5 lg:grid-cols-2">
-        <TaskTimeCard flow={flow} emptyLabel={taskTimeEmptyLabel(model)} />
-        <CostCard totals={report.totals} points={report.points} />
-      </div>
+      <TaskTimeCard flow={flow} emptyLabel={taskTimeEmptyLabel(model)} />
+      <CostCard totals={report.totals} points={report.points} />
+      <TaskCostCard points={report.points} />
     </>
   );
 }

--- a/web_src/src/pages/factories/pages/velocityCards.tsx
+++ b/web_src/src/pages/factories/pages/velocityCards.tsx
@@ -365,6 +365,11 @@ export function CostCard({ totals, points }: { totals: VelocityTotals; points: V
  * "what did we spend"; this one answers "is a task getting cheaper".
  */
 export function TaskCostCard({ points }: { points: VelocityPoint[] }) {
+  /*
+   * Tasks can close with nothing tracked, on a plan that reports no cost or
+   * on spend below a cent. The chart then has no line to draw, so the note
+   * speaks about the missing spend rather than claiming no task closed.
+   */
   const hasMedian = points.some(
     (point) => point.medianTaskCost.modelCostUsd > 0 || point.medianTaskCost.computeCostUsd > 0,
   );
@@ -381,7 +386,7 @@ export function TaskCostCard({ points }: { points: VelocityPoint[] }) {
           <TaskCostChart points={points} />
         </div>
       ) : (
-        <ChartEmptyNote>No tasks closed in this period.</ChartEmptyNote>
+        <ChartEmptyNote>No tracked spend for closed tasks in this period.</ChartEmptyNote>
       )}
     </section>
   );

--- a/web_src/src/pages/factories/pages/velocityCards.tsx
+++ b/web_src/src/pages/factories/pages/velocityCards.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { ArrowDownRight, ArrowUpRight, Info } from "lucide-react";
 
 import { formatCompactTokenValue } from "@/lib/formatTokenCount";
@@ -10,14 +10,17 @@ import { formatDurationHours, type FactoryVelocityFlow } from "../lib/factoryVel
 import {
   VELOCITY_BREAKDOWN_COPY,
   VELOCITY_BREAKDOWN_OPTIONS,
+  VELOCITY_COST_MODE_COPY,
+  VELOCITY_COST_MODE_OPTIONS,
   type VelocityBreakdown,
+  type VelocityCostMode,
   type VelocityIntakeSeries,
   type VelocityPeriodDays,
   type VelocityPoint,
   type VelocityTotals,
 } from "../lib/factoryVelocityReport";
-import { VELOCITY_TIME_COLORS } from "../lib/velocitySeriesColors";
-import { CostChart, DeliveryChart, FlowChart } from "./VelocityCharts";
+import { VELOCITY_COST_COLORS, VELOCITY_TIME_COLORS } from "../lib/velocitySeriesColors";
+import { CostChart, DeliveryChart, FlowChart, TaskCostChart } from "./VelocityCharts";
 
 export const velocityCardClassName = "rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5";
 const cardTitleClassName = "text-[14px] font-medium tracking-[-0.01em] text-foreground";
@@ -75,16 +78,22 @@ function Metric({
   hint,
   tooltip,
   change,
+  color,
 }: {
   label: string;
   value: string;
   hint?: string;
   tooltip?: string;
   change?: MetricChange;
+  /** Color of the band this number belongs to, when a chart below draws one. */
+  color?: string;
 }) {
   return (
     <div className="min-w-0">
       <div className="flex items-center gap-1">
+        {color ? (
+          <span className="size-1.5 shrink-0 rounded-full" style={{ backgroundColor: color }} aria-hidden />
+        ) : null}
         <p className="text-[12px] text-muted-foreground">{label}</p>
         {tooltip ? (
           <Tooltip>
@@ -306,35 +315,73 @@ export function TaskTimeCard({
 }
 
 export function CostCard({ totals, points }: { totals: VelocityTotals; points: VelocityPoint[] }) {
+  const [mode, setMode] = useState<VelocityCostMode>("daily");
   const hasCost = totals.costUsd > 0;
 
   return (
     <section className={velocityCardClassName} data-testid="velocity-cost">
-      <h2 className={cardTitleClassName}>Tracked SuperPlane cost</h2>
-      <p className={cardSubtitleClassName}>Model spend of the tasks that closed. Third-party charges are excluded.</p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className={cardTitleClassName}>Costs</h2>
+          <p className={cardSubtitleClassName}>{VELOCITY_COST_MODE_COPY[mode]}</p>
+        </div>
+        {hasCost ? (
+          <SegmentedNav
+            ariaLabel="Add up costs by"
+            size="xs"
+            value={mode}
+            onValueChange={(value) => setMode(value as VelocityCostMode)}
+            options={VELOCITY_COST_MODE_OPTIONS}
+          />
+        ) : null}
+      </div>
 
       {hasCost ? (
         <>
-          <div className="mt-5">
+          <div className="mt-5 grid grid-cols-2 gap-x-8 gap-y-6 lg:grid-cols-3">
+            <Metric label="Total cost" value={formatUsd(totals.costUsd)} />
             <Metric
-              label="Total cost"
-              value={formatUsd(totals.costUsd)}
+              label="Tokens"
+              color={VELOCITY_COST_COLORS.model}
+              value={formatUsd(totals.modelCostUsd)}
               hint={`${formatCompactTokenValue(totals.tokens)} tokens`}
             />
-          </div>
-
-          <div className="mt-4 border-t border-border pt-2">
-            <p className="text-[12px] text-muted-foreground">
-              {formatUsd(totals.wasteCostUsd)} of this went to tasks that closed without a merge.
-            </p>
+            <Metric label="Compute" color={VELOCITY_COST_COLORS.compute} value={formatUsd(totals.computeCostUsd)} />
           </div>
 
           <div className="mt-5 border-t border-border pt-4">
-            <CostChart points={points} />
+            <CostChart points={points} mode={mode} />
           </div>
         </>
       ) : (
-        <ChartEmptyNote>No tracked model spend in this period.</ChartEmptyNote>
+        <ChartEmptyNote>No tracked spend in this period.</ChartEmptyNote>
+      )}
+    </section>
+  );
+}
+
+/**
+ * What one task costs, tracked over the period. The Costs card above answers
+ * "what did we spend"; this one answers "is a task getting cheaper".
+ */
+export function TaskCostCard({ points }: { points: VelocityPoint[] }) {
+  const hasMedian = points.some(
+    (point) => point.medianTaskCost.modelCostUsd > 0 || point.medianTaskCost.computeCostUsd > 0,
+  );
+
+  return (
+    <section className={velocityCardClassName} data-testid="velocity-task-cost">
+      <h2 className={cardTitleClassName}>Per task costs</h2>
+      <p className={cardSubtitleClassName}>
+        Median spend of one task that closed, by day, split between tokens and compute.
+      </p>
+
+      {hasMedian ? (
+        <div className="mt-5">
+          <TaskCostChart points={points} />
+        </div>
+      ) : (
+        <ChartEmptyNote>No tasks closed in this period.</ChartEmptyNote>
       )}
     </section>
   );


### PR DESCRIPTION
## Summary

The Velocity report gave one cost number per day. A reader could see how
much the workspace spent, but not what the money paid for, and not what
one typical task costs. Two questions stayed unanswered: does spend go
to model tokens or to runner machine time, and is a rising total more
tasks or more expensive tasks?

This change reports spend in two bands, tokens and compute, on each day
and on the window totals. The Costs card charts the bands as a stacked
area over the full row, with a Daily and a Cumulative view, and names
the total of each band in the summary. A new Per Task Costs card charts
the median spend of one task per day. The median, not the mean, because
a few long reruns pull a mean far above the typical task.

Two rules keep the numbers honest:

- The bands are rounded apart and added up for the total, so a stacked
  chart always matches the total it is drawn against.
- The two medians are drawn as separate lines, not stacked. Medians do
  not add up, so a stack of them would show a total that no task ever
  cost.

## Test plan

- [ ] `make test PKG_TEST_PACKAGES=./pkg/models` and
      `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/factories` pass.
      (`Test__DescribeFactoryUsage`, `Test__RecordComputeUsage__*`, and
      `TestSummarizeSpendingKPITotalsAndExplorer` fail on `main` too.)
- [ ] `make lint`, `make check.build.app`, `make check.lint.ui`, and the
      frontend type check pass.
- [ ] Open the Velocity page of a workspace with tracked spend. The
      Costs card shows a tokens band and a compute band that add up to
      the total cost.
- [ ] Switch the Costs card to Cumulative. The bands climb and end at
      the window total.
- [ ] The Per Task Costs card shows two lines. A day with no closed
      tasks reports no median.
- [ ] A workspace with no spend shows an empty state, not zero bands.

Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["Name the missing spend on the per task c..."](https://github.com/superplanehq/superplane/commit/61824d0089684f395698dd1a5d85cb8da51ffc84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60578746)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->