### PR TITLE
feat: Clean up Create with an Agent session UI

### DIFF
--- a/pkg/components/runner/openrouter/run.js
+++ b/pkg/components/runner/openrouter/run.js
@@ -29,8 +29,6 @@ const WRAP_UP_PROMPT =
   "You have no remaining tool turns. Do not call tools. Write a plain-text summary of what you completed and what remains.";
 const TOOL_NUDGE =
   "Use the bash, read, edit, or write tools to do the work. Do not only describe the changes.";
-const PLANNING_TOOL_NUDGE =
-  "Use the bash or read tools to gather context, or call propose_draft/survey. Do not only describe the changes.";
 const TOOLS = [
   {
     type: "function",
@@ -170,7 +168,6 @@ async function runPrompt(promptFile, model, maxTurns = DEFAULT_MAX_TURNS) {
   const planning = planningEnabled(process.env);
   const planningHelpers = planning ? loadPlanningHelpers(process.env) : null;
   const tools = planning ? planningToolDefs(planningHelpers) : TOOLS;
-  const toolNudge = planning ? PLANNING_TOOL_NUDGE : TOOL_NUDGE;
   if (planning) {
     process.stdout.write("Planning session tools enabled\n");
     process.stdout.write(`allowed tools: ${tools.map((tool) => tool.function.name).join(", ")}\n`);
@@ -216,10 +213,10 @@ async function runPrompt(promptFile, model, maxTurns = DEFAULT_MAX_TURNS) {
       const toolCalls = extractToolCalls(message);
       pendingToolCalls = toolCalls.length > 0;
       if (!pendingToolCalls) {
-        if (!nudgedForTools) {
+        if (!planning && !nudgedForTools) {
           nudgedForTools = true;
           process.stderr.write("OpenRouter agent returned no tool calls; asking it to use tools\n");
-          messages.push({ role: "user", content: toolNudge });
+          messages.push({ role: "user", content: TOOL_NUDGE });
           continue;
         }
         break;

--- a/pkg/components/runner/openrouter/run_test.go
+++ b/pkg/components/runner/openrouter/run_test.go
@@ -225,6 +225,8 @@ func TestRunPromptPlanningAdvertisesPlanningToolsNotWriteEdit(t *testing.T) {
 	assert.NotContains(t, names, "write")
 	assert.NotContains(t, names, "edit")
 	assert.Empty(t, result.planningRequests)
+	require.Len(t, result.chatRequests, 1)
+	assert.NotContains(t, result.output, "asking it to use tools")
 }
 
 func TestRunPromptPlanningProposeDraftPostsToDraftsEndpoint(t *testing.T) {

--- a/pkg/grpc/actions/factories/planning_canvas.go
+++ b/pkg/grpc/actions/factories/planning_canvas.go
@@ -25,12 +25,25 @@ var (
 	errPlanningGitHubRequired = errors.New("github is not connected")
 )
 
+const (
+	planningCanvasGreetCloser     = "Greet the user in plain text. Then stop."
+	planningCanvasFirstTurnCloser = "" +
+		"Refine key: {{ root().data.planning_session.refine_key }}\n" +
+		"Refine title: {{ root().data.planning_session.refine_title }}\n" +
+		"Refine description: {{ root().data.planning_session.refine_description }}\n\n" +
+		"If the refine key is not empty, you already have that draft task. Tell the user you have this task and you are ready to refine it. Ask what they want to change. Do not explore the repository unless you need to understand a requested change. Do not call propose_draft until they say what to change. Then stop.\n\n" +
+		"If the refine key is empty, greet the user in plain text. Then stop."
+)
+
 func ensurePlanningCanvas(tx *gorm.DB, factoryModel *models.Factory, userID uuid.UUID) (*models.Canvas, string, error) {
 	if err := requirePlanningGitHub(tx, factoryModel); err != nil {
 		return nil, "", err
 	}
 	canvas, err := models.FindPlanningCanvas(tx, factoryModel.OrganizationID, factoryModel.ID)
 	if err == nil {
+		if syncErr := syncPlanningCanvasStockPrompt(tx, canvas.ID); syncErr != nil {
+			return nil, "", syncErr
+		}
 		entrypoint, entryErr := planningCanvasEntrypoint(tx, canvas.ID)
 		return canvas, entrypoint, entryErr
 	}
@@ -232,6 +245,70 @@ func planningTemplateIntegrations(tx *gorm.DB, factoryModel *models.Factory) map
 		}
 	}
 	return out
+}
+
+func syncPlanningCanvasStockPrompt(tx *gorm.DB, canvasID uuid.UUID) error {
+	nodes, err := models.FindCanvasNodesInTransaction(tx, canvasID)
+	if err != nil {
+		return err
+	}
+	changed := false
+	for i := range nodes {
+		if nodes[i].Type != models.NodeTypeComponent {
+			continue
+		}
+		config := nodes[i].Configuration.Data()
+		if !rewritePlanningCanvasPrompt(config) {
+			continue
+		}
+		nodes[i].Configuration = datatypes.NewJSONType(config)
+		if err := tx.Model(&nodes[i]).Select("Configuration").Updates(&nodes[i]).Error; err != nil {
+			return err
+		}
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	live, err := models.FindLiveCanvasVersionInTransaction(tx, canvasID)
+	if err != nil {
+		return err
+	}
+	versionNodes := append([]models.Node(nil), live.Nodes...)
+	for i := range versionNodes {
+		rewritePlanningCanvasPrompt(versionNodes[i].Configuration)
+	}
+	now := time.Now()
+	live.Nodes = datatypes.NewJSONSlice(versionNodes)
+	live.UpdatedAt = &now
+	return tx.Model(live).Select("Nodes", "UpdatedAt").Updates(live).Error
+}
+
+func rewritePlanningCanvasPrompt(config map[string]any) bool {
+	if config == nil {
+		return false
+	}
+	rewritten := false
+	for _, step := range planningCanvasConfigSteps(config["steps"]) {
+		prompt, _ := step["prompt"].(string)
+		next, ok := replacePlanningCanvasGreetCloser(prompt)
+		if !ok {
+			continue
+		}
+		step["prompt"] = next
+		rewritten = true
+	}
+	return rewritten
+}
+
+func replacePlanningCanvasGreetCloser(prompt string) (string, bool) {
+	if !strings.Contains(prompt, planningCanvasGreetCloser) {
+		return prompt, false
+	}
+	if strings.Contains(prompt, "planning_session.refine_key") {
+		return prompt, false
+	}
+	return strings.Replace(prompt, planningCanvasGreetCloser, planningCanvasFirstTurnCloser, 1), true
 }
 
 func planningCanvasPromptFromConfig(config map[string]any) string {

--- a/pkg/grpc/actions/factories/planning_session.go
+++ b/pkg/grpc/actions/factories/planning_session.go
@@ -52,11 +52,16 @@ func StartPlanningSession(ctx context.Context, organizationID string, req *pb.St
 		if findErr = rejectIfPlanningSessionAtCap(tx, factoryModel, canvas.ID); findErr != nil {
 			return findErr
 		}
+		workOrderID, parseErr := parseOptionalPlanningWorkOrderID(req.GetWorkOrderId())
+		if parseErr != nil {
+			return parseErr
+		}
 		session, findErr = factoryModel.StartPlanningSession(tx, models.StartPlanningSessionParams{
 			CreatedByUserID: userID,
 			Repository:      repository,
 			CanvasID:        canvas.ID,
 			Entrypoint:      entrypoint,
+			WorkOrderID:     workOrderID,
 		})
 		return findErr
 	})
@@ -241,6 +246,18 @@ func parseSessionID(sessionID string) (uuid.UUID, error) {
 	return id, nil
 }
 
+func parseOptionalPlanningWorkOrderID(workOrderID string) (uuid.UUID, error) {
+	raw := strings.TrimSpace(workOrderID)
+	if raw == "" {
+		return uuid.Nil, nil
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.Nil, invalidArgument("invalid work order id")
+	}
+	return id, nil
+}
+
 func loadPlanningSession(
 	ctx context.Context,
 	organizationID, factoryID, sessionID string,
@@ -329,7 +346,11 @@ func serializePlanningSession(tx *gorm.DB, factoryModel *models.Factory, session
 	}
 	out.ExecutionId = executionID
 	if draft := session.Draft(); strings.TrimSpace(draft.Title) != "" {
-		out.Draft = &pb.PlanningSessionDraft{Title: draft.Title, Description: draft.Description}
+		out.Draft = &pb.PlanningSessionDraft{
+			Title:       draft.Title,
+			Description: draft.Description,
+			WorkOrderId: draft.WorkOrderID,
+		}
 	}
 	if survey := session.CurrentSurvey(); session.SurveyID != nil && len(survey.Questions) > 0 {
 		out.Survey = &pb.PlanningSessionSurvey{

--- a/pkg/grpc/actions/factories/planning_session_test.go
+++ b/pkg/grpc/actions/factories/planning_session_test.go
@@ -47,13 +47,15 @@ func Test__StartPlanningSession__CreatesSessionAndPendingRun(t *testing.T) {
 		if node.Type == models.NodeTypeComponent {
 			hasAgent = true
 			prompt := planningCanvasPromptFromConfig(node.Configuration.Data())
-			assert.Contains(t, prompt, "Greet the user in plain text")
+			assert.Contains(t, prompt, "greet the user in plain text")
 			assert.Contains(t, prompt, "Use survey to ask one or more questions")
 			assert.NotContains(t, prompt, "say:")
 			assert.NotContains(t, prompt, "with say")
 			assert.Contains(t, prompt, "Do not call wait_for_user")
 			assert.Contains(t, prompt, "When the user creates or skips a draft")
 			assert.Contains(t, prompt, "When the user starts a refine")
+			assert.Contains(t, prompt, "planning_session.refine_key")
+			assert.Contains(t, prompt, "If the refine key is not empty")
 			assert.NotContains(t, prompt, "Start by calling wait_for_user")
 		}
 	}
@@ -151,6 +153,86 @@ func Test__StartPlanningSession__KeepsExistingCanvasPrompt(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "Custom planning prompt.", planningAgentPrompt(t, r.Organization.ID, factoryModel.ID))
+}
+
+func Test__StartPlanningSession__AttachesDraftWorkOrder(t *testing.T) {
+	r := support.Setup(t)
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	db := database.DB(t.Context())
+	setupPlanningStart(t, r.Organization.ID)
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	order, err := factoryModel.CreateWorkOrder(db, "Retry refunds", "Stop double charges.", &r.User, nil, nil)
+	require.NoError(t, err)
+
+	resp, err := StartPlanningSession(ctx, r.Organization.ID.String(), &pb.StartPlanningSessionRequest{
+		FactoryId:   factoryModel.ID.String(),
+		Repository:  "acme/payments",
+		WorkOrderId: order.ID.String(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Session.Draft)
+	assert.Equal(t, "Retry refunds", resp.Session.Draft.Title)
+	assert.Equal(t, "Stop double charges.", resp.Session.Draft.Description)
+	assert.Equal(t, order.ID.String(), resp.Session.Draft.WorkOrderId)
+	require.Len(t, resp.Session.Created, 1)
+	assert.Equal(t, order.ID.String(), resp.Session.Created[0].Id)
+
+	session, err := models.FindPlanningSession(db, r.Organization.ID, factoryModel.ID, uuid.MustParse(resp.Session.Id))
+	require.NoError(t, err)
+	var run models.CanvasRun
+	require.NoError(t, db.First(&run, "id = ?", session.CanvasRunID).Error)
+	input, ok := run.Input.Data().(map[string]any)
+	require.True(t, ok)
+	planning, ok := input["planning_session"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, factoryModel.WorkOrderKey(order.Number), planning["refine_key"])
+}
+
+func Test__StartPlanningSession__SyncsStockGreetCloser(t *testing.T) {
+	r := support.Setup(t)
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	setupPlanningStart(t, r.Organization.ID)
+	factoryModel, err := models.CreateFactory(database.DB(t.Context()), r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+
+	_, err = StartPlanningSession(ctx, r.Organization.ID.String(), &pb.StartPlanningSessionRequest{
+		FactoryId:  factoryModel.ID.String(),
+		Repository: "acme/payments",
+	})
+	require.NoError(t, err)
+
+	canvas, err := models.FindPlanningCanvas(database.DB(t.Context()), r.Organization.ID, factoryModel.ID)
+	require.NoError(t, err)
+	nodes, err := models.FindCanvasNodesInTransaction(database.DB(t.Context()), canvas.ID)
+	require.NoError(t, err)
+	rewrote := false
+	for i := range nodes {
+		if nodes[i].Type != models.NodeTypeComponent {
+			continue
+		}
+		config := nodes[i].Configuration.Data()
+		for _, step := range planningCanvasConfigSteps(config["steps"]) {
+			if _, ok := step["prompt"]; ok {
+				step["prompt"] = "You are in a SuperPlane planning session.\n\nGreet the user in plain text. Then stop."
+				rewrote = true
+			}
+		}
+		nodes[i].Configuration = datatypes.NewJSONType(config)
+		require.NoError(t, database.DB(t.Context()).Model(&nodes[i]).Select("Configuration").Updates(&nodes[i]).Error)
+	}
+	require.True(t, rewrote)
+	require.NoError(t, rewritePlanningCanvasLivePrompt(t, canvas.ID, "You are in a SuperPlane planning session.\n\nGreet the user in plain text. Then stop."))
+
+	_, err = StartPlanningSession(ctx, r.Organization.ID.String(), &pb.StartPlanningSessionRequest{
+		FactoryId:  factoryModel.ID.String(),
+		Repository: "acme/payments",
+	})
+	require.NoError(t, err)
+	prompt := planningAgentPrompt(t, r.Organization.ID, factoryModel.ID)
+	assert.Contains(t, prompt, "planning_session.refine_key")
+	assert.Contains(t, prompt, "If the refine key is not empty")
+	assert.Contains(t, planningLiveAgentPrompt(t, canvas.ID), "planning_session.refine_key")
 }
 
 func Test__StartPlanningSession__KeepsPreviousSessionForSameUser(t *testing.T) {
@@ -439,4 +521,35 @@ func planningAgentPrompt(t *testing.T, organizationID, factoryID uuid.UUID) stri
 	}
 	t.Fatal("missing planning agent")
 	return ""
+}
+
+func planningLiveAgentPrompt(t *testing.T, canvasID uuid.UUID) string {
+	t.Helper()
+	live, err := models.FindLiveCanvasVersionInTransaction(database.DB(t.Context()), canvasID)
+	require.NoError(t, err)
+	for _, node := range live.Nodes {
+		if node.Type == models.NodeTypeComponent {
+			return planningCanvasPromptFromConfig(node.Configuration)
+		}
+	}
+	t.Fatal("missing planning agent in live version")
+	return ""
+}
+
+func rewritePlanningCanvasLivePrompt(t *testing.T, canvasID uuid.UUID, prompt string) error {
+	t.Helper()
+	live, err := models.FindLiveCanvasVersionInTransaction(database.DB(t.Context()), canvasID)
+	if err != nil {
+		return err
+	}
+	nodes := append([]models.Node(nil), live.Nodes...)
+	for i := range nodes {
+		for _, step := range planningCanvasConfigSteps(nodes[i].Configuration["steps"]) {
+			if _, ok := step["prompt"]; ok {
+				step["prompt"] = prompt
+			}
+		}
+	}
+	live.Nodes = datatypes.NewJSONSlice(nodes)
+	return database.DB(t.Context()).Model(live).Select("Nodes").Updates(live).Error
 }

--- a/pkg/grpc/actions/factories/templates/create-with-agent.canvas.yaml
+++ b/pkg/grpc/actions/factories/templates/create-with-agent.canvas.yaml
@@ -60,7 +60,13 @@ spec:
               When the user starts a refine, read the current task. Tell them you are ready. Ask what they want to change. Do not call propose_draft until they say what to change.
               Do not call wait_for_user. SuperPlane waits after you stop.
 
-              Greet the user in plain text. Then stop.
+              Refine key: {{ root().data.planning_session.refine_key }}
+              Refine title: {{ root().data.planning_session.refine_title }}
+              Refine description: {{ root().data.planning_session.refine_description }}
+
+              If the refine key is not empty, you already have that draft task. Tell the user you have this task and you are ready to refine it. Ask what they want to change. Do not explore the repository unless you need to understand a requested change. Do not call propose_draft until they say what to change. Then stop.
+
+              If the refine key is empty, greet the user in plain text. Then stop.
       position:
         x: 720
         'y': 880

--- a/pkg/models/factory_planning_session.go
+++ b/pkg/models/factory_planning_session.go
@@ -74,6 +74,7 @@ type StartPlanningSessionParams struct {
 	Repository      string
 	CanvasID        uuid.UUID
 	Entrypoint      string
+	WorkOrderID     uuid.UUID
 }
 
 type FactoryPlanningSession struct {
@@ -153,6 +154,11 @@ func (f *Factory) StartPlanningSession(tx *gorm.DB, params StartPlanningSessionP
 		return nil, fmt.Errorf("%w: entrypoint must be onRun", ErrFactoryPlanningSessionInvalid)
 	}
 
+	refine, err := f.planningRefineWorkOrder(tx, params.WorkOrderID)
+	if err != nil {
+		return nil, err
+	}
+
 	liveVersion, err := FindLiveCanvasVersionInTransaction(tx, params.CanvasID)
 	if err != nil {
 		return nil, err
@@ -167,12 +173,7 @@ func (f *Factory) StartPlanningSession(tx *gorm.DB, params StartPlanningSessionP
 		Callbacks: datatypes.JSONSlice[core.RunCallback]{
 			{When: core.RunCallbackWhenPending, On: core.RunCallbackOnEntry, Hook: "onMessage"},
 		},
-		Input: NewJSONValue(map[string]any{
-			"planning_session": map[string]any{
-				"factory_id": f.ID.String(),
-				"repository": repository,
-			},
-		}),
+		Input:     NewJSONValue(planningSessionRunInput(f, repository, refine)),
 		State:     CanvasRunStatePending,
 		CreatedAt: &now,
 		UpdatedAt: &now,
@@ -198,7 +199,42 @@ func (f *Factory) StartPlanningSession(tx *gorm.DB, params StartPlanningSessionP
 	if err := tx.Create(session).Error; err != nil {
 		return nil, err
 	}
+	if refine != nil {
+		if err := session.attachRefineDraft(tx, refine); err != nil {
+			return nil, err
+		}
+	}
 	return session, nil
+}
+
+func (f *Factory) planningRefineWorkOrder(tx *gorm.DB, workOrderID uuid.UUID) (*FactoryWorkOrder, error) {
+	if workOrderID == uuid.Nil {
+		return nil, nil
+	}
+	order, err := f.FindWorkOrder(tx, workOrderID)
+	if err != nil {
+		return nil, err
+	}
+	if order.State != FactoryWorkOrderStateDraft {
+		return nil, fmt.Errorf("%w: work order is not a draft", ErrFactoryPlanningSessionInvalid)
+	}
+	return order, nil
+}
+
+func planningSessionRunInput(factoryModel *Factory, repository string, refine *FactoryWorkOrder) map[string]any {
+	planning := map[string]any{
+		"factory_id":         factoryModel.ID.String(),
+		"repository":         repository,
+		"refine_key":         "",
+		"refine_title":       "",
+		"refine_description": "",
+	}
+	if refine != nil {
+		planning["refine_key"] = factoryModel.WorkOrderKey(refine.Number)
+		planning["refine_title"] = refine.Title
+		planning["refine_description"] = refine.Description
+	}
+	return map[string]any{"planning_session": planning}
 }
 
 func CountOpenPlanningSessions(tx *gorm.DB, organizationID, factoryID uuid.UUID) (int64, error) {

--- a/pkg/models/factory_planning_session_draft.go
+++ b/pkg/models/factory_planning_session_draft.go
@@ -1,8 +1,10 @@
 package models
 
 import (
+	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -128,22 +130,75 @@ func (s *FactoryPlanningSession) applyRefineNote(tx *gorm.DB, text string) (bool
 	if err != nil {
 		return false, err
 	}
-	orders, err := s.CreatedOrders(tx)
+	order, err := s.findRefineWorkOrder(tx, factoryModel, key)
 	if err != nil {
 		return false, err
+	}
+	if order == nil {
+		return false, nil
+	}
+	if err := s.attachCreatedWorkOrder(tx, order.ID); err != nil {
+		return false, err
+	}
+	s.setDraft(PlanningSessionDraft{
+		Title:       order.Title,
+		Description: order.Description,
+		WorkOrderID: order.ID.String(),
+	})
+	return true, nil
+}
+
+func (s *FactoryPlanningSession) findRefineWorkOrder(tx *gorm.DB, factoryModel *Factory, key string) (*FactoryWorkOrder, error) {
+	orders, err := s.CreatedOrders(tx)
+	if err != nil {
+		return nil, err
 	}
 	for i := range orders {
 		if factoryModel.WorkOrderKey(orders[i].Number) != key {
 			continue
 		}
-		s.setDraft(PlanningSessionDraft{
-			Title:       orders[i].Title,
-			Description: orders[i].Description,
-			WorkOrderID: orders[i].ID.String(),
-		})
-		return true, nil
+		return &orders[i], nil
 	}
-	return false, nil
+	return factoryModel.findDraftWorkOrderByKey(tx, key)
+}
+
+func (f *Factory) findDraftWorkOrderByKey(tx *gorm.DB, key string) (*FactoryWorkOrder, error) {
+	number, ok := f.workOrderNumberFromKey(key)
+	if !ok {
+		return nil, nil
+	}
+	var order FactoryWorkOrder
+	err := tx.Where("organization_id = ? AND factory_id = ? AND number = ?", f.OrganizationID, f.ID, number).First(&order).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if order.State != FactoryWorkOrderStateDraft {
+		return nil, nil
+	}
+	return &order, nil
+}
+
+func (f *Factory) workOrderNumberFromKey(key string) (int64, bool) {
+	rest, ok := strings.CutPrefix(strings.TrimSpace(key), f.Key+"-")
+	if !ok {
+		return 0, false
+	}
+	number, err := strconv.ParseInt(rest, 10, 64)
+	if err != nil || number <= 0 {
+		return 0, false
+	}
+	return number, true
+}
+
+func (s *FactoryPlanningSession) attachCreatedWorkOrder(tx *gorm.DB, orderID uuid.UUID) error {
+	link := FactoryPlanningSessionWorkOrder{
+		SessionID:   s.ID,
+		WorkOrderID: orderID,
+	}
+	return tx.Where(link).Attrs(FactoryPlanningSessionWorkOrder{CreatedAt: time.Now()}).FirstOrCreate(&link).Error
 }
 
 func (s *FactoryPlanningSession) updateCreatedWorkOrder(

--- a/pkg/models/factory_planning_session_draft.go
+++ b/pkg/models/factory_planning_session_draft.go
@@ -137,15 +137,22 @@ func (s *FactoryPlanningSession) applyRefineNote(tx *gorm.DB, text string) (bool
 	if order == nil {
 		return false, nil
 	}
-	if err := s.attachCreatedWorkOrder(tx, order.ID); err != nil {
+	if err := s.attachRefineDraft(tx, order); err != nil {
 		return false, err
+	}
+	return true, nil
+}
+
+func (s *FactoryPlanningSession) attachRefineDraft(tx *gorm.DB, order *FactoryWorkOrder) error {
+	if err := s.attachCreatedWorkOrder(tx, order.ID); err != nil {
+		return err
 	}
 	s.setDraft(PlanningSessionDraft{
 		Title:       order.Title,
 		Description: order.Description,
 		WorkOrderID: order.ID.String(),
 	})
-	return true, nil
+	return s.saveDraft(tx)
 }
 
 func (s *FactoryPlanningSession) findRefineWorkOrder(tx *gorm.DB, factoryModel *Factory, key string) (*FactoryWorkOrder, error) {

--- a/pkg/models/factory_planning_session_test.go
+++ b/pkg/models/factory_planning_session_test.go
@@ -54,6 +54,70 @@ func TestFactory_StartPlanningSession_RequiresRepository(t *testing.T) {
 	assert.ErrorIs(t, err, ErrFactoryPlanningSessionInvalid)
 }
 
+func TestFactory_StartPlanningSession_AttachesDraftWorkOrder(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+	org, userID, factoryModel := setupFactoryWithUser(t, "plan-refine-start")
+	db := database.Conn()
+	canvas, entrypoint := createPlanningCanvas(t, org.ID, factoryModel.ID, userID)
+	order, err := factoryModel.CreateWorkOrder(db, "Retry refunds", "Stop double charges.", &userID, nil, nil)
+	require.NoError(t, err)
+
+	session, err := factoryModel.StartPlanningSession(db, StartPlanningSessionParams{
+		CreatedByUserID: userID,
+		Repository:      "acme/payments",
+		CanvasID:        canvas.ID,
+		Entrypoint:      entrypoint,
+		WorkOrderID:     order.ID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, order.Title, session.Draft().Title)
+	assert.Equal(t, order.Description, session.Draft().Description)
+	assert.Equal(t, order.ID.String(), session.Draft().WorkOrderID)
+	ids, err := session.CreatedWorkOrderIDs(db)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	assert.Equal(t, order.ID.String(), ids[0])
+
+	var run CanvasRun
+	require.NoError(t, db.First(&run, "id = ?", session.CanvasRunID).Error)
+	planning := planningSessionInputFromRun(t, run)
+	assert.Equal(t, factoryModel.WorkOrderKey(order.Number), planning["refine_key"])
+	assert.Equal(t, order.Title, planning["refine_title"])
+	assert.Equal(t, order.Description, planning["refine_description"])
+}
+
+func TestFactory_StartPlanningSession_RejectsOpenWorkOrder(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+	org, userID, factoryModel := setupFactoryWithUser(t, "plan-refine-open-start")
+	db := database.Conn()
+	canvas, entrypoint := createPlanningCanvas(t, org.ID, factoryModel.ID, userID)
+	order, err := factoryModel.CreateWorkOrder(db, "Retry refunds", "Stop double charges.", &userID, nil, nil)
+	require.NoError(t, err)
+	_, err = order.UpdateStatus(db, FactoryWorkOrderStatusUpdate{
+		ToState: FactoryWorkOrderStateOpen,
+		Actor:   &userID,
+	})
+	require.NoError(t, err)
+
+	_, err = factoryModel.StartPlanningSession(db, StartPlanningSessionParams{
+		CreatedByUserID: userID,
+		Repository:      "acme/payments",
+		CanvasID:        canvas.ID,
+		Entrypoint:      entrypoint,
+		WorkOrderID:     order.ID,
+	})
+	assert.ErrorIs(t, err, ErrFactoryPlanningSessionInvalid)
+}
+
+func planningSessionInputFromRun(t *testing.T, run CanvasRun) map[string]any {
+	t.Helper()
+	input, ok := run.Input.Data().(map[string]any)
+	require.True(t, ok)
+	planning, ok := input["planning_session"].(map[string]any)
+	require.True(t, ok)
+	return planning
+}
+
 func TestFactoryPlanningSession_HeartbeatAndEnd(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-hb")

--- a/pkg/models/factory_planning_session_test.go
+++ b/pkg/models/factory_planning_session_test.go
@@ -400,6 +400,27 @@ func TestFactoryPlanningSession_RefineNoteAsksWhatToChange(t *testing.T) {
 	assert.NotEqual(t, note, result.Text)
 }
 
+func TestFactoryPlanningSession_FollowUpKeepsCurrentDraftInWaitText(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+	session := startTestPlanningSession(t, "plan-follow-draft")
+	db := database.Conn()
+
+	require.NoError(t, session.ProposeDraft(db, PlanningSessionDraft{
+		Title:       "Add a color field with a visual color picker to the Puppy entity",
+		Description: "Add a color attribute and a picker on the Puppy form.",
+	}))
+	require.NoError(t, session.BeginWait(db))
+	require.NoError(t, session.SendUserMessage(db, "I actually want this to be about size and not color"))
+	assert.Equal(t, "I actually want this to be about size and not color", lastTextMessage(session, PlanningSessionMessageRoleUser))
+	result := session.Wait()
+	assert.Equal(t, PlanningWaitKindMessage, result.Kind)
+	assert.Contains(t, result.Text, "Add a color field with a visual color picker to the Puppy entity")
+	assert.Contains(t, result.Text, "Add a color attribute and a picker on the Puppy form.")
+	assert.Contains(t, result.Text, "I actually want this to be about size and not color")
+	assert.Contains(t, result.Text, "this draft")
+	assert.NotEqual(t, "I actually want this to be about size and not color", result.Text)
+}
+
 func TestFactoryPlanningSession_RefineNoteReloadsDraftAndUpdatesSameTask(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-refine")

--- a/pkg/models/factory_planning_session_test.go
+++ b/pkg/models/factory_planning_session_test.go
@@ -414,6 +414,67 @@ func TestFactoryPlanningSession_RefineNoteLeavesOrdinaryChatAlone(t *testing.T) 
 	assert.Equal(t, "", session.Draft().WorkOrderID)
 }
 
+func TestFactoryPlanningSession_RefineNoteAttachesExistingBacklogDraftAndUpdatesSameTask(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+	session := startTestPlanningSession(t, "plan-refine-backlog")
+	db := database.Conn()
+	factoryModel, err := FindFactory(db, session.OrganizationID, session.FactoryID)
+	require.NoError(t, err)
+
+	order, err := factoryModel.CreateWorkOrder(db, "Retry refunds", "Stop double charges.", &session.CreatedByUserID, nil, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, session.BeginWait(db))
+	require.NoError(t, session.SendUserMessage(db, PlanningRefineNote(factoryModel.WorkOrderKey(order.Number), order.Title)))
+	assert.Equal(t, order.Title, session.Draft().Title)
+	assert.Equal(t, order.Description, session.Draft().Description)
+	assert.Equal(t, order.ID.String(), session.Draft().WorkOrderID)
+	ids, err := session.CreatedWorkOrderIDs(db)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	assert.Equal(t, order.ID.String(), ids[0])
+
+	require.NoError(t, session.ProposeDraft(db, PlanningSessionDraft{
+		Title:       "Retry refunds once",
+		Description: "Agent edit.",
+	}))
+	assert.Equal(t, order.ID.String(), session.Draft().WorkOrderID)
+
+	updated, err := session.CreateDraftWorkOrder(db, factoryModel, session.CreatedByUserID)
+	require.NoError(t, err)
+	assert.Equal(t, order.ID, updated.ID)
+	assert.Equal(t, "Retry refunds once", updated.Title)
+	assert.Equal(t, "Agent edit.", updated.Description)
+	ids, err = session.CreatedWorkOrderIDs(db)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+}
+
+func TestFactoryPlanningSession_RefineNoteIgnoresOpenWorkOrder(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+	session := startTestPlanningSession(t, "plan-refine-open")
+	db := database.Conn()
+	factoryModel, err := FindFactory(db, session.OrganizationID, session.FactoryID)
+	require.NoError(t, err)
+
+	order, err := factoryModel.CreateWorkOrder(db, "Retry refunds", "Stop double charges.", &session.CreatedByUserID, nil, nil)
+	require.NoError(t, err)
+	_, err = order.UpdateStatus(db, FactoryWorkOrderStatusUpdate{
+		ToState: FactoryWorkOrderStateOpen,
+		Actor:   &session.CreatedByUserID,
+	})
+	require.NoError(t, err)
+
+	note := PlanningRefineNote(factoryModel.WorkOrderKey(order.Number), order.Title)
+	require.NoError(t, session.BeginWait(db))
+	require.NoError(t, session.SendUserMessage(db, note))
+	assert.Equal(t, note, session.Wait().Text)
+	assert.Equal(t, "", session.Draft().WorkOrderID)
+	ids, err := session.CreatedWorkOrderIDs(db)
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
 func TestEndPlanningSessionForFinishedRun(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-run-fail")

--- a/pkg/models/factory_planning_session_test.go
+++ b/pkg/models/factory_planning_session_test.go
@@ -15,7 +15,7 @@ import (
 func TestFactory_StartPlanningSession(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	org, userID, factoryModel := setupFactoryWithUser(t, "plan-start")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	canvas, entrypoint := createPlanningCanvas(t, org.ID, factoryModel.ID, userID)
 
 	session, err := factoryModel.StartPlanningSession(db, StartPlanningSessionParams{
@@ -43,7 +43,7 @@ func TestFactory_StartPlanningSession(t *testing.T) {
 func TestFactory_StartPlanningSession_RequiresRepository(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	org, userID, factoryModel := setupFactoryWithUser(t, "plan-repo")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	canvas, entrypoint := createPlanningCanvas(t, org.ID, factoryModel.ID, userID)
 
 	_, err := factoryModel.StartPlanningSession(db, StartPlanningSessionParams{
@@ -57,7 +57,7 @@ func TestFactory_StartPlanningSession_RequiresRepository(t *testing.T) {
 func TestFactory_StartPlanningSession_AttachesDraftWorkOrder(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	org, userID, factoryModel := setupFactoryWithUser(t, "plan-refine-start")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	canvas, entrypoint := createPlanningCanvas(t, org.ID, factoryModel.ID, userID)
 	order, err := factoryModel.CreateWorkOrder(db, "Retry refunds", "Stop double charges.", &userID, nil, nil)
 	require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestFactory_StartPlanningSession_AttachesDraftWorkOrder(t *testing.T) {
 func TestFactory_StartPlanningSession_RejectsOpenWorkOrder(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	org, userID, factoryModel := setupFactoryWithUser(t, "plan-refine-open-start")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	canvas, entrypoint := createPlanningCanvas(t, org.ID, factoryModel.ID, userID)
 	order, err := factoryModel.CreateWorkOrder(db, "Retry refunds", "Stop double charges.", &userID, nil, nil)
 	require.NoError(t, err)
@@ -121,7 +121,7 @@ func planningSessionInputFromRun(t *testing.T, run CanvasRun) map[string]any {
 func TestFactoryPlanningSession_HeartbeatAndEnd(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-hb")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	before := session.HeartbeatAt
 	require.NoError(t, session.Heartbeat(db))
@@ -140,7 +140,7 @@ func TestFactoryPlanningSession_HeartbeatAndEnd(t *testing.T) {
 func TestFactoryPlanningSession_EndIfStale(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-stale")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	require.NoError(t, db.Model(session).Update("heartbeat_at", time.Now().Add(-6*time.Minute)).Error)
 	require.NoError(t, db.First(session, "id = ?", session.ID).Error)
@@ -154,7 +154,7 @@ func TestFactoryPlanningSession_EndIfStale(t *testing.T) {
 func TestFactoryPlanningSession_EndIfStale_KeepsRecentHeartbeat(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-fresh-hb")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	require.NoError(t, db.Model(session).Update("heartbeat_at", time.Now().Add(-2*time.Minute)).Error)
 	require.NoError(t, db.First(session, "id = ?", session.ID).Error)
@@ -168,7 +168,7 @@ func TestFactoryPlanningSession_EndIfStale_KeepsRecentHeartbeat(t *testing.T) {
 func TestFactoryPlanningSession_SendMessageResolvesWait(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-wait")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	require.NoError(t, session.BeginWait(db))
 	assert.Equal(t, PlanningWaitPending, session.WaitState)
@@ -193,7 +193,7 @@ func TestFactoryPlanningSession_SendMessageResolvesWait(t *testing.T) {
 func TestFactoryPlanningSession_RestoreWaitKeepsQueuedUserMessage(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-restore-queue")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	require.NoError(t, session.BeginWait(db))
 	require.NoError(t, session.SendUserMessage(db, "Add refund retries"))
@@ -216,7 +216,7 @@ func TestFactoryPlanningSession_RestoreWaitKeepsQueuedUserMessage(t *testing.T) 
 func TestFactoryPlanningSession_BeginWaitDeliversQueuedUserMessage(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-queue")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	require.NoError(t, session.SendUserMessage(db, "Add a puppy color field"))
 	assert.Equal(t, PlanningWaitIdle, session.WaitState)
@@ -234,7 +234,7 @@ func TestFactoryPlanningSession_BeginWaitDeliversQueuedUserMessage(t *testing.T)
 func TestFactoryPlanningSession_CreateDraftBeforeWaitIsKept(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-create-early")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	factoryModel, err := FindFactory(db, session.OrganizationID, session.FactoryID)
 	require.NoError(t, err)
 
@@ -258,7 +258,7 @@ func TestFactoryPlanningSession_CreateDraftBeforeWaitIsKept(t *testing.T) {
 func TestFactoryPlanningSession_SkipDraftBeforeWaitIsKept(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-skip-early")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	require.NoError(t, session.ProposeDraft(db, PlanningSessionDraft{
 		Title:       "Retry refunds",
@@ -277,7 +277,7 @@ func TestFactoryPlanningSession_SkipDraftBeforeWaitIsKept(t *testing.T) {
 func TestFactoryPlanningSession_ProposeSurveyAndSendClearsIt(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-survey")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	require.NoError(t, session.ProposeSurvey(db, PlanningSessionSurvey{
 		Questions: []PlanningSessionSurveyQuestion{
@@ -297,7 +297,7 @@ func TestFactoryPlanningSession_ProposeSurveyAndSendClearsIt(t *testing.T) {
 func TestFactoryPlanningSession_ProposeSurveyRejectsEmptyQuestions(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-survey-empty")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	err := session.ProposeSurvey(db, PlanningSessionSurvey{})
 	assert.ErrorIs(t, err, ErrFactoryPlanningSessionInvalid)
@@ -307,7 +307,7 @@ func TestFactoryPlanningSession_ProposeSurveyRejectsEmptyQuestions(t *testing.T)
 func TestFactoryPlanningSession_ProposeSurveyReplacesPrevious(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-survey-replace")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	require.NoError(t, session.ProposeSurvey(db, PlanningSessionSurvey{
 		Questions: []PlanningSessionSurveyQuestion{
@@ -326,7 +326,7 @@ func TestFactoryPlanningSession_ProposeSurveyReplacesPrevious(t *testing.T) {
 func TestFactoryPlanningSession_ProposeAndSkipDraft(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-draft")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	require.NoError(t, session.ProposeDraft(db, PlanningSessionDraft{
 		Title:       "Retry refunds",
@@ -347,7 +347,7 @@ func TestFactoryPlanningSession_ProposeAndSkipDraft(t *testing.T) {
 func TestFactoryPlanningSession_CreateDraftWorkOrder(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-create")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	factoryModel, err := FindFactory(db, session.OrganizationID, session.FactoryID)
 	require.NoError(t, err)
 
@@ -372,7 +372,7 @@ func TestFactoryPlanningSession_CreateDraftWorkOrder(t *testing.T) {
 func TestFactoryPlanningSession_RefineNoteAsksWhatToChange(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-refine-ready")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	factoryModel, err := FindFactory(db, session.OrganizationID, session.FactoryID)
 	require.NoError(t, err)
 
@@ -403,7 +403,7 @@ func TestFactoryPlanningSession_RefineNoteAsksWhatToChange(t *testing.T) {
 func TestFactoryPlanningSession_FollowUpKeepsCurrentDraftInWaitText(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-follow-draft")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	require.NoError(t, session.ProposeDraft(db, PlanningSessionDraft{
 		Title:       "Add a color field with a visual color picker to the Puppy entity",
@@ -424,7 +424,7 @@ func TestFactoryPlanningSession_FollowUpKeepsCurrentDraftInWaitText(t *testing.T
 func TestFactoryPlanningSession_RefineNoteReloadsDraftAndUpdatesSameTask(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-refine")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	factoryModel, err := FindFactory(db, session.OrganizationID, session.FactoryID)
 	require.NoError(t, err)
 
@@ -464,7 +464,7 @@ func TestFactoryPlanningSession_RefineNoteReloadsDraftAndUpdatesSameTask(t *test
 func TestFactoryPlanningSession_SkipAfterRefineKeepsCreatedTask(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-refine-skip")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	factoryModel, err := FindFactory(db, session.OrganizationID, session.FactoryID)
 	require.NoError(t, err)
 
@@ -490,7 +490,7 @@ func TestFactoryPlanningSession_SkipAfterRefineKeepsCreatedTask(t *testing.T) {
 func TestFactoryPlanningSession_RefineNoteLeavesOrdinaryChatAlone(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-refine-chat")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	require.NoError(t, session.BeginWait(db))
 	require.NoError(t, session.SendUserMessage(db, "Refine checkout: please."))
@@ -502,7 +502,7 @@ func TestFactoryPlanningSession_RefineNoteLeavesOrdinaryChatAlone(t *testing.T) 
 func TestFactoryPlanningSession_RefineNoteAttachesExistingBacklogDraftAndUpdatesSameTask(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-refine-backlog")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	factoryModel, err := FindFactory(db, session.OrganizationID, session.FactoryID)
 	require.NoError(t, err)
 
@@ -538,7 +538,7 @@ func TestFactoryPlanningSession_RefineNoteAttachesExistingBacklogDraftAndUpdates
 func TestFactoryPlanningSession_RefineNoteIgnoresOpenWorkOrder(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-refine-open")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	factoryModel, err := FindFactory(db, session.OrganizationID, session.FactoryID)
 	require.NoError(t, err)
 
@@ -563,7 +563,7 @@ func TestFactoryPlanningSession_RefineNoteIgnoresOpenWorkOrder(t *testing.T) {
 func TestEndPlanningSessionForFinishedRun(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-run-fail")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	require.NotNil(t, session.CanvasRunID)
 
 	require.NoError(t, EndPlanningSessionForFinishedRun(db, *session.CanvasRunID, CanvasRunResultPassed))
@@ -581,7 +581,7 @@ func TestEndPlanningSessionForFinishedRun(t *testing.T) {
 func TestEndPlanningSessionForFinishedRun_Cancelled(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-run-cancel")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	require.NotNil(t, session.CanvasRunID)
 
 	require.NoError(t, EndPlanningSessionForFinishedRun(db, *session.CanvasRunID, CanvasRunResultCancelled))
@@ -593,7 +593,7 @@ func TestEndPlanningSessionForFinishedRun_Cancelled(t *testing.T) {
 func TestEndPlanningSessionForFinishedRun_AlreadyEnded(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-run-ended")
-	db := database.Conn()
+	db := database.DB(t.Context())
 	require.NoError(t, session.End(db))
 	require.NotNil(t, session.CanvasRunID)
 
@@ -605,14 +605,14 @@ func TestEndPlanningSessionForFinishedRun_AlreadyEnded(t *testing.T) {
 
 func TestEndPlanningSessionForFinishedRun_NoSession(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
-	require.NoError(t, EndPlanningSessionForFinishedRun(database.Conn(), uuid.New(), CanvasRunResultFailed))
+	require.NoError(t, EndPlanningSessionForFinishedRun(database.DB(t.Context()), uuid.New(), CanvasRunResultFailed))
 }
 
 func TestFactoryPlanningSession_ListStaleOpenPlanningSessions(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-list-stale")
 	fresh := startTestPlanningSession(t, "plan-list-fresh")
-	db := database.Conn()
+	db := database.DB(t.Context())
 
 	require.NoError(t, db.Model(session).Update("heartbeat_at", time.Now().Add(-6*time.Minute)).Error)
 
@@ -626,7 +626,7 @@ func TestFactoryPlanningSession_ListStaleOpenPlanningSessions(t *testing.T) {
 func startTestPlanningSession(t *testing.T, prefix string) *FactoryPlanningSession {
 	t.Helper()
 	org, userID, factoryModel := setupFactoryWithUser(t, prefix)
-	db := database.Conn()
+	db := database.DB(t.Context())
 	canvas, entrypoint := createPlanningCanvas(t, org.ID, factoryModel.ID, userID)
 	session, err := factoryModel.StartPlanningSession(db, StartPlanningSessionParams{
 		CreatedByUserID: userID,
@@ -653,7 +653,7 @@ func createPlanningCanvas(t *testing.T, orgID, factoryID, userID uuid.UUID) (*Ca
 		CreatedAt:      &now,
 		UpdatedAt:      &now,
 	}
-	require.NoError(t, database.Conn().Transaction(func(tx *gorm.DB) error {
+	require.NoError(t, database.DB(t.Context()).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(canvas).Error; err != nil {
 			return err
 		}

--- a/pkg/models/factory_planning_session_wait.go
+++ b/pkg/models/factory_planning_session_wait.go
@@ -111,5 +111,27 @@ func planningWaitText(text string, refined bool, draft PlanningSessionDraft) str
 	if refined {
 		return planningRefinePrompt(text, draft)
 	}
-	return text
+	return planningDraftFollowUpPrompt(text, draft)
+}
+
+func planningDraftFollowUpPrompt(text string, draft PlanningSessionDraft) string {
+	if strings.TrimSpace(draft.Title) == "" && strings.TrimSpace(draft.Description) == "" && strings.TrimSpace(draft.WorkOrderID) == "" {
+		return text
+	}
+	var b strings.Builder
+	b.WriteString("The user is talking about this draft. Do not ask which task they mean.\n\n")
+	if title := strings.TrimSpace(draft.Title); title != "" {
+		b.WriteString("Title: ")
+		b.WriteString(title)
+		b.WriteString("\n\n")
+	}
+	if description := strings.TrimSpace(draft.Description); description != "" {
+		b.WriteString("Description:\n")
+		b.WriteString(description)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("User message:\n")
+	b.WriteString(text)
+	b.WriteString("\n\nApply this change to this draft. When they asked you to change it, call propose_draft with the updated title and description.")
+	return b.String()
 }

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -2054,6 +2054,7 @@ message UsageByMachineType {
 message PlanningSessionDraft {
   string title = 1;
   string description = 2;
+  string work_order_id = 3;
 }
 
 message PlanningSessionCreatedOrder {
@@ -2098,6 +2099,7 @@ message PlanningSession {
 message StartPlanningSessionRequest {
   string factory_id = 1;
   string repository = 2;
+  string work_order_id = 3;
 }
 
 message StartPlanningSessionResponse {

--- a/web_src/src/pages/factories/WorkOrderDescription.spec.tsx
+++ b/web_src/src/pages/factories/WorkOrderDescription.spec.tsx
@@ -43,6 +43,23 @@ describe("WorkOrderDescription", () => {
     expect(screen.queryByRole("button", { name: /show more/i })).not.toBeInTheDocument();
   });
 
+  it("does not add Show more when collapse is off", () => {
+    render(
+      <div data-testid="description-pane" style={{ overflowY: "auto", padding: "24px 0" }}>
+        <WorkOrderDescription description="# Test description" collapsible={false} />
+      </div>,
+    );
+
+    const pane = screen.getByTestId("description-pane");
+    Object.defineProperty(pane, "clientHeight", { configurable: true, get: () => 520 });
+    const content = screen.getByTestId("work-order-description-markdown").parentElement;
+    Object.defineProperty(content!, "scrollHeight", { configurable: true, get: () => 640 });
+
+    act(() => notifyResize());
+    expect(screen.queryByRole("button", { name: /show more/i })).not.toBeInTheDocument();
+    expect(content).not.toHaveStyle({ maxHeight: "440px" });
+  });
+
   it("keeps the body open when it fits the scroll pane", () => {
     const contentHeight = 360;
     render(

--- a/web_src/src/pages/factories/WorkOrderDescription.tsx
+++ b/web_src/src/pages/factories/WorkOrderDescription.tsx
@@ -19,15 +19,20 @@ import {
 interface WorkOrderDescriptionProps {
   description: string;
   className?: string;
+  /** When false, always show the full markdown. Default is true. */
+  collapsible?: boolean;
 }
 
-export function WorkOrderDescription({ description, className }: WorkOrderDescriptionProps) {
+export function WorkOrderDescription({ description, className, collapsible = true }: WorkOrderDescriptionProps) {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const [needsToggle, setNeedsToggle] = useState(false);
   const [collapsedMaxHeight, setCollapsedMaxHeight] = useState(FALLBACK_COLLAPSED_MAX_HEIGHT_PX);
 
   useLayoutEffect(() => {
+    if (!collapsible) {
+      return;
+    }
     const content = contentRef.current;
     if (!content) {
       return;
@@ -52,21 +57,19 @@ export function WorkOrderDescription({ description, className }: WorkOrderDescri
       }
     }
     return () => observer.disconnect();
-  }, [description]);
+  }, [description, collapsible]);
 
   if (!description.trim()) {
     return null;
   }
 
-  const showFade = needsToggle && !isExpanded;
+  const showFade = collapsible && needsToggle && !isExpanded;
+  const clamp = collapsible && !isExpanded && needsToggle;
 
   return (
     <section className={className} data-testid="work-order-description">
       <div className="relative">
-        <div
-          ref={contentRef}
-          style={!isExpanded && needsToggle ? { maxHeight: `${collapsedMaxHeight}px`, overflow: "hidden" } : undefined}
-        >
+        <div ref={contentRef} style={clamp ? { maxHeight: `${collapsedMaxHeight}px`, overflow: "hidden" } : undefined}>
           <MarkdownContent content={description} variant="workspace" data-testid="work-order-description-markdown" />
         </div>
         {showFade ? (
@@ -77,7 +80,7 @@ export function WorkOrderDescription({ description, className }: WorkOrderDescri
         ) : null}
       </div>
 
-      {needsToggle ? (
+      {collapsible && needsToggle ? (
         <Button
           type="button"
           variant="ghost"

--- a/web_src/src/pages/factories/pages/BacklogColumn.tsx
+++ b/web_src/src/pages/factories/pages/BacklogColumn.tsx
@@ -1,21 +1,16 @@
 import type { FactoriesWorkOrder } from "@/api-client";
 
-import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
 import { WorkOrderBoardLane, workOrderKanbanLaneScrollClassName } from "../workOrders/WorkOrderBoardChrome";
 import type { WorkOrderCardContext } from "../workOrders/WorkOrderCard";
 import { BacklogCreatePopover } from "./BacklogCreatePopover";
 import { BacklogIntakeSources } from "./BacklogIntakeSources";
 import { BacklogSettingsDialog } from "./BacklogSettingsDialog";
 import { ColumnLaneMenu } from "./ColumnLaneMenu";
-import { CreateWithAgentDialog } from "./CreateWithAgentDialog";
-import { usePlanningSessionLiveRun } from "./usePlanningSessionLiveRun";
 import { LineBoardOrderCard } from "./LineBoardOrderCard";
 import { lineBoardColumnLaneClassName, type LineBoardColumnColorId } from "./lineBoardColumnColors";
 import { isFirstRunOnboardingFactory, type ConfiguredLineIntakeSource } from "./lineIntakeModel";
 import { BacklogOnboardingCard } from "./onboarding/first-run/BacklogOnboardingCard";
-import { workspacePlanningRepository } from "./planningSessionView";
 import { useBacklogCreateMenu } from "./useBacklogCreateMenu";
-import { useCreateWithAgentSession } from "./useCreateWithAgentSession";
 
 export type BacklogColumnProps = {
   organizationId: string;
@@ -34,6 +29,7 @@ export type BacklogColumnProps = {
   canRename: boolean;
   onRename: (title: string) => void;
   onCreateWorkOrder: () => void;
+  onCreateWithAgent: () => void;
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string, order?: FactoriesWorkOrder) => void;
   /** Tasks the Backlog automation analyzes right now. */
@@ -71,6 +67,7 @@ export function BacklogColumn({
   canRename,
   onRename,
   onCreateWorkOrder,
+  onCreateWithAgent,
   workOrderCardContext,
   onOpenWorkOrder,
   analyzingOrderIds,
@@ -81,15 +78,13 @@ export function BacklogColumn({
   const surfaceClassName = lineBoardColumnLaneClassName(colorId);
   const atCapacity = size != null && orders.length >= size;
   const canAdd = canCreateWorkOrder && !atCapacity;
-  const { factory } = useFactoriesLayout();
   const createMenu = useBacklogCreateMenu(organizationId, factoryId, onOpenWorkOrder);
-  const agentSession = useCreateWithAgentSession(workspacePlanningRepository(factory), organizationId, factoryId);
   const createPopover = backlogCreatePopoverProps({
     canAdd,
     atCapacity,
     createMenu,
     onCreateWorkOrder,
-    onCreateWithAgent: agentSession.start,
+    onCreateWithAgent,
   });
 
   return (
@@ -158,40 +153,7 @@ export function BacklogColumn({
         onSave={onSaveSettings}
         onClose={onCloseSettings}
       />
-      <BacklogCreateWithAgentDialog factoryKey={factoryKey} organizationId={organizationId} session={agentSession} />
     </>
-  );
-}
-
-function BacklogCreateWithAgentDialog({
-  factoryKey,
-  organizationId,
-  session,
-}: {
-  factoryKey: string;
-  organizationId: string;
-  session: ReturnType<typeof useCreateWithAgentSession>;
-}) {
-  const view = usePlanningSessionLiveRun(organizationId, session.view);
-  return (
-    <CreateWithAgentDialog
-      open={session.open}
-      workspaceName={factoryKey}
-      organizationId={organizationId}
-      view={view}
-      onComposerChange={session.onComposerChange}
-      onSend={session.onSend}
-      onSubmitSurvey={session.onSubmitSurvey}
-      onDraftTitleChange={session.onDraftTitleChange}
-      onDraftDescriptionChange={session.onDraftDescriptionChange}
-      onCreateDraft={session.onCreateDraft}
-      onSkipDraft={session.onSkipDraft}
-      onSelectCreated={session.onSelectCreated}
-      onRefineCreated={session.onRefineCreated}
-      onRequestClose={session.onRequestClose}
-      onCancelEnd={session.onCancelEnd}
-      onConfirmEnd={session.onConfirmEnd}
-    />
   );
 }
 

--- a/web_src/src/pages/factories/pages/CreateWithAgent.stories.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgent.stories.tsx
@@ -46,13 +46,6 @@ function StaticSession({ initial }: { initial: CreateWithAgentView }) {
               : current,
           )
         }
-        onDraftDescriptionChange={(description) =>
-          setView((current) =>
-            current.right.kind === "draft"
-              ? { ...current, right: { kind: "draft", draft: { ...current.right.draft, description } } }
-              : current,
-          )
-        }
         onCreateDraft={() => undefined}
         onSkipDraft={() => undefined}
         onSelectCreated={(order) => setView((current) => ({ ...current, right: { kind: "preview", order } }))}

--- a/web_src/src/pages/factories/pages/CreateWithAgentDialog.spec.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgentDialog.spec.tsx
@@ -222,6 +222,21 @@ describe("CreateWithAgentDialog", () => {
     expect(within(draft).queryByRole("button", { name: /show more/i })).not.toBeInTheDocument();
   });
 
+  it("wraps a long draft title", () => {
+    const title = "Add a color field with a visual color picker to the Puppy entity";
+    renderDialog(
+      runningCreateWithAgentView({
+        right: { kind: "draft", draft: { title, description: "Add a color field." } },
+      }),
+    );
+
+    const field = screen.getByLabelText("Task title");
+    expect(field).toHaveValue(title);
+    expect(field.tagName).toBe("TEXTAREA");
+    expect(field).toHaveClass("wrap-anywhere");
+    expect(field).not.toHaveClass("truncate");
+  });
+
   it("renders preview description markdown like the task popup", () => {
     const order = {
       id: "wo-1",

--- a/web_src/src/pages/factories/pages/CreateWithAgentDialog.spec.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgentDialog.spec.tsx
@@ -204,6 +204,7 @@ describe("CreateWithAgentDialog", () => {
     expect(within(draft).getByTestId("work-order-description-markdown")).toHaveTextContent("Add a color field.");
     expect(within(draft).getByRole("button", { name: "Edit" })).toBeInTheDocument();
     expect(screen.queryByTestId("create-with-agent-draft-description")).not.toBeInTheDocument();
+    expect(within(draft).queryByRole("button", { name: /show more/i })).not.toBeInTheDocument();
   });
 
   it("renders preview description markdown like the task popup", () => {
@@ -225,6 +226,7 @@ describe("CreateWithAgentDialog", () => {
     expect(within(preview).queryByText(/## Data model/)).not.toBeInTheDocument();
     expect(within(preview).getByTestId("work-order-description-markdown")).toHaveTextContent("Add a color field.");
     expect(within(preview).queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(within(preview).queryByRole("button", { name: /show more/i })).not.toBeInTheDocument();
   });
 
   it("shows a read-only task without edit fields", () => {

--- a/web_src/src/pages/factories/pages/CreateWithAgentDialog.spec.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgentDialog.spec.tsx
@@ -82,6 +82,18 @@ describe("CreateWithAgentDialog", () => {
     expect(screen.getByTestId("create-with-agent-machine")).toHaveTextContent("acme/payments");
   });
 
+  it("titles the dialog as Refine this task when the session already has a draft", () => {
+    renderDialog(
+      runningCreateWithAgentView({
+        refining: true,
+        right: { kind: "draft", draft: { title: "Retry refunds", description: "Stop double charges." } },
+      }),
+    );
+
+    expect(screen.getByRole("heading", { name: CREATE_WITH_AGENT_COPY.titleRefine })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: CREATE_WITH_AGENT_COPY.title })).not.toBeInTheDocument();
+  });
+
   it("shows a planning-session intro while the log is empty", () => {
     renderDialog(emptyCreateWithAgentView());
 

--- a/web_src/src/pages/factories/pages/CreateWithAgentDialog.spec.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgentDialog.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -55,8 +55,10 @@ describe("CreateWithAgentDialog", () => {
 
     expect(screen.getByTestId("create-with-agent-dialog")).toBeInTheDocument();
     expect(screen.getByTestId(`split-run-phase-${PLANNING_SESSION_PHASE_ID}`)).toBeInTheDocument();
-    expect(screen.getByTestId("create-with-agent-stream")).toHaveTextContent(CREATE_WITH_AGENT_COPY.menu);
-    expect(screen.getByTestId("create-with-agent-stream")).toHaveTextContent("Agent");
+    expect(screen.queryByTestId(`split-run-automation-header-${PLANNING_SESSION_PHASE_ID}`)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("split-run-stream-line-agent")).not.toBeInTheDocument();
+    expect(screen.getByTestId("create-with-agent-stream")).not.toHaveTextContent(CREATE_WITH_AGENT_COPY.menu);
+    expect(screen.getByTestId("create-with-agent-stream")).not.toHaveTextContent("Agent");
     expect(screen.getByText(CREATE_WITH_AGENT_COPY.emptyHeadline)).toBeInTheDocument();
     expect(screen.getByTestId("create-with-agent-stream")).toHaveTextContent(CREATE_WITH_AGENT_COPY.greeting);
     expect(screen.queryByTestId("create-with-agent-message-greet")).not.toBeInTheDocument();
@@ -80,13 +82,21 @@ describe("CreateWithAgentDialog", () => {
     expect(screen.getByTestId("create-with-agent-machine")).toHaveTextContent("acme/payments");
   });
 
-  it("shows the Automations stream while the machine is starting", () => {
+  it("shows a planning-session intro while the log is empty", () => {
     renderDialog(emptyCreateWithAgentView());
 
     expect(screen.getByTestId("create-with-agent-machine")).toHaveTextContent(CREATE_WITH_AGENT_COPY.machineStarting);
-    expect(screen.getByTestId(`split-run-phase-${PLANNING_SESSION_PHASE_ID}`)).toBeInTheDocument();
+    expect(screen.getByTestId("create-with-agent-log-intro")).toHaveTextContent(CREATE_WITH_AGENT_COPY.logStarting);
+    expect(screen.queryByTestId(`split-run-phase-${PLANNING_SESSION_PHASE_ID}`)).not.toBeInTheDocument();
     expect(screen.getByTestId("create-with-agent-composer")).toBeEnabled();
     expect(screen.queryByTestId("create-with-agent-activity-starting")).not.toBeInTheDocument();
+  });
+
+  it("hides the log intro after the agent writes", () => {
+    renderDialog(runningCreateWithAgentView());
+
+    expect(screen.queryByTestId("create-with-agent-log-intro")).not.toBeInTheDocument();
+    expect(screen.getByTestId(`split-run-phase-${PLANNING_SESSION_PHASE_ID}`)).toBeInTheDocument();
   });
 
   it("asks before the session ends", () => {
@@ -173,6 +183,48 @@ describe("CreateWithAgentDialog", () => {
 
     screen.getByRole("button", { name: "NEW-1 Retry refunds" }).click();
     expect(onSelectCreated).toHaveBeenCalledWith(order);
+  });
+
+  it("renders draft description markdown like the task popup", () => {
+    renderDialog(
+      runningCreateWithAgentView({
+        right: {
+          kind: "draft",
+          draft: {
+            title: "Add a color attribute to puppies",
+            description: "## Data model\n\nAdd a `color` field.",
+          },
+        },
+      }),
+    );
+
+    const draft = screen.getByTestId("create-with-agent-draft");
+    expect(within(draft).getByRole("heading", { level: 2, name: "Data model" })).toBeInTheDocument();
+    expect(within(draft).queryByText(/## Data model/)).not.toBeInTheDocument();
+    expect(within(draft).getByTestId("work-order-description-markdown")).toHaveTextContent("Add a color field.");
+    expect(within(draft).getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    expect(screen.queryByTestId("create-with-agent-draft-description")).not.toBeInTheDocument();
+  });
+
+  it("renders preview description markdown like the task popup", () => {
+    const order = {
+      id: "wo-1",
+      key: "NEW-1",
+      title: "Add a color attribute to puppies",
+      description: "## Data model\n\nAdd a `color` field.",
+    };
+    renderDialog(
+      runningCreateWithAgentView({
+        created: [order],
+        right: { kind: "preview", order },
+      }),
+    );
+
+    const preview = screen.getByTestId("create-with-agent-preview");
+    expect(within(preview).getByRole("heading", { level: 2, name: "Data model" })).toBeInTheDocument();
+    expect(within(preview).queryByText(/## Data model/)).not.toBeInTheDocument();
+    expect(within(preview).getByTestId("work-order-description-markdown")).toHaveTextContent("Add a color field.");
+    expect(within(preview).queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
   });
 
   it("shows a read-only task without edit fields", () => {

--- a/web_src/src/pages/factories/pages/CreateWithAgentDialog.spec.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgentDialog.spec.tsx
@@ -37,7 +37,6 @@ function renderDialog(view: CreateWithAgentDialogProps["view"]) {
       onSend={noop}
       onSubmitSurvey={noop}
       onDraftTitleChange={noop}
-      onDraftDescriptionChange={noop}
       onCreateDraft={noop}
       onSkipDraft={noop}
       onSelectCreated={noop}
@@ -92,6 +91,12 @@ describe("CreateWithAgentDialog", () => {
 
     expect(screen.getByRole("heading", { name: CREATE_WITH_AGENT_COPY.titleRefine })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: CREATE_WITH_AGENT_COPY.title })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: CREATE_WITH_AGENT_COPY.update })).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("create-with-agent-draft")).queryByRole("button", {
+        name: CREATE_WITH_AGENT_COPY.create,
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows a planning-session intro while the log is empty", () => {
@@ -122,7 +127,6 @@ describe("CreateWithAgentDialog", () => {
         onSend={noop}
         onSubmitSurvey={noop}
         onDraftTitleChange={noop}
-        onDraftDescriptionChange={noop}
         onCreateDraft={noop}
         onSkipDraft={noop}
         onSelectCreated={noop}
@@ -176,7 +180,6 @@ describe("CreateWithAgentDialog", () => {
         onSend={noop}
         onSubmitSurvey={noop}
         onDraftTitleChange={noop}
-        onDraftDescriptionChange={noop}
         onCreateDraft={noop}
         onSkipDraft={noop}
         onSelectCreated={onSelectCreated}
@@ -214,7 +217,7 @@ describe("CreateWithAgentDialog", () => {
     expect(within(draft).getByRole("heading", { level: 2, name: "Data model" })).toBeInTheDocument();
     expect(within(draft).queryByText(/## Data model/)).not.toBeInTheDocument();
     expect(within(draft).getByTestId("work-order-description-markdown")).toHaveTextContent("Add a color field.");
-    expect(within(draft).getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    expect(within(draft).queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
     expect(screen.queryByTestId("create-with-agent-draft-description")).not.toBeInTheDocument();
     expect(within(draft).queryByRole("button", { name: /show more/i })).not.toBeInTheDocument();
   });

--- a/web_src/src/pages/factories/pages/CreateWithAgentDialog.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgentDialog.tsx
@@ -22,6 +22,7 @@ import { PlanningSessionSurveyForm } from "./PlanningSessionSurveyForm";
 import { JumpToLatestPill } from "./work-order-split-run/JumpToLatestPill";
 import { PhaseLogCard } from "./work-order-split-run/PhaseLogCard";
 import { SplitRunAttentionNote } from "./work-order-split-run/SplitRunAttentionNote";
+import { WorkOrderSplitRunDescription } from "./work-order-split-run/WorkOrderSplitRunDescription";
 import { useFollowLogScroll } from "./work-order-split-run/useFollowLogScroll";
 
 export type CreateWithAgentDialogProps = {
@@ -206,14 +207,18 @@ function CreateWithAgentStream({
           className="absolute inset-0 overflow-y-auto px-3 py-3"
           data-testid="create-with-agent-log"
         >
-          <PhaseLogCard
-            phase={planningSessionPhase(view)}
-            expanded
-            collapsible={false}
-            organizationId={organizationId}
-            canvasId={view.canvasId}
-            compactSessionLog
-          />
+          {showCreateWithAgentLogIntro(view) ? (
+            <CreateWithAgentLogIntro />
+          ) : (
+            <PhaseLogCard
+              phase={planningSessionPhase(view)}
+              expanded
+              collapsible={false}
+              organizationId={organizationId}
+              canvasId={view.canvasId}
+              compactSessionLog
+            />
+          )}
         </div>
         {follow.following ? null : (
           <JumpToLatestPill onJumpToLatest={() => follow.setFollowing(true)} testId="create-with-agent-older" />
@@ -264,6 +269,22 @@ function CreateWithAgentStream({
         </div>
       </form>
     </section>
+  );
+}
+
+function showCreateWithAgentLogIntro(view: CreateWithAgentView): boolean {
+  return view.machineStatus === "starting" && view.messages.length === 0;
+}
+
+function CreateWithAgentLogIntro() {
+  return (
+    <div
+      className="flex items-center gap-2 px-2 py-1.5 text-[13px] text-muted-foreground"
+      data-testid="create-with-agent-log-intro"
+    >
+      <Loader2 className="size-3.5 animate-spin" aria-hidden />
+      <p>{CREATE_WITH_AGENT_COPY.logStarting}</p>
+    </div>
   );
 }
 
@@ -407,14 +428,9 @@ function DraftWorkPane({
         data-testid="create-with-agent-draft-title"
         className="mt-3 h-auto border-0 bg-transparent p-0 text-[22px] font-semibold tracking-[-0.02em] shadow-none focus-visible:ring-0"
       />
-      <Textarea
-        value={description}
-        onChange={(event) => onDescriptionChange(event.target.value)}
-        disabled={failed}
-        aria-label="Task description"
-        data-testid="create-with-agent-draft-description"
-        className="mt-3 min-h-0 flex-1 resize-none border-0 bg-transparent p-0 text-[13px] shadow-none focus-visible:ring-0"
-      />
+      <div className="mt-3 min-h-0 flex-1 overflow-y-auto">
+        <WorkOrderSplitRunDescription description={description} canEdit={!failed} onSave={onDescriptionChange} />
+      </div>
       <div className="mt-4 flex justify-end gap-2">
         <Button type="button" variant="ghost" disabled={failed} onClick={onSkip}>
           {CREATE_WITH_AGENT_COPY.skip}
@@ -445,9 +461,9 @@ function PreviewWorkPane({
     <div className="flex min-h-0 flex-1 flex-col px-5 py-4" data-testid="create-with-agent-preview">
       <p className="text-[12px] font-medium text-muted-foreground">{order.key}</p>
       <h2 className="mt-2 text-[22px] font-semibold tracking-[-0.02em]">{order.title}</h2>
-      <p className="mt-3 min-h-0 flex-1 overflow-y-auto text-[13px] leading-relaxed text-muted-foreground">
-        {order.description}
-      </p>
+      <div className="mt-3 min-h-0 flex-1 overflow-y-auto">
+        <WorkOrderSplitRunDescription description={order.description} />
+      </div>
       <div className="mt-4 flex justify-end">
         <Button type="button" variant="outline" disabled={failed} onClick={() => onRefine(order)}>
           {CREATE_WITH_AGENT_COPY.refineFurther}

--- a/web_src/src/pages/factories/pages/CreateWithAgentDialog.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgentDialog.tsx
@@ -75,6 +75,7 @@ export function CreateWithAgentDialog({
             workspaceName={workspaceName}
             repository={view.repository}
             machineStatus={view.machineStatus}
+            refining={view.refining}
             onEndSession={onRequestClose}
           />
           <div className="grid min-h-0 flex-1 grid-cols-1 md:grid-cols-2">
@@ -118,11 +119,13 @@ function CreateWithAgentHeader({
   workspaceName,
   repository,
   machineStatus,
+  refining,
   onEndSession,
 }: {
   workspaceName: string;
   repository: string;
   machineStatus: CreateWithAgentView["machineStatus"];
+  refining: boolean;
   onEndSession: () => void;
 }) {
   const starting = machineStatus === "starting";
@@ -139,9 +142,13 @@ function CreateWithAgentHeader({
         <span className="truncate text-foreground">{workspaceName}</span>
         <span aria-hidden>/</span>
         <DialogTitle className="truncate text-[13px] font-medium text-foreground">
-          {CREATE_WITH_AGENT_COPY.title}
+          {refining ? CREATE_WITH_AGENT_COPY.titleRefine : CREATE_WITH_AGENT_COPY.title}
         </DialogTitle>
-        <DialogDescription className="sr-only">Create tasks with an agent in this workspace.</DialogDescription>
+        <DialogDescription className="sr-only">
+          {refining
+            ? "Refine this task with an agent in this workspace."
+            : "Create tasks with an agent in this workspace."}
+        </DialogDescription>
       </div>
       <div className="flex shrink-0 items-center gap-2">
         <span
@@ -242,14 +249,20 @@ function CreateWithAgentStream({
       ) : null}
       <form className="border-t border-border bg-background p-3" onSubmit={handleSubmit}>
         <label htmlFor="create-with-agent-composer" className="sr-only">
-          {CREATE_WITH_AGENT_COPY.composerPlaceholder}
+          {view.refining
+            ? CREATE_WITH_AGENT_COPY.composerPlaceholderRefine
+            : CREATE_WITH_AGENT_COPY.composerPlaceholder}
         </label>
         <div className="flex items-end gap-2">
           <Textarea
             id="create-with-agent-composer"
             data-testid="create-with-agent-composer"
             value={view.composer}
-            placeholder={CREATE_WITH_AGENT_COPY.composerPlaceholder}
+            placeholder={
+              view.refining
+                ? CREATE_WITH_AGENT_COPY.composerPlaceholderRefine
+                : CREATE_WITH_AGENT_COPY.composerPlaceholder
+            }
             disabled={failed}
             onChange={(event) => onComposerChange(event.target.value)}
             onKeyDown={(event) => {

--- a/web_src/src/pages/factories/pages/CreateWithAgentDialog.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgentDialog.tsx
@@ -34,7 +34,6 @@ export type CreateWithAgentDialogProps = {
   onSend: () => void;
   onSubmitSurvey: (text: string) => void;
   onDraftTitleChange: (title: string) => void;
-  onDraftDescriptionChange: (description: string) => void;
   onCreateDraft: () => void;
   onSkipDraft: () => void;
   onSelectCreated: (order: CreateWithAgentCreatedOrder) => void;
@@ -53,7 +52,6 @@ export function CreateWithAgentDialog({
   onSend,
   onSubmitSurvey,
   onDraftTitleChange,
-  onDraftDescriptionChange,
   onCreateDraft,
   onSkipDraft,
   onSelectCreated,
@@ -90,7 +88,6 @@ export function CreateWithAgentDialog({
               view={view}
               failed={view.machineStatus === "failed"}
               onDraftTitleChange={onDraftTitleChange}
-              onDraftDescriptionChange={onDraftDescriptionChange}
               onCreateDraft={onCreateDraft}
               onSkipDraft={onSkipDraft}
               onSelectCreated={onSelectCreated}
@@ -319,7 +316,6 @@ function CreateWithAgentWorkPane({
   view,
   failed,
   onDraftTitleChange,
-  onDraftDescriptionChange,
   onCreateDraft,
   onSkipDraft,
   onSelectCreated,
@@ -328,7 +324,6 @@ function CreateWithAgentWorkPane({
   view: CreateWithAgentView;
   failed: boolean;
   onDraftTitleChange: (title: string) => void;
-  onDraftDescriptionChange: (description: string) => void;
   onCreateDraft: () => void;
   onSkipDraft: () => void;
   onSelectCreated: (order: CreateWithAgentCreatedOrder) => void;
@@ -345,8 +340,8 @@ function CreateWithAgentWorkPane({
           title={view.right.draft.title}
           description={view.right.draft.description}
           failed={failed}
+          refining={view.refining}
           onTitleChange={onDraftTitleChange}
-          onDescriptionChange={onDraftDescriptionChange}
           onCreate={onCreateDraft}
           onSkip={onSkipDraft}
         />
@@ -417,16 +412,16 @@ function DraftWorkPane({
   title,
   description,
   failed,
+  refining,
   onTitleChange,
-  onDescriptionChange,
   onCreate,
   onSkip,
 }: {
   title: string;
   description: string;
   failed: boolean;
+  refining: boolean;
   onTitleChange: (title: string) => void;
-  onDescriptionChange: (description: string) => void;
   onCreate: () => void;
   onSkip: () => void;
 }) {
@@ -442,12 +437,7 @@ function DraftWorkPane({
         className="mt-3 h-auto border-0 bg-transparent p-0 text-[22px] font-semibold tracking-[-0.02em] shadow-none focus-visible:ring-0"
       />
       <div className="mt-3 min-h-0 flex-1 overflow-y-auto">
-        <WorkOrderSplitRunDescription
-          description={description}
-          canEdit={!failed}
-          collapsible={false}
-          onSave={onDescriptionChange}
-        />
+        <WorkOrderSplitRunDescription description={description} collapsible={false} />
       </div>
       <div className="mt-4 flex justify-end gap-2">
         <Button type="button" variant="ghost" disabled={failed} onClick={onSkip}>
@@ -459,7 +449,7 @@ function DraftWorkPane({
           disabled={failed || !title.trim()}
           onClick={onCreate}
         >
-          {CREATE_WITH_AGENT_COPY.create}
+          {refining ? CREATE_WITH_AGENT_COPY.update : CREATE_WITH_AGENT_COPY.create}
         </Button>
       </div>
     </div>

--- a/web_src/src/pages/factories/pages/CreateWithAgentDialog.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgentDialog.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
   AlertDialog,
@@ -428,13 +427,14 @@ function DraftWorkPane({
   return (
     <div className="flex min-h-0 flex-1 flex-col px-5 py-4" data-testid="create-with-agent-draft">
       <p className="text-[12px] font-medium text-muted-foreground">{CREATE_WITH_AGENT_COPY.draftLabel}</p>
-      <Input
+      <Textarea
         value={title}
         onChange={(event) => onTitleChange(event.target.value)}
         disabled={failed}
+        rows={1}
         aria-label="Task title"
         data-testid="create-with-agent-draft-title"
-        className="mt-3 h-auto border-0 bg-transparent p-0 text-[22px] font-semibold tracking-[-0.02em] shadow-none focus-visible:ring-0"
+        className="mt-3 min-h-0 resize-none border-0 bg-transparent p-0 text-[22px] font-semibold tracking-[-0.02em] shadow-none focus-visible:ring-0"
       />
       <div className="mt-3 min-h-0 flex-1 overflow-y-auto">
         <WorkOrderSplitRunDescription description={description} collapsible={false} />

--- a/web_src/src/pages/factories/pages/CreateWithAgentDialog.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgentDialog.tsx
@@ -429,7 +429,12 @@ function DraftWorkPane({
         className="mt-3 h-auto border-0 bg-transparent p-0 text-[22px] font-semibold tracking-[-0.02em] shadow-none focus-visible:ring-0"
       />
       <div className="mt-3 min-h-0 flex-1 overflow-y-auto">
-        <WorkOrderSplitRunDescription description={description} canEdit={!failed} onSave={onDescriptionChange} />
+        <WorkOrderSplitRunDescription
+          description={description}
+          canEdit={!failed}
+          collapsible={false}
+          onSave={onDescriptionChange}
+        />
       </div>
       <div className="mt-4 flex justify-end gap-2">
         <Button type="button" variant="ghost" disabled={failed} onClick={onSkip}>
@@ -462,7 +467,7 @@ function PreviewWorkPane({
       <p className="text-[12px] font-medium text-muted-foreground">{order.key}</p>
       <h2 className="mt-2 text-[22px] font-semibold tracking-[-0.02em]">{order.title}</h2>
       <div className="mt-3 min-h-0 flex-1 overflow-y-auto">
-        <WorkOrderSplitRunDescription description={order.description} />
+        <WorkOrderSplitRunDescription description={order.description} collapsible={false} />
       </div>
       <div className="mt-4 flex justify-end">
         <Button type="button" variant="outline" disabled={failed} onClick={() => onRefine(order)}>

--- a/web_src/src/pages/factories/pages/LinesPage.backlogCreate.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.backlogCreate.spec.tsx
@@ -8,6 +8,7 @@ import {
   ACME_ONBOARDING_FACTORY,
   ACME_ONBOARDING_FACTORY_KEY,
   ACME_ONBOARDING_LINE_ID,
+  DRAFT_WORK_ORDER,
   GITHUB_ISSUES_INTAKE,
   GITHUB_ISSUES_INTAKE_ID,
   PRIMARY_FACTORY_KEY,
@@ -212,6 +213,57 @@ describe("LinesPage backlog create", () => {
     await waitFor(() => {
       expect(screen.getByTestId("create-with-agent-dialog")).toBeInTheDocument();
     });
+  });
+
+  it("opens the agent session from Refine on a backlog draft", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        session: {
+          id: "session-1",
+          repository: "acme/payments",
+          canvasRunId: "run-1",
+          messages: [],
+          draft: {
+            title: DRAFT_WORK_ORDER.title,
+            description: DRAFT_WORK_ORDER.description,
+            workOrderId: DRAFT_WORK_ORDER.id,
+          },
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    useFactoryWorkOrders.mockReturnValue({ data: [DRAFT_WORK_ORDER] });
+    const user = userEvent.setup();
+    renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`, vi.fn(), {
+      ...REFUND_FACTORY,
+      onboarding: { ...REFUND_FACTORY.onboarding, appRepository: "acme/payments" },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Open Draft: rework refund telemetry" }));
+    await user.click(within(screen.getByTestId("split-run-attention-note")).getByRole("button", { name: "Refine" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("create-with-agent-dialog")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
+      `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/task/105`,
+    );
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([url, init]) => {
+          return (
+            String(url).includes("/planning-sessions") &&
+            !String(url).includes("/messages") &&
+            init?.method === "POST" &&
+            String(init?.body).includes(`"work_order_id":"${DRAFT_WORK_ORDER.id}"`)
+          );
+        }),
+      ).toBe(true);
+    });
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/messages"))).toBe(false);
+    expect(screen.getByRole("heading", { name: "Refine this task" })).toBeInTheDocument();
   });
 
   it("starts the session with the workspace repository, not the demo repo", async () => {

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -671,7 +671,6 @@ function LineCreateWithAgentDialog({
       onSend={session.onSend}
       onSubmitSurvey={session.onSubmitSurvey}
       onDraftTitleChange={session.onDraftTitleChange}
-      onDraftDescriptionChange={session.onDraftDescriptionChange}
       onCreateDraft={session.onCreateDraft}
       onSkipDraft={session.onSkipDraft}
       onSelectCreated={session.onSelectCreated}

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -31,7 +31,11 @@ import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import { AddIntakePicker } from "./AddIntakePicker";
 import { AddPRFeedbackPicker } from "./AddPRFeedbackPicker";
 import { BacklogColumn, type BacklogIntakePanel } from "./BacklogColumn";
+import { CreateWithAgentDialog } from "./CreateWithAgentDialog";
 import { LineBoardOrderCard, LineBoardWorkOrderCard } from "./LineBoardOrderCard";
+import { workspacePlanningRepository } from "./planningSessionView";
+import { useCreateWithAgentSession } from "./useCreateWithAgentSession";
+import { usePlanningSessionLiveRun } from "./usePlanningSessionLiveRun";
 import {
   buildLinePhaseBoard,
   collectLineBacklogOrders,
@@ -582,6 +586,8 @@ function LineDetail({
   );
   const peekOrderId = peekOrder?.id ?? null;
   const backlogAnalysis = useFactoryBacklogAnalysis(organizationId, factoryId);
+  const { factory } = useFactoriesLayout();
+  const agentSession = useCreateWithAgentSession(workspacePlanningRepository(factory), organizationId, factoryId);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="lines-detail">
@@ -601,6 +607,7 @@ function LineDetail({
           canCreateWorkOrder={canCreateWorkOrder}
           canRename={canUpdate}
           onCreateWorkOrder={onCreateWorkOrder}
+          onCreateWithAgent={agentSession.start}
           intakePanel={intakePanel}
           onAddIntake={onAddIntake}
           verifyListeners={verifyListeners}
@@ -625,9 +632,51 @@ function LineDetail({
           onDispatch={workOrderCardContext.onDispatch}
           analysisRuns={backlogAnalysis.runsByWorkOrder.get(peekOrderId) ?? []}
           onClose={onClosePeek}
+          onRefine={() => {
+            const key = peekOrder.key?.trim();
+            const title = peekOrder.title?.trim();
+            if (!key || !title) {
+              return;
+            }
+            onClosePeek();
+            agentSession.start({ key, title });
+          }}
         />
       ) : null}
+      <LineCreateWithAgentDialog factoryKey={factoryKey} organizationId={organizationId} session={agentSession} />
     </div>
+  );
+}
+
+function LineCreateWithAgentDialog({
+  factoryKey,
+  organizationId,
+  session,
+}: {
+  factoryKey: string;
+  organizationId: string;
+  session: ReturnType<typeof useCreateWithAgentSession>;
+}) {
+  const view = usePlanningSessionLiveRun(organizationId, session.view);
+  return (
+    <CreateWithAgentDialog
+      open={session.open}
+      workspaceName={factoryKey}
+      organizationId={organizationId}
+      view={view}
+      onComposerChange={session.onComposerChange}
+      onSend={session.onSend}
+      onSubmitSurvey={session.onSubmitSurvey}
+      onDraftTitleChange={session.onDraftTitleChange}
+      onDraftDescriptionChange={session.onDraftDescriptionChange}
+      onCreateDraft={session.onCreateDraft}
+      onSkipDraft={session.onSkipDraft}
+      onSelectCreated={session.onSelectCreated}
+      onRefineCreated={session.onRefineCreated}
+      onRequestClose={session.onRequestClose}
+      onCancelEnd={session.onCancelEnd}
+      onConfirmEnd={session.onConfirmEnd}
+    />
   );
 }
 
@@ -645,6 +694,7 @@ function LineBoardSplitRunPopup({
   onDispatch,
   analysisRuns,
   onClose,
+  onRefine,
 }: {
   organizationId: string;
   factoryId: string;
@@ -659,6 +709,7 @@ function LineBoardSplitRunPopup({
   onDispatch: (orderId: string, input: { lineName: string; model?: string }) => Promise<void>;
   analysisRuns: BacklogAnalysisRun[];
   onClose: () => void;
+  onRefine: () => void;
 }) {
   const { data: peekChecks = [] } = useWorkOrderChecks(organizationId, factoryId, peekOrderId);
   const { data: peekPullRequests = [] } = useFactoryPullRequests(organizationId, factoryId, {
@@ -694,6 +745,7 @@ function LineBoardSplitRunPopup({
         resolvedLineName ? (model) => onDispatch(peekOrderId, { lineName: resolvedLineName, model }) : undefined
       }
       onClose={onClose}
+      onRefine={onRefine}
       fixed
     />
   );
@@ -815,6 +867,7 @@ function PhaseBoard({
   canCreateWorkOrder,
   canRename,
   onCreateWorkOrder,
+  onCreateWithAgent,
   intakePanel,
   onAddIntake,
   verifyListeners,
@@ -835,6 +888,7 @@ function PhaseBoard({
   canCreateWorkOrder: boolean;
   canRename: boolean;
   onCreateWorkOrder: () => void;
+  onCreateWithAgent: () => void;
   intakePanel: BacklogIntakePanel;
   onAddIntake?: () => void;
   verifyListeners: LaneListener[];
@@ -958,6 +1012,7 @@ function PhaseBoard({
           canRename={canRename}
           onRename={(title) => setColumnTitle("backlog", title)}
           onCreateWorkOrder={onCreateWorkOrder}
+          onCreateWithAgent={onCreateWithAgent}
           workOrderCardContext={workOrderCardContext}
           onOpenWorkOrder={onOpenWorkOrder}
           analyzingOrderIds={analyzingOrderIds}

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -633,13 +633,16 @@ function LineDetail({
           analysisRuns={backlogAnalysis.runsByWorkOrder.get(peekOrderId) ?? []}
           onClose={onClosePeek}
           onRefine={() => {
-            const key = peekOrder.key?.trim();
+            const id = peekOrder.id?.trim();
             const title = peekOrder.title?.trim();
-            if (!key || !title) {
+            if (!id || !title) {
               return;
             }
-            onClosePeek();
-            agentSession.start({ key, title });
+            agentSession.start({
+              id,
+              title,
+              description: peekOrder.description ?? "",
+            });
           }}
         />
       ) : null}

--- a/web_src/src/pages/factories/pages/createWithAgentCopy.ts
+++ b/web_src/src/pages/factories/pages/createWithAgentCopy.ts
@@ -31,6 +31,7 @@ export const CREATE_WITH_AGENT_COPY = {
   draftLabel: "Draft task",
   sessionList: "This session",
   create: "Create",
+  update: "Update",
   skip: "Skip",
   refineFurther: "Refine further",
   openTask: "Open task",
@@ -42,6 +43,7 @@ export const CREATE_WITH_AGENT_COPY = {
   failedSurvey: "Failed to send the answers.",
   failedDraft: "Failed to save the draft.",
   failedCreate: "Failed to create the task.",
+  failedUpdate: "Failed to update the task.",
   failedSkip: "Failed to skip the draft.",
 } as const;
 

--- a/web_src/src/pages/factories/pages/createWithAgentCopy.ts
+++ b/web_src/src/pages/factories/pages/createWithAgentCopy.ts
@@ -33,6 +33,8 @@ export const CREATE_WITH_AGENT_COPY = {
   create: "Create",
   update: "Update",
   skip: "Skip",
+  refine: "Refine",
+  refineTooltip: "Ask an agent to update this task.",
   refineFurther: "Refine further",
   openTask: "Open task",
   greeting: "The repository is ready. What do you want to do?",

--- a/web_src/src/pages/factories/pages/createWithAgentCopy.ts
+++ b/web_src/src/pages/factories/pages/createWithAgentCopy.ts
@@ -1,6 +1,7 @@
 export const CREATE_WITH_AGENT_COPY = {
   menu: "Create with an Agent",
   title: "New task with an agent",
+  titleRefine: "Refine this task",
   endSession: "End session",
   endSessionAsk: "End this session?",
   endSessionBody: "The machine will stop. Tasks you already created stay in the backlog.",
@@ -16,6 +17,7 @@ export const CREATE_WITH_AGENT_COPY = {
   otherAnswer: "Or write your own answer",
   surveySkipped: "Skipped the survey.",
   composerPlaceholder: "Tell the agent what you want to do",
+  composerPlaceholderRefine: "Tell the agent what you want to change",
   viewingOlder: "You are viewing older messages.",
   jumpToLatest: "Jump to latest",
   machineStarting: "The machine is starting",
@@ -45,4 +47,9 @@ export const CREATE_WITH_AGENT_COPY = {
 
 export function planningRefineNote(key: string, title: string) {
   return `Refine ${key}: ${title}.`;
+}
+
+export function isPlanningRefineNote(text: string) {
+  const match = /^Refine (\S+): .+\.$/.exec(text.trim());
+  return Boolean(match?.[1] && /-\d+$/.test(match[1]));
 }

--- a/web_src/src/pages/factories/pages/createWithAgentCopy.ts
+++ b/web_src/src/pages/factories/pages/createWithAgentCopy.ts
@@ -19,6 +19,7 @@ export const CREATE_WITH_AGENT_COPY = {
   viewingOlder: "You are viewing older messages.",
   jumpToLatest: "Jump to latest",
   machineStarting: "The machine is starting",
+  logStarting: "Starting the planning session.",
   machineRunning: "Machine is running",
   machineWaiting: "Waiting for you",
   machineStopped: "The machine stopped",

--- a/web_src/src/pages/factories/pages/createWithAgentDemo.ts
+++ b/web_src/src/pages/factories/pages/createWithAgentDemo.ts
@@ -16,6 +16,7 @@ export function emptyCreateWithAgentView(repository = CREATE_WITH_AGENT_DEMO_REP
     created: [],
     right: { kind: "empty" },
     endConfirmOpen: false,
+    refining: false,
   };
 }
 

--- a/web_src/src/pages/factories/pages/createWithAgentTypes.ts
+++ b/web_src/src/pages/factories/pages/createWithAgentTypes.ts
@@ -53,4 +53,5 @@ export type CreateWithAgentView = {
   created: CreateWithAgentCreatedOrder[];
   right: CreateWithAgentRightPane;
   endConfirmOpen: boolean;
+  refining: boolean;
 };

--- a/web_src/src/pages/factories/pages/planningSessionClient.ts
+++ b/web_src/src/pages/factories/pages/planningSessionClient.ts
@@ -28,11 +28,15 @@ async function planningSessionRequest(
   return body.session;
 }
 
-export function startPlanningSession(organizationId: string, factoryId: string, repository = "") {
+export function startPlanningSession(organizationId: string, factoryId: string, repository = "", workOrderId = "") {
   const trimmed = repository.trim();
+  const refineId = workOrderId.trim();
   return planningSessionRequest(organizationId, `/api/v1/factories/${factoryId}/planning-sessions`, {
     method: "POST",
-    body: JSON.stringify(trimmed ? { repository: trimmed } : {}),
+    body: JSON.stringify({
+      ...(trimmed ? { repository: trimmed } : {}),
+      ...(refineId ? { work_order_id: refineId } : {}),
+    }),
   });
 }
 

--- a/web_src/src/pages/factories/pages/planningSessionLog.spec.ts
+++ b/web_src/src/pages/factories/pages/planningSessionLog.spec.ts
@@ -234,6 +234,23 @@ describe("groupPlanningSessionLog", () => {
     ).toHaveLength(2);
   });
 
+  it("hides the draft follow-up wait wrap from the transcript", () => {
+    const groups = groupPlanningSessionLog([
+      note({
+        id: "agent-step-10",
+        componentType: "prompt",
+        componentName:
+          "The user is talking about this draft. Do not ask which task they mean.\n\nTitle: Add a color field\n\nUser message:\nI actually want this to be about size and not color.",
+      }),
+    ]);
+
+    const notes = groups.flatMap((group) =>
+      group.events.filter((event) => event.kind === "note").map((event) => event.line.componentName),
+    );
+    expect(notes.join("\n")).not.toContain("The user is talking about this draft");
+    expect(notes.join("\n")).not.toContain("Do not ask which task they mean");
+  });
+
   it("hides setup and collapses truncated draft tool JSON", () => {
     const groups = groupPlanningSessionLog([
       note({
@@ -465,5 +482,43 @@ describe("mergePlanningSessionNotes", () => {
 
     expect(merged.map((line) => line.id)).toEqual(["agent-step-7", "look", "agent-step-8"]);
     expect(merged[2]?.userTalk).toBe("survey");
+  });
+
+  it("shows the raw follow-up when the live log has the draft wait wrap", () => {
+    const wrap =
+      "The user is talking about this draft. Do not ask which task they mean.\n\nTitle: Add a color field\n\nUser message:\nI actually want this to be about size and not color.";
+    const live: SplitRunStreamLine[] = [
+      note({
+        id: "wait",
+        componentType: "prompt",
+        componentName: wrap,
+      }),
+      note({
+        id: "look",
+        noteParentId: "wait",
+        componentType: "note",
+        componentName: "Let me review the current draft and apply the requested change.",
+      }),
+    ];
+
+    const merged = mergePlanningSessionNotes(live, [
+      note({
+        id: "user-1",
+        componentType: "prompt",
+        componentName: "I actually want this to be about size and not color.",
+        userTalk: "message",
+      }),
+    ]);
+    const groups = groupPlanningSessionLog(merged);
+    const talk = groups.flatMap((group) =>
+      group.events.filter((event) => event.kind === "note").map((event) => event.line),
+    );
+
+    expect(talk.map((line) => line.componentName)).toEqual([
+      "Let me review the current draft and apply the requested change.",
+      "I actually want this to be about size and not color.",
+    ]);
+    expect(talk[1]?.userTalk).toBe("message");
+    expect(talk.map((line) => line.componentName).join("\n")).not.toContain("The user is talking about this draft");
   });
 });

--- a/web_src/src/pages/factories/pages/planningSessionLog.ts
+++ b/web_src/src/pages/factories/pages/planningSessionLog.ts
@@ -217,7 +217,8 @@ function isPlanningSessionSystemPrompt(text: string): boolean {
     name.startsWith("Greet the user") ||
     name.startsWith("The user created the draft task") ||
     name.startsWith("The user skipped that draft") ||
-    name.startsWith("The user started refining")
+    name.startsWith("The user started refining") ||
+    name.startsWith("The user is talking about this draft")
   );
 }
 
@@ -450,7 +451,8 @@ function isPlanningSessionWaitPrompt(text: string): boolean {
     name === "Wait for the next user message" ||
     name.startsWith("The user created the draft task") ||
     name.startsWith("The user skipped that draft") ||
-    name.startsWith("The user started refining")
+    name.startsWith("The user started refining") ||
+    name.startsWith("The user is talking about this draft")
   );
 }
 
@@ -460,7 +462,12 @@ function streamNoteHasText(notes: SplitRunStreamLine[], text: string): boolean {
     return true;
   }
   const prefix = needle.slice(0, 48);
-  return notes.some((note) => `${note.componentName}\n${note.detail ?? ""}`.includes(prefix));
+  return notes.some((note) => {
+    if (isPlanningSessionSystemPrompt(note.componentName)) {
+      return false;
+    }
+    return `${note.componentName}\n${note.detail ?? ""}`.includes(prefix);
+  });
 }
 
 /**

--- a/web_src/src/pages/factories/pages/planningSessionView.spec.ts
+++ b/web_src/src/pages/factories/pages/planningSessionView.spec.ts
@@ -237,6 +237,27 @@ describe("createWithAgentViewFromSession", () => {
     ]);
   });
 
+  it("hides Refine protocol notes from the transcript", () => {
+    const view = createWithAgentViewFromSession(
+      {
+        repository: "acme/payments",
+        canvasId: "canvas-1",
+        executionId: "exec-1",
+        draft: { title: "Retry refunds", description: "Stop double charges.", workOrderId: "wo-1" },
+        messages: [
+          { id: "note", role: "user", text: "Refine NEW-11: Retry refunds." },
+          { id: "ready", role: "agent", text: "I have this task. What do you want to change?" },
+        ],
+      },
+      { composer: "", right: { kind: "empty" }, endConfirmOpen: false },
+    );
+
+    expect(view.refining).toBe(true);
+    expect(view.messages).toEqual([
+      { id: "ready", kind: "text", role: "agent", text: "I have this task. What do you want to change?" },
+    ]);
+  });
+
   it("leaves the order key undefined when the server sends no created_at", () => {
     const view = createWithAgentViewFromSession(
       {

--- a/web_src/src/pages/factories/pages/planningSessionView.ts
+++ b/web_src/src/pages/factories/pages/planningSessionView.ts
@@ -40,24 +40,6 @@ export function createWithAgentViewFromSession(
   session: PlanningSessionPayload,
   extras: Pick<CreateWithAgentView, "composer" | "right" | "endConfirmOpen">,
 ): CreateWithAgentView {
-  const created: CreateWithAgentCreatedOrder[] = (session.created ?? [])
-    .filter((order): order is { id: string; key: string; title: string; description?: string } =>
-      Boolean(order.id && order.key && order.title),
-    )
-    .map((order) => ({
-      id: order.id,
-      key: order.key,
-      title: order.title,
-      description: order.description ?? "",
-    }));
-
-  const draftTitle = session.draft?.title?.trim() ?? "";
-  const right = draftTitle
-    ? { kind: "draft" as const, draft: { title: draftTitle, description: session.draft?.description ?? "" } }
-    : extras.right.kind === "preview"
-      ? extras.right
-      : { kind: "empty" as const };
-
   return {
     repository: session.repository ?? "",
     machineStatus: createWithAgentMachineStatus(session),
@@ -67,11 +49,38 @@ export function createWithAgentViewFromSession(
     messages: (session.messages ?? []).flatMap(planningSessionMessageFromPayload),
     survey: planningSessionSurveyFromPayload(session.survey),
     composer: extras.composer,
-    created,
-    right,
+    created: createdOrdersFromSession(session),
+    right: planningSessionRightPane(session, extras.right),
     endConfirmOpen: extras.endConfirmOpen,
     refining: Boolean(session.draft?.workOrderId?.trim()),
   };
+}
+
+function createdOrdersFromSession(session: PlanningSessionPayload): CreateWithAgentCreatedOrder[] {
+  return (session.created ?? [])
+    .filter((order): order is { id: string; key: string; title: string; description?: string } =>
+      Boolean(order.id && order.key && order.title),
+    )
+    .map((order) => ({
+      id: order.id,
+      key: order.key,
+      title: order.title,
+      description: order.description ?? "",
+    }));
+}
+
+function planningSessionRightPane(
+  session: PlanningSessionPayload,
+  right: CreateWithAgentView["right"],
+): CreateWithAgentView["right"] {
+  const draftTitle = session.draft?.title?.trim() ?? "";
+  if (draftTitle) {
+    return { kind: "draft", draft: { title: draftTitle, description: session.draft?.description ?? "" } };
+  }
+  if (right.kind === "preview") {
+    return right;
+  }
+  return { kind: "empty" };
 }
 
 function planningSessionSurveyFromPayload(

--- a/web_src/src/pages/factories/pages/planningSessionView.ts
+++ b/web_src/src/pages/factories/pages/planningSessionView.ts
@@ -1,3 +1,4 @@
+import { isPlanningRefineNote } from "./createWithAgentCopy";
 import type { CreateWithAgentCreatedOrder, CreateWithAgentMessage, CreateWithAgentView } from "./createWithAgentTypes";
 import { isPlanningSurveyReply } from "./planningSessionSurvey";
 
@@ -17,7 +18,7 @@ export type PlanningSessionPayload = {
   waitState?: string;
   executionId?: string;
   messages?: PlanningSessionMessagePayload[];
-  draft?: { title?: string; description?: string } | null;
+  draft?: { title?: string; description?: string; workOrderId?: string } | null;
   created?: Array<{ id?: string; key?: string; title?: string; description?: string }>;
   survey?: PlanningSessionSurveyPayload | null;
 };
@@ -69,6 +70,7 @@ export function createWithAgentViewFromSession(
     created,
     right,
     endConfirmOpen: extras.endConfirmOpen,
+    refining: Boolean(session.draft?.workOrderId?.trim()),
   };
 }
 
@@ -117,6 +119,9 @@ function createWithAgentMachineStatus(session: PlanningSessionPayload): CreateWi
 }
 
 function planningSessionMessageFromPayload(message: PlanningSessionMessagePayload): CreateWithAgentMessage[] {
+  if (message.role === "user" && message.text && isPlanningRefineNote(message.text)) {
+    return [];
+  }
   if (message.text && (message.role === "user" || message.role === "agent")) {
     const createdAtMs = parsePlanningMessageCreatedAt(message.createdAt);
     return [

--- a/web_src/src/pages/factories/pages/useCreateWithAgentSession.spec.tsx
+++ b/web_src/src/pages/factories/pages/useCreateWithAgentSession.spec.tsx
@@ -141,6 +141,29 @@ describe("useCreateWithAgentSession", () => {
     });
   });
 
+  it("tells the agent when Refine starts on a backlog draft", async () => {
+    startPlanningSession.mockResolvedValue(session("session-1"));
+    sendPlanningSessionMessage.mockResolvedValue({
+      ...session("session-1"),
+      draft: { title: "Retry refunds", description: "Stop double charges." },
+    });
+    const { result } = renderHook(() => useCreateWithAgentSession("acme/payments", "org-1", "factory-1"));
+
+    act(() => {
+      result.current.start({ key: "RF-105", title: "Retry refunds" });
+    });
+
+    await waitFor(() => {
+      expect(sendPlanningSessionMessage).toHaveBeenCalledWith(
+        "org-1",
+        "factory-1",
+        "session-1",
+        "Refine RF-105: Retry refunds.",
+      );
+    });
+    expect(result.current.open).toBe(true);
+  });
+
   it("does not tell the agent when the title opens read-only", async () => {
     startPlanningSession.mockResolvedValue({
       ...session("session-1"),

--- a/web_src/src/pages/factories/pages/useCreateWithAgentSession.spec.tsx
+++ b/web_src/src/pages/factories/pages/useCreateWithAgentSession.spec.tsx
@@ -141,27 +141,27 @@ describe("useCreateWithAgentSession", () => {
     });
   });
 
-  it("tells the agent when Refine starts on a backlog draft", async () => {
-    startPlanningSession.mockResolvedValue(session("session-1"));
-    sendPlanningSessionMessage.mockResolvedValue({
+  it("starts Refine with the draft work order and does not send a protocol note", async () => {
+    startPlanningSession.mockResolvedValue({
       ...session("session-1"),
-      draft: { title: "Retry refunds", description: "Stop double charges." },
+      draft: { title: "Retry refunds", description: "Stop double charges.", workOrderId: "wo-1" },
     });
     const { result } = renderHook(() => useCreateWithAgentSession("acme/payments", "org-1", "factory-1"));
 
     act(() => {
-      result.current.start({ key: "RF-105", title: "Retry refunds" });
+      result.current.start({ id: "wo-1", title: "Retry refunds", description: "Stop double charges." });
     });
 
     await waitFor(() => {
-      expect(sendPlanningSessionMessage).toHaveBeenCalledWith(
-        "org-1",
-        "factory-1",
-        "session-1",
-        "Refine RF-105: Retry refunds.",
-      );
+      expect(startPlanningSession).toHaveBeenCalledWith("org-1", "factory-1", "acme/payments", "wo-1");
     });
+    expect(sendPlanningSessionMessage).not.toHaveBeenCalled();
     expect(result.current.open).toBe(true);
+    expect(result.current.view.refining).toBe(true);
+    expect(result.current.view.right).toEqual({
+      kind: "draft",
+      draft: { title: "Retry refunds", description: "Stop double charges." },
+    });
   });
 
   it("does not tell the agent when the title opens read-only", async () => {

--- a/web_src/src/pages/factories/pages/useCreateWithAgentSession.ts
+++ b/web_src/src/pages/factories/pages/useCreateWithAgentSession.ts
@@ -457,10 +457,6 @@ function createWithAgentViewActions({
       const description = view.right.kind === "draft" ? view.right.draft.description : "";
       patchDraft(title, description);
     },
-    onDraftDescriptionChange: (description: string) => {
-      const title = view.right.kind === "draft" ? view.right.draft.title : "";
-      patchDraft(title, description);
-    },
     onCreateDraft: () => {
       if (!sessionId) {
         return;
@@ -469,7 +465,12 @@ function createWithAgentViewActions({
       void createPlanningSessionWorkOrder(organizationId, factoryId, sessionId)
         .then((session) => applySession(session, generation))
         .catch((error: unknown) => {
-          showErrorToast(getApiErrorMessage(error, CREATE_WITH_AGENT_COPY.failedCreate));
+          showErrorToast(
+            getApiErrorMessage(
+              error,
+              view.refining ? CREATE_WITH_AGENT_COPY.failedUpdate : CREATE_WITH_AGENT_COPY.failedCreate,
+            ),
+          );
         });
     },
     onSkipDraft: () => {

--- a/web_src/src/pages/factories/pages/useCreateWithAgentSession.ts
+++ b/web_src/src/pages/factories/pages/useCreateWithAgentSession.ts
@@ -23,6 +23,11 @@ import {
 import { isPlanningSurveyReply } from "./planningSessionSurvey";
 import { createWithAgentViewFromSession, type PlanningSessionPayload } from "./planningSessionView";
 
+export type PlanningRefineTarget = {
+  key: string;
+  title: string;
+};
+
 const POLL_MS = 1500;
 const DRAFT_SAVE_MS = 400;
 const UNMOUNT_END_MS = 100;
@@ -138,21 +143,25 @@ export function useCreateWithAgentSession(repository: string, organizationId: st
     stopSession(id);
   }, [resetLocalSession, stopSession]);
 
-  const start = useCallback(() => {
-    openPlanningSession({
-      repository,
-      organizationId,
-      factoryId,
-      sessionIdRef,
-      startGenerationRef,
-      stopSession,
-      applySession,
-      resetLocalSession,
-      setView,
-      setSessionId,
-      setOpen,
-    });
-  }, [applySession, factoryId, organizationId, repository, resetLocalSession, stopSession]);
+  const start = useCallback(
+    (refine?: PlanningRefineTarget) => {
+      openPlanningSession({
+        repository,
+        organizationId,
+        factoryId,
+        refine,
+        sessionIdRef,
+        startGenerationRef,
+        stopSession,
+        applySession,
+        resetLocalSession,
+        setView,
+        setSessionId,
+        setOpen,
+      });
+    },
+    [applySession, factoryId, organizationId, repository, resetLocalSession, stopSession],
+  );
 
   const patchDraft = (title: string, description: string) =>
     savePlanningDraft({ title, description, sessionId, organizationId, factoryId, draftSaveTimer, setView });
@@ -228,6 +237,7 @@ function openPlanningSession({
   repository,
   organizationId,
   factoryId,
+  refine,
   sessionIdRef,
   startGenerationRef,
   stopSession,
@@ -240,6 +250,7 @@ function openPlanningSession({
   repository: string;
   organizationId: string;
   factoryId: string;
+  refine?: PlanningRefineTarget;
   sessionIdRef: { current: string };
   startGenerationRef: { current: number };
   stopSession: (id: string) => void;
@@ -256,7 +267,23 @@ function openPlanningSession({
   setSessionId("");
   setOpen(true);
   void startPlanningSession(organizationId, factoryId, repository)
-    .then((session) => applySession(session, generation))
+    .then((session) => {
+      applySession(session, generation);
+      const sessionId = session.id ?? "";
+      const key = refine?.key.trim() ?? "";
+      const title = refine?.title.trim() ?? "";
+      if (!sessionId || !key || !title) {
+        return;
+      }
+      return sendPlanningSessionMessage(organizationId, factoryId, sessionId, planningRefineNote(key, title))
+        .then((next) => applySession(next, generation))
+        .catch((error: unknown) => {
+          if (generation !== startGenerationRef.current) {
+            return;
+          }
+          showErrorToast(getApiErrorMessage(error, CREATE_WITH_AGENT_COPY.failedSend));
+        });
+    })
     .catch((error: unknown) => {
       if (generation !== startGenerationRef.current) {
         return;

--- a/web_src/src/pages/factories/pages/useCreateWithAgentSession.ts
+++ b/web_src/src/pages/factories/pages/useCreateWithAgentSession.ts
@@ -2,7 +2,7 @@ import { getApiErrorMessage } from "@/lib/errors";
 import { showErrorToast } from "@/lib/toast";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { CREATE_WITH_AGENT_COPY, planningRefineNote } from "./createWithAgentCopy";
+import { CREATE_WITH_AGENT_COPY, isPlanningRefineNote, planningRefineNote } from "./createWithAgentCopy";
 import {
   cancelCreateWithAgentEnd,
   emptyCreateWithAgentView,
@@ -24,8 +24,9 @@ import { isPlanningSurveyReply } from "./planningSessionSurvey";
 import { createWithAgentViewFromSession, type PlanningSessionPayload } from "./planningSessionView";
 
 export type PlanningRefineTarget = {
-  key: string;
+  id: string;
   title: string;
+  description?: string;
 };
 
 const POLL_MS = 1500;
@@ -263,26 +264,19 @@ function openPlanningSession({
   const generation = startGenerationRef.current + 1;
   startGenerationRef.current = generation;
   stopSession(sessionIdRef.current);
-  setView(emptyCreateWithAgentView(repository));
+  const refineTitle = refine?.title.trim() ?? "";
+  setView({
+    ...emptyCreateWithAgentView(repository),
+    refining: Boolean(refine?.id.trim()),
+    right: refineTitle
+      ? { kind: "draft", draft: { title: refineTitle, description: refine?.description?.trim() ?? "" } }
+      : { kind: "empty" },
+  });
   setSessionId("");
   setOpen(true);
-  void startPlanningSession(organizationId, factoryId, repository)
+  void startPlanningSession(organizationId, factoryId, repository, refine?.id.trim() ?? "")
     .then((session) => {
       applySession(session, generation);
-      const sessionId = session.id ?? "";
-      const key = refine?.key.trim() ?? "";
-      const title = refine?.title.trim() ?? "";
-      if (!sessionId || !key || !title) {
-        return;
-      }
-      return sendPlanningSessionMessage(organizationId, factoryId, sessionId, planningRefineNote(key, title))
-        .then((next) => applySession(next, generation))
-        .catch((error: unknown) => {
-          if (generation !== startGenerationRef.current) {
-            return;
-          }
-          showErrorToast(getApiErrorMessage(error, CREATE_WITH_AGENT_COPY.failedSend));
-        });
     })
     .catch((error: unknown) => {
       if (generation !== startGenerationRef.current) {
@@ -394,24 +388,26 @@ function sendPlanningText({
     return;
   }
   const generation = startGenerationRef.current;
-  setView((current) => ({
-    ...setCreateWithAgentComposer(current, ""),
-    survey: undefined,
-    messages: [
-      ...current.messages,
-      {
-        id: `local-${current.messages.length + 1}`,
-        kind: "text",
-        role: "user",
-        text: body,
-        // Sorts to the end immediately. The server round-trip replaces this
-        // with the persisted message, whose created_at keeps the same
-        // relative position so there is no visible jump.
-        createdAtMs: Date.now(),
-        ...(isPlanningSurveyReply(body) ? { origin: "survey" as const } : {}),
-      },
-    ],
-  }));
+  if (!isPlanningRefineNote(body)) {
+    setView((current) => ({
+      ...setCreateWithAgentComposer(current, ""),
+      survey: undefined,
+      messages: [
+        ...current.messages,
+        {
+          id: `local-${current.messages.length + 1}`,
+          kind: "text",
+          role: "user",
+          text: body,
+          // Sorts to the end immediately. The server round-trip replaces this
+          // with the persisted message, whose created_at keeps the same
+          // relative position so there is no visible jump.
+          createdAtMs: Date.now(),
+          ...(isPlanningSurveyReply(body) ? { origin: "survey" as const } : {}),
+        },
+      ],
+    }));
+  }
   void sendPlanningSessionMessage(organizationId, factoryId, sessionId, body)
     .then((session) => applySession(session, generation))
     .catch((error: unknown) => {

--- a/web_src/src/pages/factories/pages/useCreateWithAgentSession.ts
+++ b/web_src/src/pages/factories/pages/useCreateWithAgentSession.ts
@@ -66,6 +66,16 @@ function clearDraftSaveTimer(timer: { current: number | undefined }) {
   timer.current = undefined;
 }
 
+function stopPlanningSession(organizationId: string, factoryId: string, id: string, options?: { keepalive?: boolean }) {
+  if (!id || !organizationId || !factoryId) {
+    return;
+  }
+  const request = options
+    ? endPlanningSession(organizationId, factoryId, id, options)
+    : endPlanningSession(organizationId, factoryId, id);
+  void request.catch(() => undefined);
+}
+
 export function useCreateWithAgentSession(repository: string, organizationId: string, factoryId: string) {
   const [open, setOpen] = useState(false);
   const [sessionId, setSessionId] = useState("");
@@ -110,15 +120,7 @@ export function useCreateWithAgentSession(repository: string, organizationId: st
   });
 
   const stopSession = useCallback(
-    (id: string, options?: { keepalive?: boolean }) => {
-      if (!id || !organizationId || !factoryId) {
-        return;
-      }
-      const request = options
-        ? endPlanningSession(organizationId, factoryId, id, options)
-        : endPlanningSession(organizationId, factoryId, id);
-      void request.catch(() => undefined);
-    },
+    (id: string, options?: { keepalive?: boolean }) => stopPlanningSession(organizationId, factoryId, id, options),
     [factoryId, organizationId],
   );
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.spec.tsx
@@ -471,4 +471,34 @@ describe("PhaseLogCard collapsed stream", () => {
     expect(screen.getByText("I can draft that.")).toBeInTheDocument();
     expect(screen.getByText("I can draft that.").closest("[data-testid='split-run-user-note']")).toBeNull();
   });
+
+  it("renders markdown in compact session log notes", () => {
+    render(
+      <PhaseLogCard
+        phase={PHASE}
+        expanded
+        compactSessionLog
+        stream={[
+          line({
+            id: "runner-agent",
+            nodeId: "runner-agent",
+            componentName: "Agent",
+            componentType: "Run Claude Code",
+            component: "runnerClaudeCode",
+          }),
+          line({
+            id: "agent-1",
+            nodeId: "runner-agent",
+            note: true,
+            componentType: "note",
+            componentName: "Changed color to **size** with a `medium` option.",
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("size").tagName).toBe("STRONG");
+    expect(screen.getByText("medium").tagName).toBe("CODE");
+    expect(screen.queryByText("**size**")).not.toBeInTheDocument();
+  });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.spec.tsx
@@ -401,6 +401,38 @@ describe("PhaseLogCard collapsed stream", () => {
     expect(screen.getByRole("button", { name: "Read 1 file, ran 1 command" })).toBeInTheDocument();
   });
 
+  it("hides the automation and node headers in the compact session log", () => {
+    render(
+      <PhaseLogCard
+        phase={PHASE}
+        expanded
+        compactSessionLog
+        stream={[
+          line({
+            id: "runner-agent",
+            nodeId: "runner-agent",
+            componentName: "Agent",
+            componentType: "Run Claude Code",
+            component: "runnerClaudeCode",
+          }),
+          line({
+            id: "agent-1",
+            nodeId: "runner-agent",
+            note: true,
+            componentType: "note",
+            componentName: "The repository is ready. What do you want to do?",
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByTestId("split-run-automation-header-plan")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("split-run-stream-line-runner-agent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Plan")).not.toBeInTheDocument();
+    expect(screen.queryByText("Agent")).not.toBeInTheDocument();
+    expect(screen.getByText("The repository is ready. What do you want to do?")).toBeInTheDocument();
+  });
+
   it("marks user replies in the compact session log", () => {
     render(
       <PhaseLogCard

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.stream.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.stream.spec.tsx
@@ -227,12 +227,12 @@ describe("PhaseLogCard stream details", () => {
     const user = userEvent.setup();
     render(<PhaseLogCard phase={PHASE} expanded stream={PLANNING_STREAM} />);
 
-    const note = screen.getByText(LONG_NOTE);
+    const note = screen.getByText(LONG_NOTE).closest(".whitespace-normal");
     expect(note).toBeInTheDocument();
     expect(note).not.toHaveClass("truncate");
     expect(note).toHaveClass("whitespace-normal");
-    expect(note.parentElement?.className).toMatch(/\bbg-muted\b/);
-    expect(note.parentElement?.className).not.toMatch(/\bbg-background\b/);
+    expect(note?.closest("[data-testid^='split-run-stream-line-']")?.className).toMatch(/\bbg-muted\b/);
+    expect(note?.closest("[data-testid^='split-run-stream-line-']")?.className).not.toMatch(/\bbg-background\b/);
     const toolSummary = screen.getByRole("button", { name: "Ran 1 command" });
     expect(toolSummary).toBeInTheDocument();
     expect(toolSummary.className).toMatch(/\bbg-muted\b/);

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
@@ -459,23 +459,25 @@ export function PhaseLogCard({
             : undefined
         }
       >
-        <AutomationHeader
-          phase={phase}
-          expanded={expanded}
-          collapsible={collapsible}
-          producedArtifacts={producedArtifacts}
-          producedPullRequests={producedPullRequests}
-          onToggle={onToggle}
-          onStop={onStop}
-          onRerun={onRerun}
-          runHref={runHref}
-          editHref={editHref}
-          actionBusy={actionBusy}
-        />
+        {compactSessionLog ? null : (
+          <AutomationHeader
+            phase={phase}
+            expanded={expanded}
+            collapsible={collapsible}
+            producedArtifacts={producedArtifacts}
+            producedPullRequests={producedPullRequests}
+            onToggle={onToggle}
+            onStop={onStop}
+            onRerun={onRerun}
+            runHref={runHref}
+            editHref={editHref}
+            actionBusy={actionBusy}
+          />
+        )}
 
         {expanded ? (
           <ol
-            className={cn("mt-1 min-w-0 list-none leading-tight", LOG_FACE)}
+            className={cn("min-w-0 list-none leading-tight", LOG_FACE, !compactSessionLog && "mt-1")}
             data-testid={`split-run-stream-${phase.id}`}
             onClick={(event) => event.stopPropagation()}
           >
@@ -828,18 +830,25 @@ function StreamNode({
 
   return (
     <li className="min-w-0">
-      <StreamNodeHeader
-        line={line}
-        hasChildren={hasChildren}
-        highlighted={highlighted}
-        artifact={artifact}
-        pullRequest={pullRequest}
-        onSelect={onSelect}
-      />
+      {compactSessionLog ? null : (
+        <StreamNodeHeader
+          line={line}
+          hasChildren={hasChildren}
+          highlighted={highlighted}
+          artifact={artifact}
+          pullRequest={pullRequest}
+          onSelect={onSelect}
+        />
+      )}
       {hasChildren ? (
         <ol className="min-w-0">
           {steps.map((step) => (
-            <StreamStep key={step.line.id} step={step} highlightUserTalk={compactSessionLog} />
+            <StreamStep
+              key={step.line.id}
+              step={step}
+              highlightUserTalk={compactSessionLog}
+              stickyHeader={!compactSessionLog}
+            />
           ))}
         </ol>
       ) : null}
@@ -917,7 +926,15 @@ function StreamNodeHeader({
   );
 }
 
-function StreamStep({ step, highlightUserTalk = false }: { step: ClaudeStepGroup; highlightUserTalk?: boolean }) {
+function StreamStep({
+  step,
+  highlightUserTalk = false,
+  stickyHeader = true,
+}: {
+  step: ClaudeStepGroup;
+  highlightUserTalk?: boolean;
+  stickyHeader?: boolean;
+}) {
   const hasOutput = Boolean(step.line.detail);
   const hasBody = step.events.length > 0 || hasOutput;
   const showHeader = Boolean(step.line.componentName.trim() || step.line.componentType);
@@ -928,7 +945,7 @@ function StreamStep({ step, highlightUserTalk = false }: { step: ClaudeStepGroup
         <div
           data-testid={`split-run-stream-line-${step.line.id}`}
           {...streamLineAttrs(step.line.status)}
-          className={cn(STREAM_LINE_WRAP_ROW, hasBody && STICKY_STEP)}
+          className={cn(STREAM_LINE_WRAP_ROW, hasBody && stickyHeader && STICKY_STEP)}
         >
           {step.line.componentType ? (
             <span className={cn("mr-2 shrink-0", stepTypeTone(step.line.componentType))}>

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
@@ -7,6 +7,7 @@ import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "re
 import type { FactoriesFactoryPullRequest, FactoriesWorkOrderArtifact } from "@/api-client";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Link } from "@/components/Link/link";
+import { MarkdownContent } from "@/pages/app/Markdown";
 import { useLiveLogStream } from "@/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream";
 
 import type { PhaseGlyphKind } from "../../lib/linePhaseRuns";
@@ -26,6 +27,8 @@ import { isRunnerComponent, mergeLiveStreamNotes, notesForLiveStream } from "./s
 /** One face and size for every log row, matched to the run log viewer. */
 const LOG_FACE = "font-mono text-[14px]";
 const PHASE_NAME_FACE = cn("flex min-w-0 items-center gap-1.5", LOG_FACE, "font-medium");
+const STREAM_NOTE_MARKDOWN =
+  "max-w-none font-sans text-[14px] leading-5 text-foreground [&_p:first-child]:mt-0 [&_p:last-child]:mb-0";
 
 function statusGlyph(status: SplitRunPhaseStatus): PhaseGlyphKind {
   if (status === "running") return "running";
@@ -985,14 +988,14 @@ function StreamTalkNote({ line, highlightUserTalk }: { line: SplitRunStreamLine;
     >
       <span className="inline-flex w-4 shrink-0" aria-hidden />
       {isUserTalk ? (
-        <div className="min-w-0 flex-1 rounded-md border-l-2 border-primary/50 bg-primary/10 px-2 py-1">
-          <span className="mb-0.5 block text-[11px] font-medium leading-none text-primary">{youLabel}</span>
-          <span className="whitespace-normal break-words leading-5 text-foreground">{line.componentName}</span>
+        <div className="min-w-0 flex-1 whitespace-normal break-words rounded-md border-l-2 border-primary/50 bg-primary/10 px-2 py-1">
+          <span className="mb-0.5 block font-sans text-[11px] font-medium leading-none text-primary">{youLabel}</span>
+          <MarkdownContent content={line.componentName} variant="workspace" className={STREAM_NOTE_MARKDOWN} />
         </div>
       ) : (
-        <span className="min-w-0 flex-1 whitespace-normal break-words py-0.5 leading-5 text-foreground">
-          {line.componentName}
-        </span>
+        <div className="min-w-0 flex-1 whitespace-normal break-words py-0.5 leading-5 text-foreground">
+          <MarkdownContent content={line.componentName} variant="workspace" className={STREAM_NOTE_MARKDOWN} />
+        </div>
       )}
     </div>
   );

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunAttentionNote.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunAttentionNote.tsx
@@ -1,8 +1,20 @@
 import type { ReactNode } from "react";
-import { Bug, CheckCircle2, CircleX, ExternalLink, FileText, Hourglass, Loader2, RotateCcw, Undo2 } from "lucide-react";
+import {
+  Bug,
+  CheckCircle2,
+  CircleX,
+  ExternalLink,
+  FileText,
+  Hourglass,
+  Loader2,
+  RotateCcw,
+  Sparkles,
+  Undo2,
+} from "lucide-react";
 
 import { Link } from "@/components/Link/link";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { MarkdownContent } from "@/pages/app/Markdown";
 import { WorkOrderPersonMention } from "@/pages/app/markdownMentions";
@@ -189,6 +201,9 @@ function ActionIcon({ icon }: { icon?: SplitRunFooterAction["icon"] }) {
   if (icon === "undo-2") {
     return <Undo2 className="size-3.5" aria-hidden />;
   }
+  if (icon === "sparkles") {
+    return <Sparkles className="size-3.5" aria-hidden />;
+  }
   return null;
 }
 
@@ -209,7 +224,7 @@ function NoteAction({
   const busy = action.kind === "start" ? startBusy : actionBusy;
   const disabled = action.kind === "start" ? startDisabled || startBusy : actionBusy;
 
-  return (
+  const button = (
     <Button
       type="button"
       size="sm"
@@ -221,5 +236,14 @@ function NoteAction({
       {busy ? <Loader2 className="size-3.5 animate-spin" aria-hidden /> : <ActionIcon icon={action.icon} />}
       {action.label}
     </Button>
+  );
+  if (!action.tooltip) {
+    return button;
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent>{action.tooltip}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.tsx
@@ -58,6 +58,7 @@ export function SplitRunReview({
   canAct = true,
   onStart,
   onReject,
+  onRefine,
   onBackToDraft,
   onStop,
   startBusy = false,
@@ -73,6 +74,7 @@ export function SplitRunReview({
   canAct?: boolean;
   onStart?: () => void | Promise<void>;
   onReject?: () => void | Promise<void>;
+  onRefine?: () => void;
   onBackToDraft?: () => void | Promise<void>;
   onStop?: (choice: SplitRunStopChoice) => void | Promise<void>;
   startBusy?: boolean;
@@ -92,6 +94,10 @@ export function SplitRunReview({
     }
     if (action.kind === "reject") {
       void onReject?.();
+      return;
+    }
+    if (action.kind === "refine") {
+      onRefine?.();
       return;
     }
     if (action.kind === "approve") {

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -708,6 +708,7 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
     const start = within(note).getByRole("button", { name: "Start" });
     expect(start).toBeInTheDocument();
+    expect(within(note).getByRole("button", { name: "Refine" })).toBeInTheDocument();
     expect(within(note).getByRole("button", { name: "Reject" })).toBeInTheDocument();
     expect(start.parentElement).toHaveClass("shrink-0");
     expect(start.parentElement).not.toHaveClass("mt-3");
@@ -719,6 +720,7 @@ describe("WorkOrderSplitRunPopup", () => {
     await openLogTab(user);
     expect(screen.getByTestId("split-run-log-pane").className).not.toContain("minmax(0,3fr)_minmax(0,2fr)");
     expect(within(note).getByRole("button", { name: "Start" })).toBeInTheDocument();
+    expect(within(note).getByRole("button", { name: "Refine" })).toBeInTheDocument();
     expect(within(note).getByRole("button", { name: "Reject" })).toBeInTheDocument();
     const backlog = screen.getByTestId("split-run-phase-backlog");
     expect(within(backlog).getByRole("button", { name: "Backlog" })).toHaveAttribute("aria-expanded", "false");

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -732,6 +732,16 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(screen.queryByTestId("split-run-checks")).not.toBeInTheDocument();
   });
 
+  it("shows a spark icon and tooltip on Refine", async () => {
+    const user = userEvent.setup();
+    renderPopup({ fixture: splitRunFixtureForWorkOrder(DRAFT_WORK_ORDER) });
+
+    const refine = within(screen.getByTestId("split-run-attention-note")).getByRole("button", { name: "Refine" });
+    expect(refine.querySelector(".lucide-sparkles")).toBeInTheDocument();
+    await user.hover(refine);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Ask an agent to update this task.");
+  });
+
   it("puts artifacts on the right and check analyses under the description", () => {
     renderPopup({
       fixture: splitRunFixtureForWorkOrder(REVIEW_CANDIDATE_WORK_ORDERS[0], { checks: OPEN_WORK_ORDER_CHECKS }),

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunDescription.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunDescription.tsx
@@ -15,11 +15,13 @@ export function WorkOrderSplitRunDescription({
   description,
   canEdit = false,
   busy = false,
+  collapsible = true,
   onSave,
 }: {
   description: string;
   canEdit?: boolean;
   busy?: boolean;
+  collapsible?: boolean;
   onSave?: (next: string) => void | Promise<void>;
 }) {
   const [editing, setEditing] = useState(false);
@@ -47,7 +49,7 @@ export function WorkOrderSplitRunDescription({
   };
 
   const body = saved.trim() ? (
-    <WorkOrderDescription description={saved} />
+    <WorkOrderDescription description={saved} collapsible={collapsible} />
   ) : (
     <p className="text-[13px] text-muted-foreground">No description yet.</p>
   );

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -216,6 +216,7 @@ export function WorkOrderSplitRunPopup({
   isDispatching = false,
   canDispatch = false,
   canUpdate = true,
+  onRefine,
 }: Omit<WorkOrderSplitRunBodyProps, "footerActions"> & {
   onClose?: () => void;
   fixed?: boolean;
@@ -223,6 +224,7 @@ export function WorkOrderSplitRunPopup({
   isDispatching?: boolean;
   canDispatch?: boolean;
   canUpdate?: boolean;
+  onRefine?: () => void;
 }) {
   const canPickDraftStartModel = useExperimentalFeature(organizationId).has(FEATURE_FACTORY_DRAFT_START_MODEL);
   const footerActions = useSplitRunFooterActions(organizationId, factoryId, orderId);
@@ -294,6 +296,7 @@ export function WorkOrderSplitRunPopup({
         canAct={canUpdate}
         onStart={draftStart}
         onReject={mutations.onReject}
+        onRefine={onRefine}
         onBackToDraft={backToDraft}
         onStop={mutations.onStop}
         startBusy={isDispatching}

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunStop.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunStop.spec.tsx
@@ -124,6 +124,25 @@ describe("WorkOrderSplitRunPopup decision footer", () => {
     expect(onDispatch).toHaveBeenCalledWith(undefined);
   });
 
+  it("refines a draft from the note", async () => {
+    const user = userEvent.setup();
+    const onRefine = vi.fn();
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter>
+          <ThemeProvider>
+            <TooltipProvider>
+              <WorkOrderSplitRunPopup fixture={splitRunFixtureForWorkOrder(DRAFT_WORK_ORDER)} onRefine={onRefine} />
+            </TooltipProvider>
+          </ThemeProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await user.click(within(screen.getByTestId("split-run-attention-note")).getByRole("button", { name: "Refine" }));
+    expect(onRefine).toHaveBeenCalledTimes(1);
+  });
+
   it("starts and rejects a draft from the note", async () => {
     enabledExperimentalFeatures.add(FEATURE_FACTORY_DRAFT_START_MODEL);
     const user = userEvent.setup();

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.spec.ts
@@ -41,7 +41,14 @@ const BACK_TO_DRAFT = {
   icon: "undo-2",
 };
 const REJECT = { id: "reject", kind: "reject", label: "Reject", emphasis: "quiet" };
-const REFINE = { id: "refine", kind: "refine", label: "Refine", emphasis: "quiet" };
+const REFINE = {
+  id: "refine",
+  kind: "refine",
+  label: "Refine",
+  emphasis: "quiet",
+  icon: "sparkles",
+  tooltip: "Ask an agent to update this task.",
+};
 const APPROVE = { id: "approve", kind: "approve", label: "Approve", emphasis: "primary" };
 const RERUN = { id: "rerun", kind: "rerun", label: "Rerun", emphasis: "primary" };
 const START = { id: "start", kind: "start", label: "Start", emphasis: "primary" };

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.spec.ts
@@ -41,19 +41,20 @@ const BACK_TO_DRAFT = {
   icon: "undo-2",
 };
 const REJECT = { id: "reject", kind: "reject", label: "Reject", emphasis: "quiet" };
+const REFINE = { id: "refine", kind: "refine", label: "Refine", emphasis: "quiet" };
 const APPROVE = { id: "approve", kind: "approve", label: "Approve", emphasis: "primary" };
 const RERUN = { id: "rerun", kind: "rerun", label: "Rerun", emphasis: "primary" };
 const START = { id: "start", kind: "start", label: "Start", emphasis: "primary" };
 const REOPEN = { id: "reopen", kind: "reopen", label: "Reopen", emphasis: "primary" };
 
 describe("buildSplitRunFooter", () => {
-  it("keeps a draft note with Reject and Start", () => {
+  it("keeps a draft note with Refine, Reject, and Start", () => {
     expect(buildSplitRunFooter({ kind: "draft", note: DRAFT_NOTE })).toEqual({
       kind: "draft",
       sentence: "This task is a draft.",
       note: { headline: "Review the plan, then start", text: "From GitHub issue PAY-842. Confidence 5/5." },
       attentionCard: true,
-      actions: [REJECT, START],
+      actions: [REFINE, REJECT, START],
     });
   });
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.ts
@@ -8,7 +8,7 @@ export type SplitRunFooterKind = "draft" | "running" | "waiting" | "failed" | "s
 /** @deprecated Use SplitRunFooterKind. Kept for fixture field name. */
 export type SplitRunFooterTone = SplitRunFooterKind;
 
-export type SplitRunFooterActionKind = "start" | "reject" | "approve" | "rerun" | "reopen" | "back-to-draft";
+export type SplitRunFooterActionKind = "start" | "reject" | "refine" | "approve" | "rerun" | "reopen" | "back-to-draft";
 
 export type SplitRunStopChoice = "canceled" | "completed" | "rerun-step" | "rerun-start" | "reopen";
 
@@ -145,6 +145,7 @@ export interface SplitRunFooter {
 }
 
 const REJECT: SplitRunFooterAction = { id: "reject", kind: "reject", label: "Reject", emphasis: "quiet" };
+const REFINE: SplitRunFooterAction = { id: "refine", kind: "refine", label: "Refine", emphasis: "quiet" };
 const APPROVE: SplitRunFooterAction = { id: "approve", kind: "approve", label: "Approve", emphasis: "primary" };
 const RERUN: SplitRunFooterAction = { id: "rerun", kind: "rerun", label: "Rerun", emphasis: "primary" };
 const START: SplitRunFooterAction = { id: "start", kind: "start", label: "Start", emphasis: "primary" };
@@ -260,8 +261,8 @@ export function toFooterNote(note: WorkOrderStatusNotePresentation): SplitRunFoo
 /**
  * Decision strip for the work-order popup. Running has no strip. Open
  * waiting and failed keep To Backlog with Reject, Approve, or Rerun.
- * Draft keeps Reject and Start. Closed failed keeps Reopen. Completed
- * and rejected explain the result only.
+ * Draft keeps Refine, Reject, and Start. Closed failed keeps Reopen.
+ * Completed and rejected explain the result only.
  */
 type FooterInput = {
   kind: SplitRunFooterKind;
@@ -295,7 +296,7 @@ function draftDecisionFooter(input: FooterInput, note?: SplitRunFooterNote): Spl
     sentence: "This task is a draft.",
     note,
     attentionCard: true,
-    actions: [REJECT, START],
+    actions: [REFINE, REJECT, START],
   });
 }
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.ts
@@ -2,6 +2,7 @@ import type { OrgUserDisplay } from "@/lib/orgUserDisplay";
 
 import { getWorkOrderDisplayStatusMeta, type WorkOrderDisplayStatus } from "../../lib/workOrderProgress";
 import type { WorkOrderStatusNotePresentation } from "../../lib/workOrderStatusNote";
+import { CREATE_WITH_AGENT_COPY } from "../createWithAgentCopy";
 
 export type SplitRunFooterKind = "draft" | "running" | "waiting" | "failed" | "stopped" | "done";
 
@@ -120,7 +121,8 @@ export interface SplitRunFooterAction {
   kind: SplitRunFooterActionKind;
   label: string;
   emphasis: "primary" | "quiet";
-  icon?: "undo-2";
+  icon?: "undo-2" | "sparkles";
+  tooltip?: string;
 }
 
 export interface SplitRunFooterNote {
@@ -145,7 +147,14 @@ export interface SplitRunFooter {
 }
 
 const REJECT: SplitRunFooterAction = { id: "reject", kind: "reject", label: "Reject", emphasis: "quiet" };
-const REFINE: SplitRunFooterAction = { id: "refine", kind: "refine", label: "Refine", emphasis: "quiet" };
+const REFINE: SplitRunFooterAction = {
+  id: "refine",
+  kind: "refine",
+  label: CREATE_WITH_AGENT_COPY.refine,
+  emphasis: "quiet",
+  icon: "sparkles",
+  tooltip: CREATE_WITH_AGENT_COPY.refineTooltip,
+};
 const APPROVE: SplitRunFooterAction = { id: "approve", kind: "approve", label: "Approve", emphasis: "primary" };
 const RERUN: SplitRunFooterAction = { id: "rerun", kind: "rerun", label: "Rerun", emphasis: "primary" };
 const START: SplitRunFooterAction = { id: "start", kind: "start", label: "Start", emphasis: "primary" };

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
@@ -169,7 +169,7 @@ describe("splitRunFixtureForWorkOrder", () => {
     expect(note?.text).toContain("**plan.md**");
     expect(note?.text).toContain("Confidence 5/5 (High):");
     expect(note?.text).toContain("- The GitHub issue names retryable status codes and a hard attempt limit.");
-    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Reject", "Start"]);
+    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Refine", "Reject", "Start"]);
   });
 
   it("pins a pull request review on a waiting implement card", () => {
@@ -744,7 +744,7 @@ describe("splitRunFixtureForWorkOrder", () => {
     expect(fixture.waitingNotes).toEqual([]);
     expect(fixture.footer.note?.headline).toBe("This task is ready to start");
     expect(fixture.footer.note?.text).toContain("Then click Start to send it to the line.");
-    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Reject", "Start"]);
+    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Refine", "Reject", "Start"]);
   });
 
   it("omits invented files and ledger pull requests for a live order", () => {


### PR DESCRIPTION
## Summary

The compact session log still showed automation and Agent rows after those headers stopped helping. Draft descriptions also showed raw markdown, and the empty log had no starting state.

This change hides the compact log headers, renders draft and preview markdown like the task popup, and shows a short intro while the planning session starts.


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["fix: Align planning tests and ESLint bud..."](https://github.com/superplanehq/superplane/commit/5383774c1ae3d392de95b6e1e87709e7692981d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61189915)</sub>

<!-- /greptile_comment -->