### PR TITLE
fix: Show account picker for single GitHub App install

### DIFF
--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -251,7 +251,7 @@ func (g *GitHub) syncHostedApp(ctx core.SyncContext, config Configuration) error
 }
 
 func (g *GitHub) refreshHostedPendingAction(ctx core.SyncContext, app common.HostedApp, metadata common.Metadata) {
-	if len(metadata.PendingInstallations) >= 2 {
+	if len(metadata.PendingInstallations) >= 1 {
 		ctx.Integration.SetMetadata(metadata)
 		return
 	}

--- a/pkg/integrations/github/hosted_oauth.go
+++ b/pkg/integrations/github/hosted_oauth.go
@@ -94,22 +94,18 @@ func (g *GitHub) afterHostedAppOAuth(ctx core.HTTPRequestContext) {
 		return
 	}
 
-	switch len(installations) {
-	case 0:
+	if len(installations) == 0 {
 		g.redirectToHostedInstall(ctx, metadata, app.Slug)
-	case 1:
-		if err := g.bindHostedInstallation(ctx, metadata, installations[0].ID); err != nil {
-			ctx.Logger.Errorf("%v", err)
-			http.Error(ctx.Response, "internal server error", http.StatusInternalServerError)
-			return
-		}
-		redirectToIntegrationSettings(ctx)
-	default:
-		metadata.PendingInstallations = installations
-		ctx.Integration.SetMetadata(metadata)
-		ctx.Integration.RemoveBrowserAction()
-		redirectToIntegrationSettings(ctx)
+		return
 	}
+
+	// Even a single installation goes through the account picker. A silent
+	// bind would lock the connection to that account (often the user's
+	// personal one) with no way to install the App on an organization.
+	metadata.PendingInstallations = installations
+	ctx.Integration.SetMetadata(metadata)
+	ctx.Integration.RemoveBrowserAction()
+	redirectToIntegrationSettings(ctx)
 }
 
 func (g *GitHub) afterHostedAppBind(ctx core.HTTPRequestContext) {

--- a/pkg/integrations/github/hosted_oauth_test.go
+++ b/pkg/integrations/github/hosted_oauth_test.go
@@ -108,15 +108,10 @@ func Test__afterHostedAppOAuth(t *testing.T) {
 		assert.Contains(t, integration.BrowserAction.URL, "installations/new")
 	})
 
-	t.Run("one install binds the connection", func(t *testing.T) {
-		t.Cleanup(resetBindClientHooks)
-		listInstallationRepos = func(context.Context, *gh.Client) ([]common.Repository, error) {
-			return []common.Repository{{ID: 1, Name: "repo", URL: "https://github.com/acme/repo"}}, nil
-		}
-		newInstallationClient = func(core.IntegrationContext, int64, string) (*gh.Client, error) {
-			return gh.NewClient(nil), nil
-		}
-
+	t.Run("one install writes allowlist and stays pending", func(t *testing.T) {
+		// A silent bind of the single installation would lock the connection
+		// to that account (often the user's personal one) with no way to
+		// install the App on an organization. The account picker must open.
 		integration := pendingHostedIntegration("csrf")
 		httpCtx := oauthHTTP(
 			jsonResponse(`{"access_token":"user-token"}`),
@@ -127,12 +122,14 @@ func Test__afterHostedAppOAuth(t *testing.T) {
 		g.afterHostedAppOAuth(ctx)
 
 		assert.Equal(t, http.StatusSeeOther, rec.Code)
-		assert.Equal(t, "ready", integration.State)
+		assert.NotEqual(t, "ready", integration.State)
+		assert.Nil(t, integration.BrowserAction)
 		metadata := integration.Metadata.(common.Metadata)
-		assert.Equal(t, "11", metadata.InstallationID)
-		assert.Equal(t, "acme", metadata.Owner)
-		assert.Empty(t, metadata.State)
-		assert.Empty(t, metadata.PendingInstallations)
+		assert.Empty(t, metadata.InstallationID)
+		assert.Equal(t, "csrf", metadata.State)
+		require.Len(t, metadata.PendingInstallations, 1)
+		assert.Equal(t, "11", metadata.PendingInstallations[0].ID)
+		assert.Equal(t, "acme", metadata.PendingInstallations[0].AccountLogin)
 		assert.Empty(t, integration.CurrentSecrets)
 		assertNoPlaintextSecrets(t, integration)
 	})
@@ -442,6 +439,34 @@ func Test__Sync_hostedAppKeepsPendingMetadata(t *testing.T) {
 	assert.Equal(t, "starter-user", metadata.StartedByUserID)
 	assert.Equal(t, "/onboarding?attempt=new&step=vcs", metadata.SetupReturnPath)
 	require.Len(t, metadata.PendingInstallations, 2)
+	assert.Nil(t, integrationCtx.BrowserAction)
+}
+
+func Test__Sync_hostedAppKeepsSinglePendingInstallation(t *testing.T) {
+	setHostedAppOAuthEnv(t)
+	restore := withFactoriesEnabledForTest(func(string) bool { return true })
+	t.Cleanup(restore)
+
+	integrationCtx := &contexts.IntegrationContext{
+		Metadata: common.Metadata{
+			State:     "csrf-keep",
+			HostedApp: true,
+			PendingInstallations: []common.PendingInstallation{
+				{ID: "11", AccountLogin: "acme"},
+			},
+			GitHubApp: common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+		},
+	}
+
+	require.NoError(t, (&GitHub{}).Sync(core.SyncContext{
+		OrganizationID: "11111111-1111-1111-1111-111111111111",
+		BaseURL:        "https://app.example",
+		Integration:    integrationCtx,
+	}))
+
+	metadata := integrationCtx.Metadata.(common.Metadata)
+	assert.Equal(t, "csrf-keep", metadata.State)
+	require.Len(t, metadata.PendingInstallations, 1)
 	assert.Nil(t, integrationCtx.BrowserAction)
 }
 

--- a/web_src/src/hooks/useOrganizationData.ts
+++ b/web_src/src/hooks/useOrganizationData.ts
@@ -25,6 +25,7 @@ import {
   organizationsDescribeUsage,
 } from "../api-client/sdk.gen";
 import type { RolesCreateRoleRequest, AuthorizationDomainType, OrganizationsRemoveUserData } from "@/api-client";
+import { accountOrganizationsQueryKey } from "./useAccountOrganizations";
 import { withOrganizationHeader } from "../lib/withOrganizationHeader";
 
 // Query Keys
@@ -567,6 +568,10 @@ export const useUpdateOrganization = (organizationId: string) => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: organizationKeys.details(organizationId) });
+      // The organization switcher lists every organization of the account and
+      // caches names. A rename must refresh that list, or the menu keeps the
+      // old name until the cache expires.
+      queryClient.invalidateQueries({ queryKey: accountOrganizationsQueryKey });
     },
   });
 };

