### PR TITLE
fix: Bind picked GitHub account without a page reload

### DIFF
--- a/pkg/integrations/github/common/metadata.go
+++ b/pkg/integrations/github/common/metadata.go
@@ -23,6 +23,11 @@ type Metadata struct {
 	// InstallRequestedAccount is the GitHub organization (or user) login the
 	// member asked an admin to approve.
 	InstallRequestedAccount string `mapstructure:"installRequestedAccount" json:"installRequestedAccount,omitempty"`
+	// StartedByGitHubLogin is the GitHub login of the member who authorized
+	// the connect OAuth. The request callback from GitHub does not name the
+	// requested organization, so Sync finds that member's App install request
+	// through this login.
+	StartedByGitHubLogin string `mapstructure:"startedByGitHubLogin" json:"startedByGitHubLogin,omitempty"`
 	// SetupReturnPath is the in-app path to open after GitHub setup. Callbacks
 	// use it when the browser cookie is missing, for example localhost to ngrok.
 	SetupReturnPath string `mapstructure:"setupReturnPath" json:"setupReturnPath,omitempty"`

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -223,7 +223,9 @@ func (g *GitHub) syncHostedApp(ctx core.SyncContext, config Configuration) error
 	if existing.HostedApp && existing.InstallationID == "" && existing.State != "" {
 		existing.SetupReturnPath = returnPath
 		if existing.InstallRequested {
-			bound, err := g.adoptRequestedInstallation(ctx, app, existing)
+			// Adopt can also record the requested account it found on
+			// GitHub, which refreshHostedPendingAction below persists.
+			bound, err := g.adoptRequestedInstallation(ctx, app, &existing)
 			if err != nil {
 				// The connection stays pending; the next sync retries.
 				ctx.Logger.Errorf("failed to adopt requested GitHub App installation: %v", err)

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -223,15 +223,12 @@ func (g *GitHub) syncHostedApp(ctx core.SyncContext, config Configuration) error
 	if existing.HostedApp && existing.InstallationID == "" && existing.State != "" {
 		existing.SetupReturnPath = returnPath
 		if existing.InstallRequested {
-			// Adopt can also record the requested account it found on
-			// GitHub, which refreshHostedPendingAction below persists.
-			bound, err := g.adoptRequestedInstallation(ctx, app, &existing)
-			if err != nil {
+			// Adopt records the requested account it found on GitHub and
+			// moves an approved installation into the account picker;
+			// refreshHostedPendingAction below persists both.
+			if err := g.adoptRequestedInstallation(ctx, app, &existing); err != nil {
 				// The connection stays pending; the next sync retries.
 				ctx.Logger.Errorf("failed to adopt requested GitHub App installation: %v", err)
-			}
-			if bound {
-				return nil
 			}
 		}
 		g.refreshHostedPendingAction(ctx, app, existing)

--- a/pkg/integrations/github/hosted_bind.go
+++ b/pkg/integrations/github/hosted_bind.go
@@ -77,45 +77,49 @@ func (g *GitHub) bindHostedInstallationWith(
 	return nil
 }
 
-// adoptRequestedInstallation binds a pending connection whose install request
-// was approved on GitHub. The approve callback carries no CSRF state and the
+// adoptRequestedInstallation resolves a pending install request once an owner
+// approved it on GitHub. The approve callback carries no CSRF state and the
 // installation webhook cannot find a connection without an installation id,
 // so Sync asks GitHub whether the requested account has the App installed.
+// An approved installation joins the account picker; the member still picks
+// the account, a silent bind must not happen.
 //
 // The request callback from GitHub also does not name the requested account,
 // so when it is unknown Sync finds the member's open install request on
 // GitHub and records the account on the metadata for the next sync and the
 // waiting screen.
-func (g *GitHub) adoptRequestedInstallation(ctx core.SyncContext, app common.HostedApp, metadata *common.Metadata) (bool, error) {
+func (g *GitHub) adoptRequestedInstallation(ctx core.SyncContext, app common.HostedApp, metadata *common.Metadata) error {
 	client, err := newAppJWTClient(ctx.Integration, app.ID)
 	if err != nil {
-		return false, fmt.Errorf("failed to create app client: %w", err)
+		return fmt.Errorf("failed to create app client: %w", err)
 	}
 
 	account := strings.TrimSpace(metadata.InstallRequestedAccount)
 	if account == "" {
 		account, err = listAppInstallationRequests(context.Background(), client, metadata.StartedByGitHubLogin)
 		if err != nil {
-			return false, fmt.Errorf("failed to list app installation requests: %w", err)
+			return fmt.Errorf("failed to list app installation requests: %w", err)
 		}
 		if account == "" {
-			return false, nil
+			return nil
 		}
 		metadata.InstallRequestedAccount = account
 	}
 
-	installationID, err := listAppInstallations(context.Background(), client, account)
+	installation, found, err := listAppInstallations(context.Background(), client, account)
 	if err != nil {
-		return false, fmt.Errorf("failed to list app installations: %w", err)
+		return fmt.Errorf("failed to list app installations: %w", err)
 	}
-	if installationID == "" {
-		return false, nil
+	if !found {
+		return nil
 	}
 
-	if err := g.bindHostedInstallationWith(ctx.Integration, ctx.Logger, *metadata, installationID); err != nil {
-		return false, err
+	if !metadata.AllowsPendingInstallation(installation.ID) {
+		metadata.PendingInstallations = append(metadata.PendingInstallations, installation)
 	}
-	return true, nil
+	metadata.InstallRequested = false
+	metadata.InstallRequestedAccount = ""
+	return nil
 }
 
 // listAppInstallationRequestsFromGitHub returns the account login of the open
@@ -146,24 +150,28 @@ func listAppInstallationRequestsFromGitHub(ctx context.Context, client *github.C
 	}
 }
 
-// listAppInstallationsFromGitHub returns the id of the App installation owned
-// by the account, or an empty string when the account has no installation.
-func listAppInstallationsFromGitHub(ctx context.Context, client *github.Client, account string) (string, error) {
+// listAppInstallationsFromGitHub returns the App installation owned by the
+// account, or found=false when the account has no installation.
+func listAppInstallationsFromGitHub(ctx context.Context, client *github.Client, account string) (common.PendingInstallation, bool, error) {
 	opts := &github.ListOptions{PerPage: 100}
 	for {
 		installations, response, err := client.Apps.ListInstallations(ctx, opts)
 		if err != nil {
-			return "", err
+			return common.PendingInstallation{}, false, err
 		}
 
 		for _, installation := range installations {
 			if strings.EqualFold(installation.GetAccount().GetLogin(), account) {
-				return strconv.FormatInt(installation.GetID(), 10), nil
+				return common.PendingInstallation{
+					ID:           strconv.FormatInt(installation.GetID(), 10),
+					AccountLogin: installation.GetAccount().GetLogin(),
+					AccountType:  installation.GetAccount().GetType(),
+				}, true, nil
 			}
 		}
 
 		if response == nil || response.NextPage == 0 {
-			return "", nil
+			return common.PendingInstallation{}, false, nil
 		}
 		opts.Page = response.NextPage
 	}

--- a/pkg/integrations/github/hosted_bind.go
+++ b/pkg/integrations/github/hosted_bind.go
@@ -13,10 +13,11 @@ import (
 )
 
 var (
-	newInstallationClient = newClientForAppInstallation
-	newAppJWTClient       = newClientForApp
-	listInstallationRepos = listInstallationRepositories
-	listAppInstallations  = listAppInstallationsFromGitHub
+	newInstallationClient       = newClientForAppInstallation
+	newAppJWTClient             = newClientForApp
+	listInstallationRepos       = listInstallationRepositories
+	listAppInstallations        = listAppInstallationsFromGitHub
+	listAppInstallationRequests = listAppInstallationRequestsFromGitHub
 )
 
 func (g *GitHub) bindHostedInstallation(ctx core.HTTPRequestContext, metadata common.Metadata, installationID string) error {
@@ -80,15 +81,27 @@ func (g *GitHub) bindHostedInstallationWith(
 // was approved on GitHub. The approve callback carries no CSRF state and the
 // installation webhook cannot find a connection without an installation id,
 // so Sync asks GitHub whether the requested account has the App installed.
-func (g *GitHub) adoptRequestedInstallation(ctx core.SyncContext, app common.HostedApp, metadata common.Metadata) (bool, error) {
-	account := strings.TrimSpace(metadata.InstallRequestedAccount)
-	if account == "" {
-		return false, nil
-	}
-
+//
+// The request callback from GitHub also does not name the requested account,
+// so when it is unknown Sync finds the member's open install request on
+// GitHub and records the account on the metadata for the next sync and the
+// waiting screen.
+func (g *GitHub) adoptRequestedInstallation(ctx core.SyncContext, app common.HostedApp, metadata *common.Metadata) (bool, error) {
 	client, err := newAppJWTClient(ctx.Integration, app.ID)
 	if err != nil {
 		return false, fmt.Errorf("failed to create app client: %w", err)
+	}
+
+	account := strings.TrimSpace(metadata.InstallRequestedAccount)
+	if account == "" {
+		account, err = listAppInstallationRequests(context.Background(), client, metadata.StartedByGitHubLogin)
+		if err != nil {
+			return false, fmt.Errorf("failed to list app installation requests: %w", err)
+		}
+		if account == "" {
+			return false, nil
+		}
+		metadata.InstallRequestedAccount = account
 	}
 
 	installationID, err := listAppInstallations(context.Background(), client, account)
@@ -99,10 +112,38 @@ func (g *GitHub) adoptRequestedInstallation(ctx core.SyncContext, app common.Hos
 		return false, nil
 	}
 
-	if err := g.bindHostedInstallationWith(ctx.Integration, ctx.Logger, metadata, installationID); err != nil {
+	if err := g.bindHostedInstallationWith(ctx.Integration, ctx.Logger, *metadata, installationID); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// listAppInstallationRequestsFromGitHub returns the account login of the open
+// App install request made by the requester, or an empty string when the
+// requester has no open request.
+func listAppInstallationRequestsFromGitHub(ctx context.Context, client *github.Client, requesterLogin string) (string, error) {
+	if strings.TrimSpace(requesterLogin) == "" {
+		return "", nil
+	}
+
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		requests, response, err := client.Apps.ListInstallationRequests(ctx, opts)
+		if err != nil {
+			return "", err
+		}
+
+		for _, request := range requests {
+			if strings.EqualFold(request.GetRequester().GetLogin(), requesterLogin) {
+				return request.GetAccount().GetLogin(), nil
+			}
+		}
+
+		if response == nil || response.NextPage == 0 {
+			return "", nil
+		}
+		opts.Page = response.NextPage
+	}
 }
 
 // listAppInstallationsFromGitHub returns the id of the App installation owned

--- a/pkg/integrations/github/hosted_oauth.go
+++ b/pkg/integrations/github/hosted_oauth.go
@@ -18,6 +18,7 @@ import (
 const (
 	githubOAuthTokenURL        = "https://github.com/login/oauth/access_token"
 	githubUserInstallationsURL = "https://api.github.com/user/installations"
+	githubUserURL              = "https://api.github.com/user"
 )
 
 type githubOAuthTokenResponse struct {
@@ -93,6 +94,16 @@ func (g *GitHub) afterHostedAppOAuth(ctx core.HTTPRequestContext) {
 		ctx.Logger.Errorf("failed to list user GitHub App installations: %v", err)
 		http.Error(ctx.Response, "internal server error", http.StatusInternalServerError)
 		return
+	}
+
+	// The request callback from GitHub does not name the requested
+	// organization, so Sync later finds this member's install request on
+	// GitHub through this login.
+	login, err := fetchGitHubUserLogin(ctx.HTTP, token)
+	if err != nil {
+		ctx.Logger.Errorf("failed to fetch GitHub user login: %v", err)
+	} else {
+		metadata.StartedByGitHubLogin = login
 	}
 
 	if len(installations) == 0 {
@@ -222,6 +233,42 @@ func exchangeGitHubUserOAuthToken(httpCtx core.HTTPContext, clientID, clientSecr
 	}
 
 	return token.AccessToken, nil
+}
+
+func fetchGitHubUserLogin(httpCtx core.HTTPContext, token string) (string, error) {
+	if httpCtx == nil {
+		return "", fmt.Errorf("HTTP context is required")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, githubUserURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	response, err := httpCtx.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	body, err := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if err != nil {
+		return "", err
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return "", fmt.Errorf("GitHub user request failed: status %d", response.StatusCode)
+	}
+
+	var payload struct {
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", err
+	}
+
+	return payload.Login, nil
 }
 
 func listUserAppInstallations(httpCtx core.HTTPContext, token string, appID int64) ([]common.PendingInstallation, error) {

--- a/pkg/integrations/github/hosted_oauth.go
+++ b/pkg/integrations/github/hosted_oauth.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -103,9 +104,26 @@ func (g *GitHub) afterHostedAppOAuth(ctx core.HTTPRequestContext) {
 	// bind would lock the connection to that account (often the user's
 	// personal one) with no way to install the App on an organization.
 	metadata.PendingInstallations = installations
+
+	// The picker now offers the requested account, so the install request is
+	// approved and the waiting state must not show next to the picker.
+	if installationsIncludeAccount(installations, metadata.InstallRequestedAccount) {
+		metadata.InstallRequested = false
+		metadata.InstallRequestedAccount = ""
+	}
+
 	ctx.Integration.SetMetadata(metadata)
 	ctx.Integration.RemoveBrowserAction()
 	redirectToIntegrationSettings(ctx)
+}
+
+func installationsIncludeAccount(installations []common.PendingInstallation, account string) bool {
+	if account == "" {
+		return false
+	}
+	return slices.ContainsFunc(installations, func(installation common.PendingInstallation) bool {
+		return strings.EqualFold(installation.AccountLogin, account)
+	})
 }
 
 func (g *GitHub) afterHostedAppBind(ctx core.HTTPRequestContext) {

--- a/pkg/integrations/github/hosted_oauth_test.go
+++ b/pkg/integrations/github/hosted_oauth_test.go
@@ -148,6 +148,7 @@ func Test__afterHostedAppOAuth(t *testing.T) {
 				{"id":11,"account":{"login":"acme","type":"Organization"}},
 				{"id":22,"account":{"login":"octo","type":"User"}}
 			]}`),
+			jsonResponse(`{"login":"member"}`),
 		)
 		ctx, rec := hostedRequestContext(integration, "/api/v1/github/app/oauth/callback?state=csrf&code=abc", httpCtx)
 
@@ -161,13 +162,15 @@ func Test__afterHostedAppOAuth(t *testing.T) {
 		assert.Empty(t, metadata.InstallationID)
 		assert.Equal(t, "csrf", metadata.State)
 		assert.Equal(t, "/onboarding?attempt=1&step=vcs", metadata.SetupReturnPath)
+		assert.Equal(t, "member", metadata.StartedByGitHubLogin)
 		require.Len(t, metadata.PendingInstallations, 2)
 		assert.Equal(t, "11", metadata.PendingInstallations[0].ID)
 		assert.Empty(t, integration.CurrentSecrets)
 		assertNoPlaintextSecrets(t, integration)
-		require.Len(t, httpCtx.Requests, 2)
+		require.Len(t, httpCtx.Requests, 3)
 		assert.Equal(t, "/user/installations", httpCtx.Requests[1].URL.Path)
 		assert.NotContains(t, httpCtx.Requests[1].URL.Path, "/app/installations")
+		assert.Equal(t, "/user", httpCtx.Requests[2].URL.Path)
 	})
 
 	t.Run("approved install request clears the waiting state", func(t *testing.T) {
@@ -537,6 +540,105 @@ func Test__Sync_hostedAppAdoptsApprovedInstallRequest(t *testing.T) {
 	assert.Nil(t, integrationCtx.BrowserAction)
 }
 
+func Test__Sync_hostedAppFindsRequestedAccountOnGitHub(t *testing.T) {
+	setHostedAppOAuthEnv(t)
+	restore := withFactoriesEnabledForTest(func(string) bool { return true })
+	t.Cleanup(restore)
+	t.Cleanup(resetBindClientHooks)
+
+	// GitHub's request callback does not name the requested account, so the
+	// connection stored only the requester's login. Sync finds the open
+	// install request on GitHub and records the account.
+	listAppInstallationRequests = func(_ context.Context, _ *gh.Client, requesterLogin string) (string, error) {
+		if requesterLogin == "member" {
+			return "acme", nil
+		}
+		return "", nil
+	}
+	listAppInstallations = func(context.Context, *gh.Client, string) (string, error) {
+		return "", nil // The request is still waiting for an approval.
+	}
+	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
+		return gh.NewClient(nil), nil
+	}
+
+	integrationCtx := &contexts.IntegrationContext{
+		State: "pending",
+		Metadata: common.Metadata{
+			State:                "csrf",
+			HostedApp:            true,
+			InstallRequested:     true,
+			StartedByGitHubLogin: "member",
+			GitHubApp:            common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+		},
+	}
+
+	require.NoError(t, (&GitHub{}).Sync(core.SyncContext{
+		Logger:         logrus.NewEntry(logrus.New()),
+		OrganizationID: "11111111-1111-1111-1111-111111111111",
+		BaseURL:        "https://app.example",
+		Integration:    integrationCtx,
+	}))
+
+	assert.NotEqual(t, "ready", integrationCtx.State)
+	metadata := integrationCtx.Metadata.(common.Metadata)
+	assert.Equal(t, "acme", metadata.InstallRequestedAccount)
+	assert.True(t, metadata.InstallRequested)
+}
+
+func Test__Sync_hostedAppAdoptsRequestWithoutStoredAccount(t *testing.T) {
+	setHostedAppOAuthEnv(t)
+	restore := withFactoriesEnabledForTest(func(string) bool { return true })
+	t.Cleanup(restore)
+	t.Cleanup(resetBindClientHooks)
+
+	listAppInstallationRequests = func(_ context.Context, _ *gh.Client, requesterLogin string) (string, error) {
+		if requesterLogin == "member" {
+			return "acme", nil
+		}
+		return "", nil
+	}
+	listAppInstallations = func(_ context.Context, _ *gh.Client, account string) (string, error) {
+		if account == "acme" {
+			return "11", nil
+		}
+		return "", nil
+	}
+	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
+		return gh.NewClient(nil), nil
+	}
+	newInstallationClient = func(core.IntegrationContext, int64, string) (*gh.Client, error) {
+		return gh.NewClient(nil), nil
+	}
+	listInstallationRepos = func(context.Context, *gh.Client) ([]common.Repository, error) {
+		return []common.Repository{{ID: 1, Name: "repo", URL: "https://github.com/acme/repo"}}, nil
+	}
+
+	integrationCtx := &contexts.IntegrationContext{
+		State: "pending",
+		Metadata: common.Metadata{
+			State:                "csrf",
+			HostedApp:            true,
+			InstallRequested:     true,
+			StartedByGitHubLogin: "member",
+			GitHubApp:            common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+		},
+	}
+
+	require.NoError(t, (&GitHub{}).Sync(core.SyncContext{
+		Logger:         logrus.NewEntry(logrus.New()),
+		OrganizationID: "11111111-1111-1111-1111-111111111111",
+		BaseURL:        "https://app.example",
+		Integration:    integrationCtx,
+	}))
+
+	assert.Equal(t, "ready", integrationCtx.State)
+	metadata := integrationCtx.Metadata.(common.Metadata)
+	assert.Equal(t, "11", metadata.InstallationID)
+	assert.Equal(t, "acme", metadata.Owner)
+	assert.False(t, metadata.InstallRequested)
+}
+
 func Test__Sync_hostedAppKeepsWaitingWhenRequestNotApproved(t *testing.T) {
 	setHostedAppOAuthEnv(t)
 	restore := withFactoriesEnabledForTest(func(string) bool { return true })
@@ -708,6 +810,7 @@ func resetBindClientHooks() {
 	newAppJWTClient = newClientForApp
 	listInstallationRepos = listInstallationRepositories
 	listAppInstallations = listAppInstallationsFromGitHub
+	listAppInstallationRequests = listAppInstallationRequestsFromGitHub
 }
 
 func assertNoPlaintextSecrets(t *testing.T, integration *contexts.IntegrationContext) {

--- a/pkg/integrations/github/hosted_oauth_test.go
+++ b/pkg/integrations/github/hosted_oauth_test.go
@@ -169,6 +169,52 @@ func Test__afterHostedAppOAuth(t *testing.T) {
 		assert.Equal(t, "/user/installations", httpCtx.Requests[1].URL.Path)
 		assert.NotContains(t, httpCtx.Requests[1].URL.Path, "/app/installations")
 	})
+
+	t.Run("approved install request clears the waiting state", func(t *testing.T) {
+		integration := pendingHostedIntegration("csrf")
+		integration.Metadata = common.Metadata{
+			State:                   "csrf",
+			HostedApp:               true,
+			InstallRequested:        true,
+			InstallRequestedAccount: "acme",
+			GitHubApp:               common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+		}
+		httpCtx := oauthHTTP(
+			jsonResponse(`{"access_token":"user-token"}`),
+			jsonResponse(`{"installations":[{"id":11,"account":{"login":"Acme","type":"Organization"}}]}`),
+		)
+		ctx, _ := hostedRequestContext(integration, "/api/v1/github/app/oauth/callback?state=csrf&code=abc", httpCtx)
+
+		g.afterHostedAppOAuth(ctx)
+
+		metadata := integration.Metadata.(common.Metadata)
+		require.Len(t, metadata.PendingInstallations, 1)
+		assert.False(t, metadata.InstallRequested)
+		assert.Empty(t, metadata.InstallRequestedAccount)
+	})
+
+	t.Run("unapproved install request keeps the waiting state", func(t *testing.T) {
+		integration := pendingHostedIntegration("csrf")
+		integration.Metadata = common.Metadata{
+			State:                   "csrf",
+			HostedApp:               true,
+			InstallRequested:        true,
+			InstallRequestedAccount: "acme",
+			GitHubApp:               common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+		}
+		httpCtx := oauthHTTP(
+			jsonResponse(`{"access_token":"user-token"}`),
+			jsonResponse(`{"installations":[{"id":22,"account":{"login":"octo","type":"User"}}]}`),
+		)
+		ctx, _ := hostedRequestContext(integration, "/api/v1/github/app/oauth/callback?state=csrf&code=abc", httpCtx)
+
+		g.afterHostedAppOAuth(ctx)
+
+		metadata := integration.Metadata.(common.Metadata)
+		require.Len(t, metadata.PendingInstallations, 1)
+		assert.True(t, metadata.InstallRequested)
+		assert.Equal(t, "acme", metadata.InstallRequestedAccount)
+	})
 }
 
 func Test__afterHostedAppBind(t *testing.T) {

--- a/pkg/integrations/github/hosted_oauth_test.go
+++ b/pkg/integrations/github/hosted_oauth_test.go
@@ -491,23 +491,17 @@ func Test__Sync_hostedAppKeepsPendingMetadata(t *testing.T) {
 	assert.Nil(t, integrationCtx.BrowserAction)
 }
 
-func Test__Sync_hostedAppAdoptsApprovedInstallRequest(t *testing.T) {
+func Test__Sync_hostedAppOffersApprovedInstallInPicker(t *testing.T) {
 	setHostedAppOAuthEnv(t)
 	restore := withFactoriesEnabledForTest(func(string) bool { return true })
 	t.Cleanup(restore)
 	t.Cleanup(resetBindClientHooks)
 
-	listInstallationRepos = func(context.Context, *gh.Client) ([]common.Repository, error) {
-		return []common.Repository{{ID: 1, Name: "repo", URL: "https://github.com/acme/repo"}}, nil
-	}
-	newInstallationClient = func(core.IntegrationContext, int64, string) (*gh.Client, error) {
-		return gh.NewClient(nil), nil
-	}
-	listAppInstallations = func(_ context.Context, _ *gh.Client, account string) (string, error) {
+	listAppInstallations = func(_ context.Context, _ *gh.Client, account string) (common.PendingInstallation, bool, error) {
 		if account == "acme" {
-			return "11", nil
+			return common.PendingInstallation{ID: "11", AccountLogin: "acme", AccountType: "Organization"}, true, nil
 		}
-		return "", nil
+		return common.PendingInstallation{}, false, nil
 	}
 	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
 		return gh.NewClient(nil), nil
@@ -521,6 +515,9 @@ func Test__Sync_hostedAppAdoptsApprovedInstallRequest(t *testing.T) {
 			InstallRequested:        true,
 			InstallRequestedAccount: "acme",
 			GitHubApp:               common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+			PendingInstallations: []common.PendingInstallation{
+				{ID: "22", AccountLogin: "octo", AccountType: "User"},
+			},
 		},
 	}
 
@@ -531,13 +528,56 @@ func Test__Sync_hostedAppAdoptsApprovedInstallRequest(t *testing.T) {
 		Integration:    integrationCtx,
 	}))
 
-	assert.Equal(t, "ready", integrationCtx.State)
+	// A silent bind must not happen: the approved installation joins the
+	// picker and the member still picks the account.
+	assert.NotEqual(t, "ready", integrationCtx.State)
 	metadata := integrationCtx.Metadata.(common.Metadata)
-	assert.Equal(t, "11", metadata.InstallationID)
-	assert.Equal(t, "acme", metadata.Owner)
+	assert.Empty(t, metadata.InstallationID)
+	assert.Equal(t, "csrf", metadata.State)
 	assert.False(t, metadata.InstallRequested)
 	assert.Empty(t, metadata.InstallRequestedAccount)
-	assert.Nil(t, integrationCtx.BrowserAction)
+	require.Len(t, metadata.PendingInstallations, 2)
+	assert.Equal(t, "11", metadata.PendingInstallations[1].ID)
+	assert.Equal(t, "acme", metadata.PendingInstallations[1].AccountLogin)
+}
+
+func Test__Sync_hostedAppDoesNotDuplicatePickerEntry(t *testing.T) {
+	setHostedAppOAuthEnv(t)
+	restore := withFactoriesEnabledForTest(func(string) bool { return true })
+	t.Cleanup(restore)
+	t.Cleanup(resetBindClientHooks)
+
+	listAppInstallations = func(context.Context, *gh.Client, string) (common.PendingInstallation, bool, error) {
+		return common.PendingInstallation{ID: "11", AccountLogin: "acme", AccountType: "Organization"}, true, nil
+	}
+	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
+		return gh.NewClient(nil), nil
+	}
+
+	integrationCtx := &contexts.IntegrationContext{
+		State: "pending",
+		Metadata: common.Metadata{
+			State:                   "csrf",
+			HostedApp:               true,
+			InstallRequested:        true,
+			InstallRequestedAccount: "acme",
+			GitHubApp:               common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+			PendingInstallations: []common.PendingInstallation{
+				{ID: "11", AccountLogin: "acme", AccountType: "Organization"},
+			},
+		},
+	}
+
+	require.NoError(t, (&GitHub{}).Sync(core.SyncContext{
+		Logger:         logrus.NewEntry(logrus.New()),
+		OrganizationID: "11111111-1111-1111-1111-111111111111",
+		BaseURL:        "https://app.example",
+		Integration:    integrationCtx,
+	}))
+
+	metadata := integrationCtx.Metadata.(common.Metadata)
+	require.Len(t, metadata.PendingInstallations, 1)
+	assert.False(t, metadata.InstallRequested)
 }
 
 func Test__Sync_hostedAppFindsRequestedAccountOnGitHub(t *testing.T) {
@@ -555,8 +595,8 @@ func Test__Sync_hostedAppFindsRequestedAccountOnGitHub(t *testing.T) {
 		}
 		return "", nil
 	}
-	listAppInstallations = func(context.Context, *gh.Client, string) (string, error) {
-		return "", nil // The request is still waiting for an approval.
+	listAppInstallations = func(context.Context, *gh.Client, string) (common.PendingInstallation, bool, error) {
+		return common.PendingInstallation{}, false, nil // The request is still waiting for an approval.
 	}
 	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
 		return gh.NewClient(nil), nil
@@ -586,7 +626,7 @@ func Test__Sync_hostedAppFindsRequestedAccountOnGitHub(t *testing.T) {
 	assert.True(t, metadata.InstallRequested)
 }
 
-func Test__Sync_hostedAppAdoptsRequestWithoutStoredAccount(t *testing.T) {
+func Test__Sync_hostedAppOffersRequestWithoutStoredAccountInPicker(t *testing.T) {
 	setHostedAppOAuthEnv(t)
 	restore := withFactoriesEnabledForTest(func(string) bool { return true })
 	t.Cleanup(restore)
@@ -598,20 +638,14 @@ func Test__Sync_hostedAppAdoptsRequestWithoutStoredAccount(t *testing.T) {
 		}
 		return "", nil
 	}
-	listAppInstallations = func(_ context.Context, _ *gh.Client, account string) (string, error) {
+	listAppInstallations = func(_ context.Context, _ *gh.Client, account string) (common.PendingInstallation, bool, error) {
 		if account == "acme" {
-			return "11", nil
+			return common.PendingInstallation{ID: "11", AccountLogin: "acme", AccountType: "Organization"}, true, nil
 		}
-		return "", nil
+		return common.PendingInstallation{}, false, nil
 	}
 	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
 		return gh.NewClient(nil), nil
-	}
-	newInstallationClient = func(core.IntegrationContext, int64, string) (*gh.Client, error) {
-		return gh.NewClient(nil), nil
-	}
-	listInstallationRepos = func(context.Context, *gh.Client) ([]common.Repository, error) {
-		return []common.Repository{{ID: 1, Name: "repo", URL: "https://github.com/acme/repo"}}, nil
 	}
 
 	integrationCtx := &contexts.IntegrationContext{
@@ -632,10 +666,12 @@ func Test__Sync_hostedAppAdoptsRequestWithoutStoredAccount(t *testing.T) {
 		Integration:    integrationCtx,
 	}))
 
-	assert.Equal(t, "ready", integrationCtx.State)
+	assert.NotEqual(t, "ready", integrationCtx.State)
 	metadata := integrationCtx.Metadata.(common.Metadata)
-	assert.Equal(t, "11", metadata.InstallationID)
-	assert.Equal(t, "acme", metadata.Owner)
+	assert.Empty(t, metadata.InstallationID)
+	require.Len(t, metadata.PendingInstallations, 1)
+	assert.Equal(t, "11", metadata.PendingInstallations[0].ID)
+	assert.Equal(t, "acme", metadata.PendingInstallations[0].AccountLogin)
 	assert.False(t, metadata.InstallRequested)
 }
 
@@ -645,8 +681,8 @@ func Test__Sync_hostedAppKeepsWaitingWhenRequestNotApproved(t *testing.T) {
 	t.Cleanup(restore)
 	t.Cleanup(resetBindClientHooks)
 
-	listAppInstallations = func(context.Context, *gh.Client, string) (string, error) {
-		return "", nil
+	listAppInstallations = func(context.Context, *gh.Client, string) (common.PendingInstallation, bool, error) {
+		return common.PendingInstallation{}, false, nil
 	}
 	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
 		return gh.NewClient(nil), nil

--- a/web_src/src/hooks/useBindGitHubInstallation.ts
+++ b/web_src/src/hooks/useBindGitHubInstallation.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { integrationKeys } from "@/hooks/useIntegrations";
+import { bindHostedGitHubInstallation } from "@/lib/hostedGitHubInstall";
+
+/**
+ * Binds a pending GitHub connection to a chosen App installation in place.
+ * A full-page redirect through the bind endpoint reloads the whole app, so
+ * this mutation calls the endpoint from the page and refreshes the
+ * connection list before it resolves.
+ */
+export function useBindGitHubInstallation(organizationId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ state, installationId }: { state: string; installationId: string }) => {
+      await bindHostedGitHubInstallation(state, installationId);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: integrationKeys.connected(organizationId) });
+    },
+  });
+}

--- a/web_src/src/hooks/useRecheckGitHubInstallRequest.ts
+++ b/web_src/src/hooks/useRecheckGitHubInstallRequest.ts
@@ -7,7 +7,7 @@ import { integrationKeys } from "@/hooks/useIntegrations";
 import { hostedGitHubInstallRequested } from "@/lib/hostedGitHubInstall";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 
-const RECHECK_INTERVAL_MS = 30_000;
+const RECHECK_INTERVAL_MS = 5_000;
 
 export function pendingGitHubInstallRequestId(instances: OrganizationsIntegration[]): string | undefined {
   const pending = instances.find(
@@ -25,8 +25,8 @@ export function pendingGitHubInstallRequestId(instances: OrganizationsIntegratio
  * The GitHub approve callback carries no CSRF state and the installation
  * webhook cannot find a connection without an installation id, so the server
  * only learns about an approval during a connection sync. An empty update
- * runs that sync: it binds the approved installation and turns the
- * connection ready. Runs on page access and then every 30 seconds until the
+ * runs that sync: an approved installation joins the account picker, where
+ * the user picks it. Runs on page access and then every 10 seconds until the
  * request resolves or the page closes.
  */
 export function useRecheckGitHubInstallRequest(organizationId: string, instances: OrganizationsIntegration[]) {

--- a/web_src/src/lib/hostedGitHubInstall.spec.ts
+++ b/web_src/src/lib/hostedGitHubInstall.spec.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  bindHostedGitHubInstallation,
   hostedGitHubAppSlug,
   hostedGitHubBindPath,
   hostedGitHubInstallRequested,
@@ -9,6 +10,40 @@ import {
   hostedGitHubState,
   pendingGitHubInstallations,
 } from "./hostedGitHubInstall";
+
+describe("bindHostedGitHubInstallation", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubFetch(response: Partial<Response>) {
+    const fetchSpy = vi.fn().mockResolvedValue(response as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+    return fetchSpy;
+  }
+
+  it("does not follow the success redirect, which can leave the page origin", async () => {
+    const fetchSpy = stubFetch({ type: "opaqueredirect", ok: false, status: 0 });
+
+    await expect(bindHostedGitHubInstallation("csrf", "11")).resolves.toBeUndefined();
+    expect(fetchSpy).toHaveBeenCalledWith("/api/v1/github/app/bind?state=csrf&installation_id=11", {
+      credentials: "same-origin",
+      redirect: "manual",
+    });
+  });
+
+  it("accepts a plain success answer", async () => {
+    stubFetch({ type: "basic", ok: true, status: 200 });
+
+    await expect(bindHostedGitHubInstallation("csrf", "11")).resolves.toBeUndefined();
+  });
+
+  it("throws on an error status", async () => {
+    stubFetch({ type: "basic", ok: false, status: 404 });
+
+    await expect(bindHostedGitHubInstallation("csrf", "11")).rejects.toThrow("Failed to connect the GitHub account");
+  });
+});
 
 describe("pendingGitHubInstallations", () => {
   it("reads valid rows", () => {

--- a/web_src/src/lib/hostedGitHubInstall.ts
+++ b/web_src/src/lib/hostedGitHubInstall.ts
@@ -85,12 +85,19 @@ export function hostedGitHubBindPath(state: string, installationId: string): str
 
 /**
  * Binds a pending connection to an App installation without leaving the page.
- * The bind endpoint answers with a redirect on success, which fetch follows;
- * any error status means the bind did not happen.
+ * The bind endpoint answers with a redirect on success and with an error
+ * status when the bind did not happen. The redirect target comes from the
+ * server BASE_URL, which can differ from the page origin (a tunnel domain in
+ * local setups), so the fetch must not follow it: the redirect itself is the
+ * success signal.
  */
 export async function bindHostedGitHubInstallation(state: string, installationId: string): Promise<void> {
-  const response = await fetch(hostedGitHubBindPath(state, installationId), { credentials: "same-origin" });
-  if (!response.ok) {
+  const response = await fetch(hostedGitHubBindPath(state, installationId), {
+    credentials: "same-origin",
+    redirect: "manual",
+  });
+  const redirected = response.type === "opaqueredirect";
+  if (!redirected && !response.ok) {
     throw new Error("Failed to connect the GitHub account");
   }
 }

--- a/web_src/src/lib/hostedGitHubInstall.ts
+++ b/web_src/src/lib/hostedGitHubInstall.ts
@@ -83,6 +83,18 @@ export function hostedGitHubBindPath(state: string, installationId: string): str
   return `/api/v1/github/app/bind?${params.toString()}`;
 }
 
+/**
+ * Binds a pending connection to an App installation without leaving the page.
+ * The bind endpoint answers with a redirect on success, which fetch follows;
+ * any error status means the bind did not happen.
+ */
+export async function bindHostedGitHubInstallation(state: string, installationId: string): Promise<void> {
+  const response = await fetch(hostedGitHubBindPath(state, installationId), { credentials: "same-origin" });
+  if (!response.ok) {
+    throw new Error("Failed to connect the GitHub account");
+  }
+}
+
 export function hostedGitHubInstallURL(slug: string, state: string): string {
   return `https://github.com/apps/${encodeURIComponent(slug)}/installations/new?state=${encodeURIComponent(state)}`;
 }

--- a/web_src/src/pages/auth/OrganizationOnboardingRedirect.component.spec.tsx
+++ b/web_src/src/pages/auth/OrganizationOnboardingRedirect.component.spec.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -29,27 +30,31 @@ vi.mock("@/contexts/useAccount", () => ({
   }),
 }));
 
-function renderOnboarding() {
+function renderOnboarding(queryClient = new QueryClient()) {
   return render(
-    <OrganizationOnboardingRedirect
-      renderWorkspace={(workspace, entryPath) => (
-        <div data-entry-path={entryPath} data-testid="internal-workspace-key">
-          {workspace.workspaceKey}
-        </div>
-      )}
-    />,
+    <QueryClientProvider client={queryClient}>
+      <OrganizationOnboardingRedirect
+        renderWorkspace={(workspace, entryPath) => (
+          <div data-entry-path={entryPath} data-testid="internal-workspace-key">
+            {workspace.workspaceKey}
+          </div>
+        )}
+      />
+    </QueryClientProvider>,
   );
 }
 
-function renderOnboardingWithReresolve() {
+function renderOnboardingWithReresolve(queryClient = new QueryClient()) {
   let reresolve: (() => Promise<void>) | undefined;
   const utils = render(
-    <OrganizationOnboardingRedirect
-      renderWorkspace={(workspace, _entryPath, reresolveWorkspace) => {
-        reresolve = reresolveWorkspace;
-        return <div data-testid="internal-workspace-slug">{workspace.organizationSlug}</div>;
-      }}
-    />,
+    <QueryClientProvider client={queryClient}>
+      <OrganizationOnboardingRedirect
+        renderWorkspace={(workspace, _entryPath, reresolveWorkspace) => {
+          reresolve = reresolveWorkspace;
+          return <div data-testid="internal-workspace-slug">{workspace.organizationSlug}</div>;
+        }}
+      />
+    </QueryClientProvider>,
   );
   return { ...utils, reresolve: () => reresolve!() };
 }
@@ -134,6 +139,35 @@ describe("OrganizationOnboardingRedirect", () => {
     await waitFor(() => expect(screen.getByTestId("internal-workspace-slug")).toHaveTextContent("dev-user-x1y2z3"));
     expect(location.replace).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops cached queries for the provisioned slug so a reused slug starts setup fresh", async () => {
+    const queryClient = new QueryClient();
+    // Cache left behind by an earlier onboarding organization that held the
+    // "dev-user" slug before it was renamed.
+    queryClient.setQueryData(["factories", "dev-user"], [{ id: "old-factory", onboarding: { step: "repo" } }]);
+    queryClient.setQueryData(["integrations", "connected", "dev-user"], [{ metadata: { id: "old-integration" } }]);
+    queryClient.setQueryData(["factories", "other-org"], [{ id: "other-factory" }]);
+
+    renderOnboarding(queryClient);
+
+    await screen.findByTestId("internal-workspace-key");
+    expect(queryClient.getQueryData(["factories", "dev-user"])).toBeUndefined();
+    expect(queryClient.getQueryData(["integrations", "connected", "dev-user"])).toBeUndefined();
+    expect(queryClient.getQueryData(["factories", "other-org"])).toBeDefined();
+  });
+
+  it("keeps cached queries when a re-resolve returns the same slug", async () => {
+    const queryClient = new QueryClient();
+    const { reresolve } = renderOnboardingWithReresolve(queryClient);
+
+    await screen.findByTestId("internal-workspace-slug");
+    // Cache written by the wizard itself after the workspace was adopted.
+    queryClient.setQueryData(["factories", "dev-user"], [{ id: "current-factory" }]);
+
+    await reresolve();
+
+    expect(queryClient.getQueryData(["factories", "dev-user"])).toBeDefined();
   });
 
   it("starts workspace setup without GitHub authorization", async () => {

--- a/web_src/src/pages/auth/OrganizationOnboardingRedirect.tsx
+++ b/web_src/src/pages/auth/OrganizationOnboardingRedirect.tsx
@@ -1,4 +1,5 @@
 import { useAccount } from "@/contexts/useAccount";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 
 import type { OnboardingWorkspaceResolution } from "../factories/pages/onboarding/onboardingWorkspaceResolutionContext";
@@ -20,11 +21,31 @@ interface OrganizationOnboardingRedirectProps {
 /** Provisions the internal workspace and renders its existing setup wizard at /onboarding. */
 export function OrganizationOnboardingRedirect({ renderWorkspace }: OrganizationOnboardingRedirectProps) {
   const { account } = useAccount();
+  const queryClient = useQueryClient();
   const hasStartedProvisioning = useRef(false);
   const [error, setError] = useState<string | null>(null);
   const [workspace, setWorkspace] = useState<ProvisionedWorkspace | null>(null);
+  const workspaceRef = useRef<ProvisionedWorkspace | null>(null);
   const owner = organizationNameFromAccount(account);
   const onboardingAttempt = useRef(getOnboardingAttempt());
+
+  // A new organization can receive the slug of an earlier onboarding
+  // organization that was later renamed (for example, to the GitHub owner).
+  // Cached queries under that slug still hold the old organization's factory
+  // and connections, which would open the wizard mid-way, so the slug starts
+  // with a clean cache whenever the wizard adopts a different slug.
+  const adoptWorkspace = useCallback(
+    (provisioned: ProvisionedWorkspace) => {
+      if (workspaceRef.current?.organizationSlug !== provisioned.organizationSlug) {
+        queryClient.removeQueries({
+          predicate: (query) => query.queryKey.includes(provisioned.organizationSlug),
+        });
+      }
+      workspaceRef.current = provisioned;
+      setWorkspace(provisioned);
+    },
+    [queryClient],
+  );
 
   useEffect(() => {
     if (!account || hasStartedProvisioning.current) return;
@@ -35,11 +56,11 @@ export function OrganizationOnboardingRedirect({ renderWorkspace }: Organization
 
     hasStartedProvisioning.current = true;
     void provisionWorkspace(owner, onboardingAttempt.current.id)
-      .then(setWorkspace)
+      .then(adoptWorkspace)
       .catch((provisioningError: unknown) => {
         setError(provisioningError instanceof Error ? provisioningError.message : "Could not start workspace setup.");
       });
-  }, [account, owner]);
+  }, [account, owner, adoptWorkspace]);
 
   // Re-runs the retry-safe onboarding endpoint for the same attempt, so a
   // workspace can move to a new organization slug (for example, after the
@@ -47,8 +68,8 @@ export function OrganizationOnboardingRedirect({ renderWorkspace }: Organization
   const reresolveWorkspace = useCallback(async () => {
     if (!owner) return;
     const result = await provisionWorkspace(owner, onboardingAttempt.current.id);
-    setWorkspace(result);
-  }, [owner]);
+    adoptWorkspace(result);
+  }, [owner, adoptWorkspace]);
 
   if (workspace) {
     return renderWorkspace(workspace, onboardingAttempt.current.entryPath, reresolveWorkspace);

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
@@ -36,10 +36,14 @@ vi.mock("@/hooks/useMe", () => ({
 
 vi.mock("@/posthog", () => ({ posthog: { reset: vi.fn() } }));
 
-// The install-request recheck needs a query client and the network; the flow
-// tests cover the waiting screen only.
+// The install-request recheck and the in-place bind need a query client and
+// the network; the flow tests cover the screens only.
 vi.mock("@/hooks/useRecheckGitHubInstallRequest", () => ({
   useRecheckGitHubInstallRequest: vi.fn(),
+}));
+
+vi.mock("@/hooks/useBindGitHubInstallation", () => ({
+  useBindGitHubInstallation: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
 }));
 
 const deleteFactoryMutateAsync = vi.fn().mockResolvedValue(undefined);

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
@@ -5,7 +5,12 @@ import { useDeleteFactory } from "@/hooks/useFactoryData";
 import { useMe } from "@/hooks/useMe";
 import { organizationMatchesRoute, organizationRouteId } from "@/lib/accountOrganizations";
 import { getApiErrorMessage } from "@/lib/errors";
-import { hostedGitHubInstallRequested, hostedGitHubInstallRequestedAccount } from "@/lib/hostedGitHubInstall";
+import {
+  hostedGitHubInstallRequested,
+  hostedGitHubInstallRequestedAccount,
+  type PendingGitHubInstallation,
+} from "@/lib/hostedGitHubInstall";
+import { useBindGitHubInstallation } from "@/hooks/useBindGitHubInstallation";
 import { useRecheckGitHubInstallRequest } from "@/hooks/useRecheckGitHubInstallRequest";
 import { pendingGitHubAccountPicker } from "@/lib/startDirectGitHubConnect";
 import {
@@ -262,12 +267,30 @@ function useFirstRunSetupFlow(model: OnboardingPageModel) {
   // user. The /account id is the account, so a match would hide the picker.
   const accountPicker = pendingGitHubAccountPicker(model.githubConnections.allInstances, me?.id);
 
+  // Binding through a page redirect reloads the whole app and walks the user
+  // through the connect screen again. Binding in place opens the repository
+  // screen directly once the connection is ready.
+  const bindInstallation = useBindGitHubInstallation(organizationId);
+  const useInstallation = (installation: PendingGitHubInstallation) => {
+    const state = accountPicker?.state;
+    if (!state || bindInstallation.isPending) return;
+    bindInstallation.mutate(
+      { state, installationId: installation.id },
+      {
+        onSuccess: () => goToScreen("choose"),
+        onError: (error) => showErrorToast(getApiErrorMessage(error, "Failed to connect the GitHub account")),
+      },
+    );
+  };
+
   return {
     screen: screenWithoutAgent(openedScreen, skipAgentScreen),
     skipAgentScreen,
     installRequested,
     githubOrganization,
     accountPicker,
+    bindingInstallationId: bindInstallation.isPending ? bindInstallation.variables?.installationId : undefined,
+    useInstallation,
     goToScreen,
     continueFromRepository,
     continueFromTickets,
@@ -342,8 +365,10 @@ export function FirstRunSetup({ model }: { model: OnboardingPageModel }) {
         pendingInstallations={flow.accountPicker?.installations}
         githubState={flow.accountPicker?.state}
         githubAppSlug={flow.accountPicker?.appSlug}
+        bindingInstallationId={flow.bindingInstallationId}
         chrome={chromeFor("connect")}
         onConnectGitHub={() => model.requestConnect("github")}
+        onUseInstallation={flow.useInstallation}
         onContinue={() => flow.goToScreen("choose")}
       />
     );

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.spec.tsx
@@ -164,6 +164,44 @@ describe("FirstRunConnectScreen", () => {
     expect(onUseInstallation).toHaveBeenCalledWith({ id: "11", accountLogin: "acme" });
   });
 
+  it("hides the waiting chip when the picker offers the requested organization", () => {
+    render(
+      <FirstRunConnectScreen
+        githubConnected={false}
+        installRequested
+        githubOrganization="Acme"
+        pendingInstallations={[{ id: "11", accountLogin: "acme" }]}
+        githubState="csrf"
+        githubAppSlug="superplane"
+        onConnectGitHub={vi.fn()}
+        onUseInstallation={vi.fn()}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("first-run-github-account-picker")).toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-github-install-requested")).not.toBeInTheDocument();
+  });
+
+  it("keeps the waiting chip when the picker lacks the requested organization", () => {
+    render(
+      <FirstRunConnectScreen
+        githubConnected={false}
+        installRequested
+        githubOrganization="acme"
+        pendingInstallations={[{ id: "22", accountLogin: "octo" }]}
+        githubState="csrf"
+        githubAppSlug="superplane"
+        onConnectGitHub={vi.fn()}
+        onUseInstallation={vi.fn()}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("first-run-github-account-picker")).toBeInTheDocument();
+    expect(screen.getByTestId("first-run-github-install-requested")).toBeInTheDocument();
+  });
+
   it("disables the picker while one account is binding", () => {
     render(
       <FirstRunConnectScreen

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.spec.tsx
@@ -119,6 +119,7 @@ describe("FirstRunConnectScreen", () => {
         githubState="csrf"
         githubAppSlug="superplane"
         onConnectGitHub={vi.fn()}
+        onUseInstallation={vi.fn()}
         onContinue={vi.fn()}
       />,
     );
@@ -133,8 +134,7 @@ describe("FirstRunConnectScreen", () => {
 
   it("asks which GitHub account to use when two installs are pending", async () => {
     const user = userEvent.setup();
-    const assign = vi.fn();
-    vi.stubGlobal("location", { ...window.location, assign });
+    const onUseInstallation = vi.fn();
 
     render(
       <FirstRunConnectScreen
@@ -146,6 +146,7 @@ describe("FirstRunConnectScreen", () => {
         githubState="csrf"
         githubAppSlug="superplane"
         onConnectGitHub={vi.fn()}
+        onUseInstallation={onUseInstallation}
         onContinue={vi.fn()}
       />,
     );
@@ -159,12 +160,29 @@ describe("FirstRunConnectScreen", () => {
       "https://github.com/apps/superplane/installations/new?state=csrf",
     );
 
-    try {
-      await user.click(screen.getByRole("button", { name: FIRST_RUN_COPY.connect.useAccount("acme") }));
-      expect(assign).toHaveBeenCalledWith("/api/v1/github/app/bind?state=csrf&installation_id=11");
-    } finally {
-      vi.unstubAllGlobals();
-    }
+    await user.click(screen.getByRole("button", { name: FIRST_RUN_COPY.connect.useAccount("acme") }));
+    expect(onUseInstallation).toHaveBeenCalledWith({ id: "11", accountLogin: "acme" });
+  });
+
+  it("disables the picker while one account is binding", () => {
+    render(
+      <FirstRunConnectScreen
+        githubConnected={false}
+        pendingInstallations={[
+          { id: "11", accountLogin: "acme" },
+          { id: "22", accountLogin: "octo" },
+        ]}
+        githubState="csrf"
+        githubAppSlug="superplane"
+        bindingInstallationId="11"
+        onConnectGitHub={vi.fn()}
+        onUseInstallation={vi.fn()}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("first-run-github-use-acme")).toBeDisabled();
+    expect(screen.getByTestId("first-run-github-use-octo")).toBeDisabled();
   });
 
   it("continues to the repository step after GitHub is connected", async () => {

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.tsx
@@ -1,12 +1,9 @@
 import { Button } from "@/components/ui/button";
+import { LoadingButton } from "@/components/ui/loading-button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Check, Clock } from "lucide-react";
 
-import {
-  hostedGitHubBindPath,
-  hostedGitHubInstallURL,
-  type PendingGitHubInstallation,
-} from "@/lib/hostedGitHubInstall";
+import { hostedGitHubInstallURL, type PendingGitHubInstallation } from "@/lib/hostedGitHubInstall";
 
 import { IntegrationChoiceIcon } from "../onboardingSteps";
 import { FIRST_RUN_COPY } from "./firstRunCopy";
@@ -49,13 +46,18 @@ function FirstRunInstallRequested({ githubOrganization }: { githubOrganization: 
 
 function FirstRunGitHubAccountPicker({
   installations,
-  githubState,
   githubAppSlug,
+  githubState,
+  bindingInstallationId,
+  onUseInstallation,
 }: {
   installations: PendingGitHubInstallation[];
-  githubState: string;
   githubAppSlug: string;
+  githubState: string;
+  bindingInstallationId?: string;
+  onUseInstallation: (installation: PendingGitHubInstallation) => void;
 }) {
+  const binding = bindingInstallationId !== undefined;
   return (
     <div className="space-y-3" data-testid="first-run-github-account-picker">
       <FirstRunPanel>
@@ -63,17 +65,17 @@ function FirstRunGitHubAccountPicker({
         <p className="mt-0.5 text-[13px] text-muted-foreground">{copy.selectAccountBody}</p>
       </FirstRunPanel>
       {installations.map((installation) => (
-        <Button
+        <LoadingButton
           key={installation.id}
           type="button"
           className="w-full justify-start"
           data-testid={`first-run-github-use-${installation.accountLogin}`}
-          onClick={() => {
-            window.location.assign(hostedGitHubBindPath(githubState, installation.id));
-          }}
+          loading={bindingInstallationId === installation.id}
+          disabled={binding}
+          onClick={() => onUseInstallation(installation)}
         >
           {copy.useAccount(installation.accountLogin)}
-        </Button>
+        </LoadingButton>
       ))}
       {githubAppSlug !== "" ? (
         <a
@@ -95,9 +97,11 @@ export function FirstRunConnectScreen({
   pendingInstallations = [],
   githubState = "",
   githubAppSlug = "",
+  bindingInstallationId,
   connectError,
   chrome,
   onConnectGitHub,
+  onUseInstallation,
   onContinue,
 }: {
   githubConnected: boolean;
@@ -106,9 +110,11 @@ export function FirstRunConnectScreen({
   pendingInstallations?: PendingGitHubInstallation[];
   githubState?: string;
   githubAppSlug?: string;
+  bindingInstallationId?: string;
   connectError?: string;
   chrome?: FirstRunChrome;
   onConnectGitHub: () => void;
+  onUseInstallation?: (installation: PendingGitHubInstallation) => void;
   onContinue: () => void;
 }) {
   const waitingForApproval = installRequested && !githubConnected;
@@ -138,11 +144,13 @@ export function FirstRunConnectScreen({
         ) : (
           <>
             {waitingForApproval ? <FirstRunInstallRequested githubOrganization={githubOrganization} /> : null}
-            {showAccountPicker ? (
+            {showAccountPicker && onUseInstallation ? (
               <FirstRunGitHubAccountPicker
                 installations={pendingInstallations}
-                githubState={githubState}
                 githubAppSlug={githubAppSlug}
+                githubState={githubState}
+                bindingInstallationId={bindingInstallationId}
+                onUseInstallation={onUseInstallation}
               />
             ) : (
               <Button

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.tsx
@@ -90,6 +90,31 @@ function FirstRunGitHubAccountPicker({
   );
 }
 
+function connectScreenState({
+  githubConnected,
+  installRequested,
+  githubOrganization,
+  pendingInstallations,
+  githubState,
+}: {
+  githubConnected: boolean;
+  installRequested: boolean;
+  githubOrganization: string;
+  pendingInstallations: PendingGitHubInstallation[];
+  githubState: string;
+}) {
+  const showAccountPicker = !githubConnected && pendingInstallations.length >= 1 && githubState !== "";
+  // A picker that offers the requested organization means the request is
+  // approved, so the waiting state must not show next to it.
+  const requestApproved = pendingInstallations.some(
+    (installation) => installation.accountLogin.toLowerCase() === githubOrganization.toLowerCase(),
+  );
+  return {
+    showAccountPicker,
+    waitingForApproval: installRequested && !githubConnected && !(showAccountPicker && requestApproved),
+  };
+}
+
 export function FirstRunConnectScreen({
   githubConnected,
   installRequested = false,
@@ -117,8 +142,13 @@ export function FirstRunConnectScreen({
   onUseInstallation?: (installation: PendingGitHubInstallation) => void;
   onContinue: () => void;
 }) {
-  const waitingForApproval = installRequested && !githubConnected;
-  const showAccountPicker = !githubConnected && pendingInstallations.length >= 1 && githubState !== "";
+  const { showAccountPicker, waitingForApproval } = connectScreenState({
+    githubConnected,
+    installRequested,
+    githubOrganization,
+    pendingInstallations,
+    githubState,
+  });
 
   return (
     <FirstRunShell testId="first-run-connect" chrome={chrome}>


### PR DESCRIPTION
## Summary

The GitHub account picker sent the browser through the bind endpoint with a full-page redirect. The app reloaded: the user saw the workspace loader, then the connect screen again, and only then could open the repository step.

This change calls the bind endpoint from the page. The picked account button shows a spinner while the bind runs, the connection list refreshes in place, and the wizard opens the repository step directly.

## Test plan

- [ ] Onboarding, hooks, and lib specs pass (311 tests).
- [ ] `make check.lint.ui` and `make check.build.ui` pass.
- [ ] Manual: connect GitHub during onboarding, pick an account in the picker. The wizard opens the repository step without a page reload.

Made with [Cursor](https://cursor.com)