### PR TITLE
fix: Use setup agent for Create with an Agent

### DIFF
--- a/pkg/grpc/actions/factories/errors.go
+++ b/pkg/grpc/actions/factories/errors.go
@@ -114,8 +114,8 @@ func factoryErrorToStatus(err error, internalMessage string) error {
 		return grpcerrors.FailedPrecondition(err, "planning session has no draft")
 	case errors.Is(err, models.ErrFactoryPlanningSessionBusy):
 		return grpcerrors.FailedPrecondition(err, "Too many Create with an Agent sessions are running.")
-	case errors.Is(err, errPlanningClaudeRequired):
-		return grpcerrors.FailedPrecondition(err, "Connect Claude before you start Create with an Agent.")
+	case errors.Is(err, errPlanningAgentRequired):
+		return grpcerrors.FailedPrecondition(err, "Connect Anthropic, OpenAI, or OpenRouter before you start Create with an Agent.")
 	case errors.Is(err, errPlanningGitHubRequired):
 		return grpcerrors.FailedPrecondition(err, "Connect GitHub before you start Create with an Agent.")
 	case errors.Is(err, errIntakeNotConnected):

--- a/pkg/grpc/actions/factories/planning_canvas.go
+++ b/pkg/grpc/actions/factories/planning_canvas.go
@@ -2,12 +2,10 @@ package factories
 
 import (
 	"errors"
-	"slices"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/superplanehq/superplane/pkg/components/runner"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/yaml"
 	"gorm.io/datatypes"
@@ -21,7 +19,7 @@ const (
 )
 
 var (
-	errPlanningClaudeRequired = errors.New("claude is not connected")
+	errPlanningAgentRequired  = errors.New("agent is not connected")
 	errPlanningGitHubRequired = errors.New("github is not connected")
 )
 
@@ -166,51 +164,15 @@ func requirePlanningGitHub(tx *gorm.DB, factoryModel *models.Factory) error {
 }
 
 func planningCanvasAgent(tx *gorm.DB, factoryModel *models.Factory) (*intakeAgent, error) {
-	if agent := resolveIntakeAgent(tx, factoryModel); agent != nil && agent.component() == "runnerClaudeCode" {
+	if agent := resolveIntakeAgent(tx, factoryModel); agent != nil {
 		return agent, nil
 	}
-	if agent := resolveClaudePlanningAgent(tx, factoryModel); agent != nil {
-		return agent, nil
-	}
-	return nil, errPlanningClaudeRequired
-}
-
-func resolveClaudePlanningAgent(tx *gorm.DB, factoryModel *models.Factory) *intakeAgent {
-	integrations, err := models.ListIntegrations(tx, factoryModel.OrganizationID)
-	if err == nil {
-		for i := range integrations {
-			if integrations[i].AppName != "claude" {
-				continue
-			}
-			if agent := intakeAgentFromIntegration(&integrations[i]); agent != nil {
-				return agent
-			}
-		}
-	}
-	providers, err := models.ListHostedLLMProviders(tx)
-	if err != nil {
-		return nil
-	}
-	index := slices.IndexFunc(providers, func(provider models.HostedLLMProvider) bool {
-		return provider.Provider == models.UsageProviderAnthropic && provider.OffersHostedModels()
-	})
-	if index < 0 {
-		return nil
-	}
-	model := hostedIntakeModel(providers[index], "opus")
-	if model == "" {
-		return nil
-	}
-	return &intakeAgent{
-		Component:   "runnerClaudeCode",
-		Credentials: map[string]any{"source": runner.CredentialsSourceHosted},
-		Model:       model,
-	}
+	return nil, errPlanningAgentRequired
 }
 
 func planningTemplateAgent(agent *intakeAgent) *factoryTemplateAgent {
 	out := &factoryTemplateAgent{
-		component: "runnerClaudeCode",
+		component: agent.component(),
 		model:     agent.model(),
 	}
 	credentials := agent.credentials()
@@ -237,7 +199,7 @@ func planningTemplateIntegrations(tx *gorm.DB, factoryModel *models.Factory) map
 			continue
 		}
 		switch integrations[i].AppName {
-		case intakeGitHubAppName, "claude":
+		case intakeGitHubAppName, "claude", "openai", "openrouter":
 			out[integrations[i].AppName] = factoryTemplateIntegration{
 				id:   integrations[i].ID.String(),
 				name: integrations[i].InstallationName,

--- a/pkg/grpc/actions/factories/planning_session_test.go
+++ b/pkg/grpc/actions/factories/planning_session_test.go
@@ -354,40 +354,22 @@ func Test__StartPlanningSession__UsesClaudeAndDefaultParallelism(t *testing.T) {
 	assert.True(t, foundClaude)
 }
 
-func Test__StartPlanningSession__KeepsClaudeWhenSetupIsCodex(t *testing.T) {
+func Test__StartPlanningSession__UsesCodexWhenSetupIsCodex(t *testing.T) {
+	r := support.Setup(t)
+	factoryModel := startPlanningWithSetupAgent(t, r.Organization.ID, r.User, "openai")
+	assertPlanningAgentComponent(t, r.Organization.ID, factoryModel.ID, "runnerCodex")
+}
+
+func Test__StartPlanningSession__UsesOpenRouterWhenSetupIsOpenRouter(t *testing.T) {
+	r := support.Setup(t)
+	factoryModel := startPlanningWithSetupAgent(t, r.Organization.ID, r.User, "openrouter")
+	assertPlanningAgentComponent(t, r.Organization.ID, factoryModel.ID, "runnerOpenRouter")
+}
+
+func Test__StartPlanningSession__RequiresAgent(t *testing.T) {
 	r := support.Setup(t)
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 	db := database.DB(t.Context())
-	setupPlanningStart(t, r.Organization.ID)
-	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
-	require.NoError(t, err)
-	agentID := createReadyOnboardingIntegration(t, r.Organization.ID, "openai")
-	require.NoError(t, factoryModel.UpdateOnboarding(db, models.FactoryOnboardingPatch{
-		AgentIntegrationID: &agentID,
-	}))
-
-	_, err = StartPlanningSession(ctx, r.Organization.ID.String(), &pb.StartPlanningSessionRequest{
-		FactoryId:  factoryModel.ID.String(),
-		Repository: "acme/payments",
-	})
-	require.NoError(t, err)
-	canvas, err := models.FindPlanningCanvas(db, r.Organization.ID, factoryModel.ID)
-	require.NoError(t, err)
-	nodes, err := models.FindCanvasNodesInTransaction(db, canvas.ID)
-	require.NoError(t, err)
-	for _, node := range nodes {
-		if node.Type == models.NodeTypeComponent {
-			assert.Equal(t, "runnerClaudeCode", node.ComponentName())
-			return
-		}
-	}
-	t.Fatal("missing planning agent")
-}
-
-func Test__StartPlanningSession__RequiresClaude(t *testing.T) {
-	r := support.Setup(t)
-	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
-	db := database.Conn()
 	require.NoError(t, db.Where("provider <> ?", "").Delete(&models.HostedLLMProvider{}).Error)
 	createReadyOnboardingIntegration(t, r.Organization.ID, intakeGitHubAppName)
 	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
@@ -398,7 +380,7 @@ func Test__StartPlanningSession__RequiresClaude(t *testing.T) {
 		Repository: "acme/payments",
 	})
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "Connect Claude before you start Create with an Agent.")
+	assert.ErrorContains(t, err, "Connect Anthropic, OpenAI, or OpenRouter before you start Create with an Agent.")
 }
 
 func Test__StartPlanningSession__RequiresGitHub(t *testing.T) {
@@ -506,6 +488,40 @@ func setupPlanningStart(t *testing.T, organizationID uuid.UUID) {
 	t.Helper()
 	upsertHostedOnboardingProvider(t, database.DB(t.Context()))
 	createReadyOnboardingIntegration(t, organizationID, intakeGitHubAppName)
+}
+
+func startPlanningWithSetupAgent(t *testing.T, organizationID, userID uuid.UUID, appName string) *models.Factory {
+	t.Helper()
+	ctx := authentication.SetUserIdInMetadata(context.Background(), userID.String())
+	db := database.DB(t.Context())
+	setupPlanningStart(t, organizationID)
+	factoryModel, err := models.CreateFactory(db, organizationID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	agentID := createReadyOnboardingIntegration(t, organizationID, appName)
+	require.NoError(t, factoryModel.UpdateOnboarding(db, models.FactoryOnboardingPatch{
+		AgentIntegrationID: &agentID,
+	}))
+	_, err = StartPlanningSession(ctx, organizationID.String(), &pb.StartPlanningSessionRequest{
+		FactoryId:  factoryModel.ID.String(),
+		Repository: "acme/payments",
+	})
+	require.NoError(t, err)
+	return factoryModel
+}
+
+func assertPlanningAgentComponent(t *testing.T, organizationID, factoryID uuid.UUID, want string) {
+	t.Helper()
+	canvas, err := models.FindPlanningCanvas(database.DB(t.Context()), organizationID, factoryID)
+	require.NoError(t, err)
+	nodes, err := models.FindCanvasNodesInTransaction(database.DB(t.Context()), canvas.ID)
+	require.NoError(t, err)
+	for _, node := range nodes {
+		if node.Type == models.NodeTypeComponent {
+			assert.Equal(t, want, node.ComponentName())
+			return
+		}
+	}
+	t.Fatal("missing planning agent")
 }
 
 func planningAgentPrompt(t *testing.T, organizationID, factoryID uuid.UUID) string {


### PR DESCRIPTION
## Summary

A missing Create with an Agent canvas always used Claude.
Setup already rewrites line apps to Anthropic, OpenAI, or OpenRouter.
Start now uses that same agent pick when it creates the canvas.
An existing canvas is not rewritten. A later agent switch still needs that rewrite.


Made with [Cursor](https://cursor.com)