--- a/web_src/src/lib/startDirectGitHubConnect.spec.ts
+++ b/web_src/src/lib/startDirectGitHubConnect.spec.ts
@@ -79,6 +79,33 @@ describe("pendingGitHubBrowserAction", () => {
 });
 
 describe("pendingGitHubInstallPicker", () => {
+  it("returns a pending GitHub connection with a single install", () => {
+    expect(
+      pendingGitHubAccountPicker(
+        [
+          {
+            metadata: { id: "int-1", integrationName: "github" },
+            status: {
+              state: "pending",
+              metadata: {
+                startedByUserID: "user-1",
+                state: "csrf",
+                githubApp: { slug: "superplane" },
+                pendingInstallations: [{ id: "11", accountLogin: "acme" }],
+              },
+            },
+          },
+        ],
+        "user-1",
+      ),
+    ).toEqual({
+      id: "int-1",
+      state: "csrf",
+      appSlug: "superplane",
+      installations: [{ id: "11", accountLogin: "acme" }],
+    });
+  });
+
   it("returns a pending GitHub connection with two or more installs", () => {
     expect(
       pendingGitHubInstallPicker(

--- a/web_src/src/lib/startDirectGitHubConnect.ts
+++ b/web_src/src/lib/startDirectGitHubConnect.ts
@@ -84,7 +84,7 @@ export function pendingGitHubAccountPicker(
     if (!isOwnPendingGitHubItem(item, currentUserId) || !item.metadata?.id) {
       return false;
     }
-    return pendingGitHubInstallations(item.status?.metadata).length >= 2;
+    return pendingGitHubInstallations(item.status?.metadata).length >= 1;
   });
   if (!pending?.metadata?.id) {
     return undefined;

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.spec.tsx
@@ -111,6 +111,26 @@ describe("FirstRunConnectScreen", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent(FIRST_RUN_COPY.connect.installRequestedBody("acme"));
   });
 
+  it("asks which GitHub account to use when one install is pending", () => {
+    render(
+      <FirstRunConnectScreen
+        githubConnected={false}
+        pendingInstallations={[{ id: "11", accountLogin: "octo" }]}
+        githubState="csrf"
+        githubAppSlug="superplane"
+        onConnectGitHub={vi.fn()}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("first-run-github-account-picker")).toHaveTextContent(
+      FIRST_RUN_COPY.connect.selectAccount,
+    );
+    expect(screen.getByTestId("first-run-github-use-octo")).toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-connect-github")).not.toBeInTheDocument();
+    expect(screen.getByTestId("first-run-github-install-other")).toBeInTheDocument();
+  });
+
   it("asks which GitHub account to use when two installs are pending", async () => {
     const user = userEvent.setup();
     const assign = vi.fn();

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.tsx
@@ -112,7 +112,7 @@ export function FirstRunConnectScreen({
   onContinue: () => void;
 }) {
   const waitingForApproval = installRequested && !githubConnected;
-  const showAccountPicker = !githubConnected && pendingInstallations.length >= 2 && githubState !== "";
+  const showAccountPicker = !githubConnected && pendingInstallations.length >= 1 && githubState !== "";
 
   return (
     <FirstRunShell testId="first-run-connect" chrome={chrome}>

--- a/web_src/src/pages/factories/pages/onboarding/initialOnboardingOrganization.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/initialOnboardingOrganization.spec.ts
@@ -6,6 +6,7 @@ import {
   isOrganizationIdentityTaken,
   nameOrganizationFromGitHubOwner,
   organizationIdentityFromOwner,
+  organizationSlugMatchesOwner,
   shouldNameOrganizationFromGitHub,
 } from "./initialOnboardingOrganization";
 
@@ -15,17 +16,26 @@ function factoryWithOnboarding(onboarding: FactoriesFactory["onboarding"]): Fact
 
 describe("shouldNameOrganizationFromGitHub", () => {
   it("names only an organization from the initial account onboarding workspace", () => {
-    expect(shouldNameOrganizationFromGitHub(factoryWithOnboarding({ initial: true }), true)).toBe(true);
-    expect(shouldNameOrganizationFromGitHub(factoryWithOnboarding({}), true)).toBe(false);
+    expect(shouldNameOrganizationFromGitHub(factoryWithOnboarding({ initial: true }))).toBe(true);
+    expect(shouldNameOrganizationFromGitHub(factoryWithOnboarding({}))).toBe(false);
+    expect(shouldNameOrganizationFromGitHub(null)).toBe(false);
   });
 
   it("retries naming after the GitHub connection was saved", () => {
     const factory = factoryWithOnboarding({ initial: true, vcsIntegrationId: "integration-id" });
-    expect(shouldNameOrganizationFromGitHub(factory, true)).toBe(true);
+    expect(shouldNameOrganizationFromGitHub(factory)).toBe(true);
+  });
+});
+
+describe("organizationSlugMatchesOwner", () => {
+  it("matches the plain owner slug and the suffixed slug", () => {
+    expect(organizationSlugMatchesOwner("acme-org", "Acme Org")).toBe(true);
+    expect(organizationSlugMatchesOwner("acme-org-1ajioa", "Acme Org")).toBe(true);
   });
 
-  it("does not rename when the user selects an existing connection", () => {
-    expect(shouldNameOrganizationFromGitHub(factoryWithOnboarding({ initial: true }), false)).toBe(false);
+  it("does not match a different slug or a non-suffix tail", () => {
+    expect(organizationSlugMatchesOwner("dev-user", "Acme Org")).toBe(false);
+    expect(organizationSlugMatchesOwner("acme-org-inc", "Acme Org")).toBe(false);
   });
 });
 
@@ -54,6 +64,17 @@ describe("isOrganizationIdentityTaken", () => {
 });
 
 describe("nameOrganizationFromGitHubOwner", () => {
+  it("does not rename when the slug already derives from the owner", async () => {
+    const update = vi.fn();
+
+    await expect(nameOrganizationFromGitHubOwner({ owner: "acme", currentSlug: "acme", update })).resolves.toBe("acme");
+    await expect(nameOrganizationFromGitHubOwner({ owner: "acme", currentSlug: "acme-1ajioa", update })).resolves.toBe(
+      "acme-1ajioa",
+    );
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it("retries with a suffix when the owner slug is already in use", async () => {
     const update = vi
       .fn()

--- a/web_src/src/pages/factories/pages/onboarding/initialOnboardingOrganization.ts
+++ b/web_src/src/pages/factories/pages/onboarding/initialOnboardingOrganization.ts
@@ -8,8 +8,8 @@ export function githubIntegrationOwner(integration: OrganizationsIntegration): s
   return typeof owner === "string" && owner.trim() ? owner.trim() : undefined;
 }
 
-export function shouldNameOrganizationFromGitHub(factory: FactoriesFactory | null, selectNewest: boolean): boolean {
-  return selectNewest && factory?.onboarding?.initial === true;
+export function shouldNameOrganizationFromGitHub(factory: FactoriesFactory | null): boolean {
+  return factory?.onboarding?.initial === true;
 }
 
 export function randomOrganizationSuffix(): string {
@@ -39,6 +39,19 @@ export function isOrganizationIdentityTaken(message: string): boolean {
   );
 }
 
+/**
+ * True when the slug already derives from this GitHub owner, either as the
+ * plain owner slug or with the random collision suffix. A repeat visit to
+ * onboarding must not rename the organization again.
+ */
+export function organizationSlugMatchesOwner(currentSlug: string, owner: string): boolean {
+  const slugBase = slugifyOrganizationOwner(owner);
+  if (currentSlug === slugBase) {
+    return true;
+  }
+  return new RegExp(`^${slugBase}-[a-z0-9]{6}$`).test(currentSlug);
+}
+
 export async function nameOrganizationFromGitHubOwner(args: {
   owner: string;
   currentSlug: string;
@@ -47,7 +60,7 @@ export async function nameOrganizationFromGitHubOwner(args: {
 }): Promise<string | undefined> {
   const nextSuffix = args.randomSuffix ?? randomOrganizationSuffix;
   let identity = organizationIdentityFromOwner(args.owner);
-  if (identity.slug === args.currentSlug) {
+  if (organizationSlugMatchesOwner(args.currentSlug, args.owner)) {
     return args.currentSlug;
   }
 

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -270,7 +270,6 @@ function useOnboardingGithubConnectionSelected(args: {
   factory: FactoriesFactory | null;
   onboardingEntryPath?: string | null;
   reresolveWorkspace: OnboardingWorkspaceResolution | null;
-  selectNewest: boolean;
   setup: OnboardingSetupApi;
   setOpenSection: (section: WizardStepId) => void;
   updateOnboarding: UpdateOnboarding;
@@ -305,7 +304,7 @@ function useOnboardingGithubConnectionSelected(args: {
     });
 
     const owner = githubIntegrationOwner(integration);
-    if (!owner || !shouldNameOrganizationFromGitHub(args.factory, args.selectNewest)) return;
+    if (!owner || !shouldNameOrganizationFromGitHub(args.factory)) return;
 
     try {
       const nextSlug = await nameOrganizationFromGitHubOwner({
@@ -352,12 +351,17 @@ function useOnboardingGithubConnectionsForPage(args: {
   selectInstance: (integrationName: string, integrationId: string) => void;
 }) {
   const selectNewest = args.searchParams.get("pick") === "newest";
-  const onConnectionSelected = useOnboardingGithubConnectionSelected({ ...args, selectNewest });
+  const onConnectionSelected = useOnboardingGithubConnectionSelected(args);
 
   return useOnboardingGithubConnections({
     integrationData: args.integrationData,
     openSection: args.openSection,
     selectNewest,
+    // An install request approved on GitHub binds the connection outside the
+    // wizard round trip, so the `pick=newest` hint is gone when the user
+    // returns. Initial onboarding still selects the single ready connection,
+    // which also names the organization after the GitHub account.
+    selectSingleInitial: args.factory?.onboarding?.initial === true,
     selections: args.selections,
     selectInstance: args.selectInstance,
     onConnectionSelected,

--- a/web_src/src/pages/factories/pages/onboarding/useSelectNewGithubConnection.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/useSelectNewGithubConnection.spec.tsx
@@ -31,6 +31,7 @@ describe("useOnboardingGithubConnections", () => {
         integrationData: [{ name: "github", allInstances: [githubConnection], readyInstances: [githubConnection] }],
         openSection: "vcs",
         selectNewest: true,
+        selectSingleInitial: false,
         selections: {},
         selectInstance,
         onConnectionSelected,
@@ -39,6 +40,76 @@ describe("useOnboardingGithubConnections", () => {
 
     await waitFor(() => expect(onConnectionSelected).toHaveBeenCalledWith(githubConnection));
     expect(selectInstance).toHaveBeenCalledWith("github", "github-connection");
+  });
+
+  it("selects the single ready connection on initial onboarding without the URL hint", async () => {
+    const selectInstance = vi.fn();
+    const onConnectionSelected = vi.fn();
+
+    renderHook(() =>
+      useOnboardingGithubConnections({
+        integrationData: [{ name: "github", allInstances: [githubConnection], readyInstances: [githubConnection] }],
+        openSection: "vcs",
+        selectNewest: false,
+        selectSingleInitial: true,
+        selections: {},
+        selectInstance,
+        onConnectionSelected,
+      }),
+    );
+
+    await waitFor(() => expect(onConnectionSelected).toHaveBeenCalledWith(githubConnection));
+    expect(selectInstance).toHaveBeenCalledWith("github", "github-connection");
+  });
+
+  it("does not auto-select without the URL hint outside initial onboarding", () => {
+    const selectInstance = vi.fn();
+    const onConnectionSelected = vi.fn();
+
+    renderHook(() =>
+      useOnboardingGithubConnections({
+        integrationData: [{ name: "github", allInstances: [githubConnection], readyInstances: [githubConnection] }],
+        openSection: "vcs",
+        selectNewest: false,
+        selectSingleInitial: false,
+        selections: {},
+        selectInstance,
+        onConnectionSelected,
+      }),
+    );
+
+    expect(onConnectionSelected).not.toHaveBeenCalled();
+    expect(selectInstance).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-select on initial onboarding when several connections are ready", () => {
+    const selectInstance = vi.fn();
+    const onConnectionSelected = vi.fn();
+    const otherConnection: OrganizationsIntegration = {
+      metadata: { id: "older-connection", integrationName: "github", createdAt: "2026-09-01T00:00:00Z" },
+      status: { state: "ready", metadata: { owner: "acme" } },
+    };
+
+    renderHook(() =>
+      useOnboardingGithubConnections({
+        integrationData: [
+          {
+            name: "github",
+            allInstances: [githubConnection, otherConnection],
+            readyInstances: [githubConnection, otherConnection],
+          },
+        ],
+        openSection: "vcs",
+        selectNewest: false,
+        selectSingleInitial: true,
+        selections: {},
+        selectInstance,
+        onConnectionSelected,
+      }),
+    );
+
+    expect(onConnectionSelected).not.toHaveBeenCalled();
+    expect(selectInstance).not.toHaveBeenCalled();
   });
 
   it("advances from vcs to repo on the same slug without re-resolving the workspace", async () => {
@@ -66,6 +137,7 @@ describe("useOnboardingGithubConnections", () => {
         integrationData: [{ name: "github", allInstances: [githubConnection], readyInstances: [githubConnection] }],
         openSection: "vcs",
         selectNewest: true,
+        selectSingleInitial: false,
         selections: {},
         selectInstance,
         onConnectionSelected,
@@ -105,6 +177,7 @@ describe("useOnboardingGithubConnections", () => {
         integrationData: [{ name: "github", allInstances: [githubConnection], readyInstances: [githubConnection] }],
         openSection: "vcs",
         selectNewest: true,
+        selectSingleInitial: false,
         selections: {},
         selectInstance,
         onConnectionSelected,

--- a/web_src/src/pages/factories/pages/onboarding/useSelectNewGithubConnection.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useSelectNewGithubConnection.ts
@@ -20,6 +20,7 @@ export function useOnboardingGithubConnections(args: {
   integrationData: IntegrationInstanceSummary[];
   openSection: WizardStepId;
   selectNewest: boolean;
+  selectSingleInitial: boolean;
   selections: IntegrationSelections;
   selectInstance: (integrationName: string, integrationId: string) => void;
   onConnectionSelected: (integration: OrganizationsIntegration) => void | Promise<void>;
@@ -30,6 +31,7 @@ export function useOnboardingGithubConnections(args: {
   useSelectNewGithubConnection({
     openSection: args.openSection,
     selectNewest: args.selectNewest,
+    selectSingleInitial: args.selectSingleInitial,
     readyInstances: githubConnections.readyInstances,
     selections: args.selections,
     selectInstance: args.selectInstance,
@@ -52,22 +54,33 @@ function newestReadyInstance(instances: OrganizationsIntegration[]): Organizatio
  * reports the selection so the wizard can continue.
  *
  * The round trip reloads the page, so the in-memory "just connected" hint is
- * gone. Only runs when the return URL asks for it (`pick=newest`), and at most
+ * gone. Runs when the return URL asks for it (`pick=newest`), and at most
  * once, so the user can still choose a different connection afterwards.
+ *
+ * Initial account onboarding also runs it for a single ready connection
+ * without the URL hint (`selectSingleInitial`). An install request approved
+ * later binds the connection outside the wizard round trip, so the return URL
+ * hint is gone when the user comes back. The selection callback saves the
+ * connection and names the organization after the GitHub account, so it must
+ * still run on that visit.
  */
 function useSelectNewGithubConnection(args: {
   openSection: WizardStepId;
   selectNewest: boolean;
+  selectSingleInitial: boolean;
   readyInstances: IntegrationInstanceSummary["readyInstances"];
   selections: IntegrationSelections;
   selectInstance: (integrationName: string, integrationId: string) => void;
   onConnectionSelected: (integration: OrganizationsIntegration) => void | Promise<void>;
 }) {
   const selectedNewConnection = useRef(false);
-  const { openSection, selectNewest, readyInstances, selections, selectInstance, onConnectionSelected } = args;
+  const { openSection, selectNewest, selectSingleInitial, readyInstances, selections, selectInstance } = args;
+  const { onConnectionSelected } = args;
 
   useEffect(() => {
-    if (selectedNewConnection.current || !selectNewest || openSection !== "vcs") return;
+    if (selectedNewConnection.current || openSection !== "vcs") return;
+    const selectSingle = selectSingleInitial && readyInstances.length === 1;
+    if (!selectNewest && !selectSingle) return;
     if (readyInstances.length === 0) return;
 
     const newest = newestReadyInstance(readyInstances);
@@ -77,5 +90,13 @@ function useSelectNewGithubConnection(args: {
     selectedNewConnection.current = true;
     if (selections.github?.id !== id) selectInstance("github", id);
     void onConnectionSelected(newest);
-  }, [openSection, selectNewest, readyInstances, selections, selectInstance, onConnectionSelected]);
+  }, [
+    openSection,
+    selectNewest,
+    selectSingleInitial,
+    readyInstances,
+    selections,
+    selectInstance,
+    onConnectionSelected,
+  ]);
 }

--- a/web_src/src/pages/organization/settings/components/IntegrationDetailsRoute/LegacyIntegrationDetails.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationDetailsRoute/LegacyIntegrationDetails.tsx
@@ -130,7 +130,7 @@ export function LegacyIntegrationDetails({ organizationId, integration }: Legacy
     searchParams.get(GITHUB_SETUP_ORG_PARAM)?.trim() ||
     hostedGitHubInstallRequestedAccount(integration.status?.metadata);
   const showInstallPicker =
-    pendingInstallations.length >= 2 && pendingInstallState !== "" && integration.status?.state !== "ready";
+    pendingInstallations.length >= 1 && pendingInstallState !== "" && integration.status?.state !== "ready";
   const browserAction = integration.status?.browserAction;
   const instructions = integrationDef?.instructions?.trim();
   const hasChanges =


### PR DESCRIPTION
## Summary

- After the GitHub OAuth callback, a user with one App installation was bound to it silently. In organization onboarding, this locked the connection to the user's personal account. The user could not install the App on a GitHub organization or select its repositories.
- This change treats one installation the same as two or more. The account picker opens, with a link to install the App on a different account.
- The onboarding rename to the GitHub account name ran only on the direct redirect back from GitHub. An install request approved later binds the connection outside that round trip, so the organization kept its provisional name. Initial onboarding now selects the single ready connection and names the organization on every return. A slug guard prevents repeat renames.
- Organization updates now invalidate the account organizations cache, so the organization switcher shows the new name at once.

## Test plan

- [ ] Install the App on your personal account only. Start onboarding and click Connect GitHub.
- [ ] Authorize on GitHub. Confirm the account picker opens with your personal account.
- [ ] Click "Install on a different account". Confirm GitHub shows the account selection page.
- [ ] Send an install request for a GitHub organization. Approve it as the organization admin.
- [ ] Open onboarding again. Confirm the connection is selected and the SuperPlane organization takes the GitHub organization name.
- [ ] Open the organization switcher. Confirm it shows the new name.
- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/integrations/github` and the touched vitest specs. Confirm all pass.

<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["fix: Name the organization on every onbo..."](https://github.com/superplanehq/superplane/commit/f2975624e8e2e2046cd9608e8ff5e1db71875808) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60672099)</sub>

<!-- /greptile_comment -->