### PR TITLE
fix: Require API key before Connect

### DIFF
--- a/web_src/src/hooks/useIntegrationCatalog.ts
+++ b/web_src/src/hooks/useIntegrationCatalog.ts
@@ -206,36 +206,20 @@ function useIntegrationCatalogActions({
       setIsModalOpen(true);
       analytics.integrationConnectStart(integration.name ?? "", "integrations_page", organizationId);
     },
-    handleConnect: async () => {
-      if (!canCreateIntegrations || !selectedIntegration?.name) {
-        return;
-      }
-      if (!integrationName.trim()) {
-        showErrorToast("Integration name is required");
-        return;
-      }
-      if (!areRequiredCreateFieldsFilled(selectedIntegration.configuration ?? [], configuration)) {
-        showErrorToast("Enter every required field.");
-        return;
-      }
-      try {
-        const result = await createIntegrationMutation.mutateAsync({
-          integrationName: selectedIntegration.name,
-          name: integrationName,
-          configuration,
-        });
-        setIsModalOpen(false);
-        setSelectedIntegration(null);
-        setIntegrationName("");
-        setConfiguration({});
-        const createdId = result.data?.integration?.metadata?.id;
-        if (createdId) {
-          navigate(integrationDetailPath(integrationsBasePath, createdId));
-        }
-      } catch (error) {
-        showErrorToast(getUsageLimitToastMessage(error, "Failed to create integration"));
-      }
-    },
+    handleConnect: () =>
+      submitCatalogConnect({
+        canCreateIntegrations,
+        selectedIntegration,
+        integrationName,
+        configuration,
+        createIntegrationMutation,
+        integrationsBasePath,
+        navigate,
+        setIsModalOpen,
+        setSelectedIntegration,
+        setIntegrationName,
+        setConfiguration,
+      }),
     handleRequestIntegration: () => {
       analytics.integrationRequested(organizationId);
     },
@@ -259,6 +243,62 @@ function useIntegrationCatalogActions({
       }
     },
   };
