### PR TITLE
fix: Bind approved GitHub install requests on sync

### DIFF
--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -222,6 +222,16 @@ func (g *GitHub) syncHostedApp(ctx core.SyncContext, config Configuration) error
 	returnPath := firstSafeSetupReturnPath(config.SetupReturnPath, existing.SetupReturnPath)
 	if existing.HostedApp && existing.InstallationID == "" && existing.State != "" {
 		existing.SetupReturnPath = returnPath
+		if existing.InstallRequested {
+			bound, err := g.adoptRequestedInstallation(ctx, app, existing)
+			if err != nil {
+				// The connection stays pending; the next sync retries.
+				ctx.Logger.Errorf("failed to adopt requested GitHub App installation: %v", err)
+			}
+			if bound {
+				return nil
+			}
+		}
 		g.refreshHostedPendingAction(ctx, app, existing)
 		return nil
 	}

--- a/pkg/integrations/github/hosted_bind.go
+++ b/pkg/integrations/github/hosted_bind.go
@@ -3,7 +3,11 @@ package github
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
+	"github.com/google/go-github/v84/github"
+	"github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/integrations/github/common"
 )
@@ -12,11 +16,21 @@ var (
 	newInstallationClient = newClientForAppInstallation
 	newAppJWTClient       = newClientForApp
 	listInstallationRepos = listInstallationRepositories
+	listAppInstallations  = listAppInstallationsFromGitHub
 )
 
 func (g *GitHub) bindHostedInstallation(ctx core.HTTPRequestContext, metadata common.Metadata, installationID string) error {
+	return g.bindHostedInstallationWith(ctx.Integration, ctx.Logger, metadata, installationID)
+}
+
+func (g *GitHub) bindHostedInstallationWith(
+	integration core.IntegrationContext,
+	logger *logrus.Entry,
+	metadata common.Metadata,
+	installationID string,
+) error {
 	metadata.InstallationID = installationID
-	client, err := newInstallationClient(ctx.Integration, metadata.GitHubApp.ID, installationID)
+	client, err := newInstallationClient(integration, metadata.GitHubApp.ID, installationID)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
@@ -36,9 +50,9 @@ func (g *GitHub) bindHostedInstallation(ctx core.HTTPRequestContext, metadata co
 	}
 
 	if metadata.Owner == "" {
-		appClient, err := newAppJWTClient(ctx.Integration, metadata.GitHubApp.ID)
+		appClient, err := newAppJWTClient(integration, metadata.GitHubApp.ID)
 		if err != nil {
-			ctx.Logger.Errorf("failed to create app client: %v", err)
+			logger.Errorf("failed to create app client: %v", err)
 		}
 		metadata.Owner = resolveInstallationOwner(context.Background(), appClient, installationID, repos)
 	}
@@ -53,11 +67,63 @@ func (g *GitHub) bindHostedInstallation(ctx core.HTTPRequestContext, metadata co
 	metadata.InstallRequested = false
 	metadata.InstallRequestedAccount = ""
 
-	ctx.Integration.SetMetadata(metadata)
-	ctx.Integration.RemoveBrowserAction()
-	ctx.Integration.Ready()
+	integration.SetMetadata(metadata)
+	integration.RemoveBrowserAction()
+	integration.Ready()
 
-	ctx.Logger.Infof("Successfully installed GitHub App %s - installation=%s", metadata.GitHubApp.Slug, metadata.InstallationID)
-	ctx.Logger.Infof("Repositories: %v", metadata.Repositories)
+	logger.Infof("Successfully installed GitHub App %s - installation=%s", metadata.GitHubApp.Slug, metadata.InstallationID)
+	logger.Infof("Repositories: %v", metadata.Repositories)
 	return nil
+}
+
+// adoptRequestedInstallation binds a pending connection whose install request
+// was approved on GitHub. The approve callback carries no CSRF state and the
+// installation webhook cannot find a connection without an installation id,
+// so Sync asks GitHub whether the requested account has the App installed.
+func (g *GitHub) adoptRequestedInstallation(ctx core.SyncContext, app common.HostedApp, metadata common.Metadata) (bool, error) {
+	account := strings.TrimSpace(metadata.InstallRequestedAccount)
+	if account == "" {
+		return false, nil
+	}
+
+	client, err := newAppJWTClient(ctx.Integration, app.ID)
+	if err != nil {
+		return false, fmt.Errorf("failed to create app client: %w", err)
+	}
+
+	installationID, err := listAppInstallations(context.Background(), client, account)
+	if err != nil {
+		return false, fmt.Errorf("failed to list app installations: %w", err)
+	}
+	if installationID == "" {
+		return false, nil
+	}
+
+	if err := g.bindHostedInstallationWith(ctx.Integration, ctx.Logger, metadata, installationID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// listAppInstallationsFromGitHub returns the id of the App installation owned
+// by the account, or an empty string when the account has no installation.
+func listAppInstallationsFromGitHub(ctx context.Context, client *github.Client, account string) (string, error) {
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		installations, response, err := client.Apps.ListInstallations(ctx, opts)
+		if err != nil {
+			return "", err
+		}
+
+		for _, installation := range installations {
+			if strings.EqualFold(installation.GetAccount().GetLogin(), account) {
+				return strconv.FormatInt(installation.GetID(), 10), nil
+			}
+		}
+
+		if response == nil || response.NextPage == 0 {
+			return "", nil
+		}
+		opts.Page = response.NextPage
+	}
 }

--- a/pkg/integrations/github/hosted_oauth_test.go
+++ b/pkg/integrations/github/hosted_oauth_test.go
@@ -442,6 +442,93 @@ func Test__Sync_hostedAppKeepsPendingMetadata(t *testing.T) {
 	assert.Nil(t, integrationCtx.BrowserAction)
 }
 
+func Test__Sync_hostedAppAdoptsApprovedInstallRequest(t *testing.T) {
+	setHostedAppOAuthEnv(t)
+	restore := withFactoriesEnabledForTest(func(string) bool { return true })
+	t.Cleanup(restore)
+	t.Cleanup(resetBindClientHooks)
+
+	listInstallationRepos = func(context.Context, *gh.Client) ([]common.Repository, error) {
+		return []common.Repository{{ID: 1, Name: "repo", URL: "https://github.com/acme/repo"}}, nil
+	}
+	newInstallationClient = func(core.IntegrationContext, int64, string) (*gh.Client, error) {
+		return gh.NewClient(nil), nil
+	}
+	listAppInstallations = func(_ context.Context, _ *gh.Client, account string) (string, error) {
+		if account == "acme" {
+			return "11", nil
+		}
+		return "", nil
+	}
+	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
+		return gh.NewClient(nil), nil
+	}
+
+	integrationCtx := &contexts.IntegrationContext{
+		State: "pending",
+		Metadata: common.Metadata{
+			State:                   "csrf",
+			HostedApp:               true,
+			InstallRequested:        true,
+			InstallRequestedAccount: "acme",
+			GitHubApp:               common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+		},
+	}
+
+	require.NoError(t, (&GitHub{}).Sync(core.SyncContext{
+		Logger:         logrus.NewEntry(logrus.New()),
+		OrganizationID: "11111111-1111-1111-1111-111111111111",
+		BaseURL:        "https://app.example",
+		Integration:    integrationCtx,
+	}))
+
+	assert.Equal(t, "ready", integrationCtx.State)
+	metadata := integrationCtx.Metadata.(common.Metadata)
+	assert.Equal(t, "11", metadata.InstallationID)
+	assert.Equal(t, "acme", metadata.Owner)
+	assert.False(t, metadata.InstallRequested)
+	assert.Empty(t, metadata.InstallRequestedAccount)
+	assert.Nil(t, integrationCtx.BrowserAction)
+}
+
+func Test__Sync_hostedAppKeepsWaitingWhenRequestNotApproved(t *testing.T) {
+	setHostedAppOAuthEnv(t)
+	restore := withFactoriesEnabledForTest(func(string) bool { return true })
+	t.Cleanup(restore)
+	t.Cleanup(resetBindClientHooks)
+
+	listAppInstallations = func(context.Context, *gh.Client, string) (string, error) {
+		return "", nil
+	}
+	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
+		return gh.NewClient(nil), nil
+	}
+
+	integrationCtx := &contexts.IntegrationContext{
+		State: "pending",
+		Metadata: common.Metadata{
+			State:                   "csrf",
+			HostedApp:               true,
+			InstallRequested:        true,
+			InstallRequestedAccount: "acme",
+			GitHubApp:               common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+		},
+	}
+
+	require.NoError(t, (&GitHub{}).Sync(core.SyncContext{
+		Logger:         logrus.NewEntry(logrus.New()),
+		OrganizationID: "11111111-1111-1111-1111-111111111111",
+		BaseURL:        "https://app.example",
+		Integration:    integrationCtx,
+	}))
+
+	assert.NotEqual(t, "ready", integrationCtx.State)
+	metadata := integrationCtx.Metadata.(common.Metadata)
+	assert.Empty(t, metadata.InstallationID)
+	assert.True(t, metadata.InstallRequested)
+	assert.Equal(t, "csrf", metadata.State)
+}
+
 func Test__Sync_hostedAppKeepsSinglePendingInstallation(t *testing.T) {
 	setHostedAppOAuthEnv(t)
 	restore := withFactoriesEnabledForTest(func(string) bool { return true })
@@ -574,6 +661,7 @@ func resetBindClientHooks() {
 	newInstallationClient = newClientForAppInstallation
 	newAppJWTClient = newClientForApp
 	listInstallationRepos = listInstallationRepositories
+	listAppInstallations = listAppInstallationsFromGitHub
 }
 
 func assertNoPlaintextSecrets(t *testing.T, integration *contexts.IntegrationContext) {

--- a/web_src/src/hooks/useRecheckGitHubInstallRequest.spec.tsx
+++ b/web_src/src/hooks/useRecheckGitHubInstallRequest.spec.tsx
@@ -1,0 +1,54 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { OrganizationsIntegration } from "@/api-client";
+
+import { pendingGitHubInstallRequestId, useRecheckGitHubInstallRequest } from "./useRecheckGitHubInstallRequest";
+
+const updateIntegration = vi.hoisted(() => vi.fn().mockResolvedValue({}));
+vi.mock("@/api-client/sdk.gen", () => ({
+  organizationsUpdateIntegration: updateIntegration,
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>;
+}
+
+const waitingInstance: OrganizationsIntegration = {
+  metadata: { id: "int-1", integrationName: "github" },
+  status: { state: "pending", metadata: { installRequested: true, installRequestedAccount: "acme" } },
+};
+
+const readyInstance: OrganizationsIntegration = {
+  metadata: { id: "int-2", integrationName: "github" },
+  status: { state: "ready", metadata: { owner: "acme" } },
+};
+
+describe("pendingGitHubInstallRequestId", () => {
+  it("finds the pending GitHub connection with an install request", () => {
+    expect(pendingGitHubInstallRequestId([readyInstance, waitingInstance])).toBe("int-1");
+    expect(pendingGitHubInstallRequestId([readyInstance])).toBeUndefined();
+  });
+});
+
+describe("useRecheckGitHubInstallRequest", () => {
+  afterEach(() => {
+    updateIntegration.mockClear();
+  });
+
+  it("rechecks the pending install request on page access", async () => {
+    renderHook(() => useRecheckGitHubInstallRequest("org-1", [waitingInstance]), { wrapper });
+
+    await waitFor(() => expect(updateIntegration).toHaveBeenCalledTimes(1));
+    const args = updateIntegration.mock.calls[0][0] as { path: { id: string; integrationId: string } };
+    expect(args.path).toEqual({ id: "org-1", integrationId: "int-1" });
+  });
+
+  it("does nothing without a pending install request", () => {
+    renderHook(() => useRecheckGitHubInstallRequest("org-1", [readyInstance]), { wrapper });
+
+    expect(updateIntegration).not.toHaveBeenCalled();
+  });
+});

--- a/web_src/src/hooks/useRecheckGitHubInstallRequest.ts
+++ b/web_src/src/hooks/useRecheckGitHubInstallRequest.ts
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import type { OrganizationsIntegration } from "@/api-client";
+import { organizationsUpdateIntegration } from "@/api-client/sdk.gen";
+import { integrationKeys } from "@/hooks/useIntegrations";
+import { hostedGitHubInstallRequested } from "@/lib/hostedGitHubInstall";
+import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
+
+const RECHECK_INTERVAL_MS = 30_000;
+
+export function pendingGitHubInstallRequestId(instances: OrganizationsIntegration[]): string | undefined {
+  const pending = instances.find(
+    (instance) =>
+      instance.metadata?.integrationName === "github" &&
+      instance.status?.state !== "ready" &&
+      hostedGitHubInstallRequested(instance.status?.metadata),
+  );
+  return pending?.metadata?.id;
+}
+
+/**
+ * Rechecks a pending GitHub App install request while the user waits.
+ *
+ * The GitHub approve callback carries no CSRF state and the installation
+ * webhook cannot find a connection without an installation id, so the server
+ * only learns about an approval during a connection sync. An empty update
+ * runs that sync: it binds the approved installation and turns the
+ * connection ready. Runs on page access and then every 30 seconds until the
+ * request resolves or the page closes.
+ */
+export function useRecheckGitHubInstallRequest(organizationId: string, instances: OrganizationsIntegration[]) {
+  const queryClient = useQueryClient();
+  const integrationId = pendingGitHubInstallRequestId(instances);
+
+  useEffect(() => {
+    if (!organizationId || !integrationId) return;
+
+    let cancelled = false;
+    const recheck = async () => {
+      try {
+        await organizationsUpdateIntegration(
+          withOrganizationHeader({
+            organizationId,
+            path: { id: organizationId, integrationId },
+            body: {},
+          }),
+        );
+      } catch {
+        // The connection stays in the waiting state; the next tick retries.
+      }
+      if (cancelled) return;
+      await queryClient.invalidateQueries({ queryKey: integrationKeys.connected(organizationId) });
+    };
+
+    void recheck();
+    const interval = setInterval(() => void recheck(), RECHECK_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [organizationId, integrationId, queryClient]);
+}

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
@@ -36,6 +36,12 @@ vi.mock("@/hooks/useMe", () => ({
 
 vi.mock("@/posthog", () => ({ posthog: { reset: vi.fn() } }));
 
+// The install-request recheck needs a query client and the network; the flow
+// tests cover the waiting screen only.
+vi.mock("@/hooks/useRecheckGitHubInstallRequest", () => ({
+  useRecheckGitHubInstallRequest: vi.fn(),
+}));
+
 const deleteFactoryMutateAsync = vi.fn().mockResolvedValue(undefined);
 const navigateSpy = vi.fn();
 

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
@@ -6,6 +6,7 @@ import { useMe } from "@/hooks/useMe";
 import { organizationMatchesRoute, organizationRouteId } from "@/lib/accountOrganizations";
 import { getApiErrorMessage } from "@/lib/errors";
 import { hostedGitHubInstallRequested, hostedGitHubInstallRequestedAccount } from "@/lib/hostedGitHubInstall";
+import { useRecheckGitHubInstallRequest } from "@/hooks/useRecheckGitHubInstallRequest";
 import { pendingGitHubAccountPicker } from "@/lib/startDirectGitHubConnect";
 import {
   GITHUB_SETUP_ORG_PARAM,
@@ -239,6 +240,10 @@ function useFirstRunSetupFlow(model: OnboardingPageModel) {
   const installRequested =
     searchParams.get(GITHUB_SETUP_REQUEST_PARAM) === GITHUB_SETUP_REQUEST_VALUE ||
     model.githubConnections.allInstances.some((instance) => hostedGitHubInstallRequested(instance.status?.metadata));
+
+  // An approved install request binds outside the wizard round trip, so the
+  // waiting screen rechecks GitHub through the connection until it is ready.
+  useRecheckGitHubInstallRequest(organizationId, model.githubConnections.allInstances);
 
   useEffect(() => {
     if (!installRequested || openedScreen !== "welcome") return;


### PR DESCRIPTION
## Summary

When an organization member requests the SuperPlane GitHub App, an organization owner approves it on GitHub. After the approval, the member stays on the "Waiting for approval" screen forever. Two gaps cause this:

- The approve redirect from GitHub carries no CSRF state, so it cannot find the pending SuperPlane connection.
- The installation webhook routes by installation id, and a pending connection has no installation id yet.

This change makes the connection recheck GitHub during Sync. When the requested account now has the App installed, Sync binds that installation and marks the connection ready. The onboarding waiting screen triggers this sync on page access and then every 30 seconds until the request resolves.

## Test plan

- [ ] Backend: `make test PKG_TEST_PACKAGES=./pkg/integrations/github` passes. New tests cover adopt-on-sync and stay-waiting-when-not-approved.
- [ ] Frontend: onboarding and hook specs pass. `make check.lint.ui` and `make check.build.ui` pass.
- [ ] Manual: as an organization member, request the App install. Approve it as the organization owner. Return to the onboarding page. The connection binds and the screen shows the connected account.

Made with [Cursor](https://cursor.com)