+}
+
+async function submitCatalogConnect({
+  canCreateIntegrations,
+  selectedIntegration,
+  integrationName,
+  configuration,
+  createIntegrationMutation,
+  integrationsBasePath,
+  navigate,
+  setIsModalOpen,
+  setSelectedIntegration,
+  setIntegrationName,
+  setConfiguration,
+}: {
+  canCreateIntegrations: boolean;
+  selectedIntegration: IntegrationsIntegrationDefinition | null;
+  integrationName: string;
+  configuration: Record<string, unknown>;
+  createIntegrationMutation: ReturnType<typeof useCreateIntegration>;
+  integrationsBasePath: string;
+  navigate: ReturnType<typeof useNavigate>;
+  setIsModalOpen: (open: boolean) => void;
+  setSelectedIntegration: (integration: IntegrationsIntegrationDefinition | null) => void;
+  setIntegrationName: (name: string) => void;
+  setConfiguration: (configuration: Record<string, unknown>) => void;
+}) {
+  if (!canCreateIntegrations || !selectedIntegration?.name) {
+    return;
+  }
+  if (!integrationName.trim()) {
+    showErrorToast("Integration name is required");
+    return;
+  }
+  if (!areRequiredCreateFieldsFilled(selectedIntegration.configuration ?? [], configuration)) {
+    showErrorToast("Enter every required field.");
+    return;
+  }
+
+  try {
+    const result = await createIntegrationMutation.mutateAsync({
+      integrationName: selectedIntegration.name,
+      name: integrationName,
+      configuration,
+    });
+    setIsModalOpen(false);
+    setSelectedIntegration(null);
+    setIntegrationName("");
+    setConfiguration({});
+    const createdId = result.data?.integration?.metadata?.id;
+    if (createdId) {
+      navigate(integrationDetailPath(integrationsBasePath, createdId));
+    }
+  } catch (error) {
+    showErrorToast(getUsageLimitToastMessage(error, "Failed to create integration"));
+  }
 }
 
 function startCatalogPrivateGitHubApp({

--- a/web_src/src/hooks/useIntegrationCatalog.ts
+++ b/web_src/src/hooks/useIntegrationCatalog.ts
@@ -18,6 +18,7 @@ import { integrationDetailPath, integrationSetupPath, useIntegrationsBasePath } 
 import { getNextIntegrationName } from "@/pages/organization/settings/components/IntegrationSetup/lib";
 import { buildIntegrationCatalog, filterIntegrationCatalog, integrationNameSet } from "@/lib/integrationCatalog";
 import { persistGitHubSetupReturnPath, startDirectGitHubConnect } from "@/lib/startDirectGitHubConnect";
+import { areRequiredCreateFieldsFilled } from "@/ui/IntegrationCreateDialog/configurationFields";
 import { useMe } from "@/hooks/useMe";
 
 const INTEGRATION_SURVEY_NAME = "Integration Survey";
@@ -49,6 +50,9 @@ export function useIntegrationCatalog(organizationId: string) {
     () => filterIntegrationCatalog(integrationCatalog, filterQuery),
     [filterQuery, integrationCatalog],
   );
+  const canConnect =
+    Boolean(integrationName.trim()) &&
+    areRequiredCreateFieldsFilled(selectedIntegration?.configuration ?? [], configuration);
 
   useReportPageReady(!isLoading && !permissionsLoading);
 
@@ -86,6 +90,7 @@ export function useIntegrationCatalog(organizationId: string) {
     selectedInstructions: selectedIntegration?.instructions?.trim() ?? "",
     integrationName,
     setIntegrationName,
+    canConnect,
     configuration,
     setConfiguration,
     isModalOpen,
@@ -203,6 +208,14 @@ function useIntegrationCatalogActions({
     },
     handleConnect: async () => {
       if (!canCreateIntegrations || !selectedIntegration?.name) {
+        return;
+      }
+      if (!integrationName.trim()) {
+        showErrorToast("Integration name is required");
+        return;
+      }
+      if (!areRequiredCreateFieldsFilled(selectedIntegration.configuration ?? [], configuration)) {
+        showErrorToast("Enter every required field.");
         return;
       }
       try {

--- a/web_src/src/pages/organization/settings/IntegrationCatalog.tsx
+++ b/web_src/src/pages/organization/settings/IntegrationCatalog.tsx
@@ -368,9 +368,7 @@ function FactoriesConnectModal({ catalog }: { catalog: CatalogState }) {
               <Button
                 onClick={() => void catalog.handleConnect()}
                 disabled={
-                  catalog.createIntegrationMutation.isPending ||
-                  !catalog.integrationName.trim() ||
-                  !catalog.canCreateIntegrations
+                  catalog.createIntegrationMutation.isPending || !catalog.canConnect || !catalog.canCreateIntegrations
                 }
                 className="flex items-center gap-2"
               >
@@ -435,9 +433,7 @@ function LegacyConnectModal({ catalog }: { catalog: CatalogState }) {
               color="blue"
               onClick={() => void catalog.handleConnect()}
               disabled={
-                catalog.createIntegrationMutation.isPending ||
-                !catalog.integrationName.trim() ||
-                !catalog.canCreateIntegrations
+                catalog.createIntegrationMutation.isPending || !catalog.canConnect || !catalog.canCreateIntegrations
               }
               className="flex items-center gap-2"
             >

--- a/web_src/src/ui/IntegrationCreateDialog/IntegrationCreateDialogFooter.tsx
+++ b/web_src/src/ui/IntegrationCreateDialog/IntegrationCreateDialogFooter.tsx
@@ -11,7 +11,7 @@ interface IntegrationCreateDialogFooterProps {
   browserActionCompleted: boolean;
   mutationPending: boolean;
   isCreatePending: boolean;
-  integrationName: string;
+  canSubmit: boolean;
   onCompleteWebhookSetup: () => Promise<void>;
   onBrowserActionContinue: () => void;
   onBrowserActionConfigSave: () => Promise<void>;
@@ -26,7 +26,7 @@ export function IntegrationCreateDialogFooter({
   browserActionCompleted,
   mutationPending,
   isCreatePending,
-  integrationName,
+  canSubmit,
   onCompleteWebhookSetup,
   onBrowserActionContinue,
   onBrowserActionConfigSave,
@@ -101,7 +101,7 @@ export function IntegrationCreateDialogFooter({
       <LoadingButton
         color="blue"
         onClick={() => void onSubmit()}
-        disabled={!integrationName?.trim()}
+        disabled={!canSubmit}
         loading={isCreatePending}
         loadingText="Connecting..."
         className="flex items-center gap-2"

--- a/web_src/src/ui/IntegrationCreateDialog/configurationFields.spec.ts
+++ b/web_src/src/ui/IntegrationCreateDialog/configurationFields.spec.ts
@@ -1,7 +1,12 @@
 import type { ConfigurationField } from "@/api-client";
 import { describe, expect, it } from "vitest";
 
-import { selectCreateStepFields, selectVisibleFields, selectWebhookStepFields } from "./configurationFields";
+import {
+  areRequiredCreateFieldsFilled,
+  selectCreateStepFields,
+  selectVisibleFields,
+  selectWebhookStepFields,
+} from "./configurationFields";
 
 const apiKey: ConfigurationField = { name: "apiKey", type: "string", required: true };
 const adminKey: ConfigurationField = { name: "adminKey", type: "string", required: false, togglable: true };
@@ -44,5 +49,54 @@ describe("selectWebhookStepFields", () => {
   it("never shows a hidden field, because it is not visible", () => {
     const visible = selectVisibleFields([apiKey, adminKey], ["adminKey"]);
     expect(selectWebhookStepFields(visible, ["apiKey"])).toEqual([]);
+  });
+});
+
+describe("areRequiredCreateFieldsFilled", () => {
+  const hiddenRequired: ConfigurationField = {
+    name: "token",
+    type: "string",
+    required: true,
+    visibilityConditions: [{ field: "mode", values: ["advanced"] }],
+  };
+
+  it("rejects an empty required apiKey", () => {
+    expect(areRequiredCreateFieldsFilled([apiKey, adminKey], {})).toBe(false);
+  });
+
+  it("rejects a whitespace-only apiKey", () => {
+    expect(areRequiredCreateFieldsFilled([apiKey], { apiKey: "   " })).toBe(false);
+  });
+
+  it("accepts a filled apiKey", () => {
+    expect(areRequiredCreateFieldsFilled([apiKey, adminKey], { apiKey: "sk-test" })).toBe(true);
+  });
+
+  it("does not require an optional togglable adminKey", () => {
+    expect(areRequiredCreateFieldsFilled([apiKey, adminKey], { apiKey: "sk-test" })).toBe(true);
+  });
+
+  it("does not require a togglable field that is turned off", () => {
+    const togglableRequired: ConfigurationField = {
+      name: "optionalSecret",
+      type: "string",
+      required: true,
+      togglable: true,
+    };
+    expect(areRequiredCreateFieldsFilled([togglableRequired], {})).toBe(true);
+  });
+
+  it("does not require a field that is not visible", () => {
+    expect(areRequiredCreateFieldsFilled([hiddenRequired], {})).toBe(true);
+  });
+
+  it("requires a visible field that has visibility conditions", () => {
+    expect(areRequiredCreateFieldsFilled([hiddenRequired], { mode: "advanced" })).toBe(false);
+    expect(areRequiredCreateFieldsFilled([hiddenRequired], { mode: "advanced", token: "abc" })).toBe(true);
+  });
+
+  it("accepts a create step with no required fields", () => {
+    expect(areRequiredCreateFieldsFilled([], {})).toBe(true);
+    expect(areRequiredCreateFieldsFilled([signingSecret], {})).toBe(true);
   });
 });

--- a/web_src/src/ui/IntegrationCreateDialog/configurationFields.ts
+++ b/web_src/src/ui/IntegrationCreateDialog/configurationFields.ts
@@ -1,4 +1,5 @@
 import type { ConfigurationField } from "@/api-client";
+import { isFieldRequired, isFieldVisible } from "@/lib/components";
 
 const WEBHOOK_SECRET_FIELD_NAMES = ["signingSecret", "webhookSigningSecret"];
 
@@ -28,4 +29,41 @@ export function selectWebhookStepFields(
     return visibleFields.filter((field) => !initialStepFieldNames.includes(field.name!));
   }
   return visibleFields.filter((field) => WEBHOOK_SECRET_FIELD_NAMES.includes(field.name!));
+}
+
+/** True when every visible, required create-step field has a non-empty value. */
+export function areRequiredCreateFieldsFilled(fields: ConfigurationField[], values: Record<string, unknown>): boolean {
+  return fields.every((field) => isCreateFieldReady(field, values));
+}
+
+function isCreateFieldReady(field: ConfigurationField, values: Record<string, unknown>): boolean {
+  if (!field.name || !isFieldVisible(field, values)) {
+    return true;
+  }
+
+  const value = values[field.name];
+  if (field.togglable && (value === null || value === undefined)) {
+    return true;
+  }
+  if (!isFieldRequired(field, values)) {
+    return true;
+  }
+
+  return !isConfigurationValueEmpty(value);
+}
+
+function isConfigurationValueEmpty(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return true;
+  }
+  if (typeof value === "string") {
+    return value.trim() === "";
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  if (typeof value === "object") {
+    return Object.keys(value).length === 0;
+  }
+  return false;
 }

--- a/web_src/src/ui/IntegrationCreateDialog/index.tsx
+++ b/web_src/src/ui/IntegrationCreateDialog/index.tsx
@@ -16,7 +16,12 @@ import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { useUpdateIntegration } from "@/hooks/useIntegrations";
 import { UsageLimitAlert } from "@/components/UsageLimitAlert";
 import { Alert, AlertDescription, AlertTitle } from "@/ui/alert";
-import { selectCreateStepFields, selectVisibleFields, selectWebhookStepFields } from "./configurationFields";
+import {
+  areRequiredCreateFieldsFilled,
+  selectCreateStepFields,
+  selectVisibleFields,
+  selectWebhookStepFields,
+} from "./configurationFields";
 import { createWithGeneratedName, useGeneratedIntegrationName } from "./generatedName";
 import { IntegrationCreateDialogFooter } from "./IntegrationCreateDialogFooter";
 import { useBrowserActionSetup } from "./useBrowserActionSetup";
@@ -195,12 +200,19 @@ export function IntegrationCreateDialog({
     setCreatedName,
   ]);
 
+  const canSubmit =
+    Boolean(effectiveIntegrationName.trim()) && areRequiredCreateFieldsFilled(createStepFields, configuration);
+
   const handleSubmit = useCallback(async () => {
     if (!integrationDefinition?.name || !organizationId) return;
     const definitionName = integrationDefinition.name;
     const nextName = effectiveIntegrationName.trim();
     if (!nextName) {
       showErrorToast("Integration name is required");
+      return;
+    }
+    if (!areRequiredCreateFieldsFilled(createStepFields, configuration)) {
+      showErrorToast("Enter every required field.");
       return;
     }
 
@@ -261,6 +273,7 @@ export function IntegrationCreateDialog({
     integrationDefinition?.name,
     organizationId,
     effectiveIntegrationName,
+    createStepFields,
     configuration,
     existingIntegrationNames,
     githubBaseName,
@@ -432,7 +445,7 @@ export function IntegrationCreateDialog({
           browserActionCompleted={browserActionCompleted}
           mutationPending={updateIntegrationMutation.isPending}
           isCreatePending={isCreatePending}
-          integrationName={effectiveIntegrationName}
+          canSubmit={canSubmit}
           onCompleteWebhookSetup={handleCompleteWebhookSetup}
           onBrowserActionContinue={handleBrowserActionContinue}
           onBrowserActionConfigSave={handleBrowserActionConfigSave}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Factory setup enabled Connect when the Claude API key was empty. SuperPlane created an Error integration. Finish setup stayed blocked.

This change requires every required create-step field before Connect. The Integrations catalog uses the same rule.

Closes #7078

## Test plan

- [ ] Open factory setup on a local instance with no hosted credit.
- [ ] Open Connect Anthropic. Leave API Key empty.
- [ ] Confirm Connect stays disabled. Confirm SuperPlane does not create an integration.
- [ ] Enter an API key. Confirm Connect is enabled.
- [ ] Open Connect Claude from organization Integrations. Leave API Key empty.
- [ ] Confirm Connect stays disabled.

[empty-api-key-connect-gate.mp4](https://cursor.com/agents/bc-c17b1603-2d10-4065-b158-7d733e87d6be/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fempty-api-key-connect-gate.mp4)

[Factory Configure Claude with empty API key](https://cursor.com/agents/bc-c17b1603-2d10-4065-b158-7d733e87d6be/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffactory-configure-claude-empty-key.webp)

[Factory Configure Claude with API key filled](https://cursor.com/agents/bc-c17b1603-2d10-4065-b158-7d733e87d6be/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffactory-configure-claude-filled-key.webp)

[Integrations catalog Connect Claude with empty API key](https://cursor.com/agents/bc-c17b1603-2d10-4065-b158-7d733e87d6be/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcatalog-connect-empty-key.webp)

[Integrations catalog Connect Claude with API key filled](https://cursor.com/agents/bc-c17b1603-2d10-4065-b158-7d733e87d6be/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcatalog-connect-filled-key.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c17b1603-2d10-4065-b158-7d733e87d6be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c17b1603-2d10-4065-b158-7d733e87d6be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["chore: Extract catalog Connect submit he..."](https://github.com/superplanehq/superplane/commit/f8769c8d8b5c0beba7c7086bb7cf9fbb15a696ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61263240)</sub>

<!-- /greptile_comment -->