### PR TITLE
fix: Skip runtime expressions in factory install params

### DIFF
--- a/pkg/grpc/actions/factories/factory_app_templates.go
+++ b/pkg/grpc/actions/factories/factory_app_templates.go
@@ -396,14 +396,19 @@ func factoryIntegrationNames(value any) []string {
 	return names
 }
 
+// deriveFactoryInstallParams infers install parameters from the current
+// canvas nodes. Only static values qualify: template expressions such as
+// "{{ root().data.repository.full_name }}" resolve during a run, so
+// substituting them into trigger configurations produces webhooks that can
+// never provision.
 func deriveFactoryInstallParams(nodes []models.Node) map[string]string {
 	params := map[string]string{}
 	for _, node := range nodes {
-		if value := configString(node.Configuration, "repository"); value != "" && params["appRepository"] == "" {
+		if value := staticConfigString(node.Configuration, "repository"); value != "" && params["appRepository"] == "" {
 			params["appRepository"] = value
 			params["backlogRepository"] = value
 		}
-		if value := configString(node.Configuration, "base"); value != "" && params["defaultBranch"] == "" {
+		if value := staticConfigString(node.Configuration, "base"); value != "" && params["defaultBranch"] == "" {
 			params["defaultBranch"] = value
 		}
 		environment, _ := node.Configuration["environment"].([]any)
@@ -411,6 +416,9 @@ func deriveFactoryInstallParams(nodes []models.Node) map[string]string {
 			entry, _ := item.(map[string]any)
 			name, _ := entry["name"].(string)
 			value, _ := entry["value"].(string)
+			if containsTemplateExpression(value) {
+				continue
+			}
 			if name == "REPO" && value != "" && params["appRepository"] == "" {
 				params["appRepository"] = value
 			}
@@ -455,6 +463,20 @@ func deriveFactoryAgent(nodes []models.Node) *factoryTemplateAgent {
 func configString(configuration map[string]any, key string) string {
 	value, _ := configuration[key].(string)
 	return value
+}
+
+// staticConfigString returns the configuration value for key, or an empty
+// string when the value contains a template expression.
+func staticConfigString(configuration map[string]any, key string) string {
+	value := configString(configuration, key)
+	if containsTemplateExpression(value) {
+		return ""
+	}
+	return value
+}
+
+func containsTemplateExpression(value string) bool {
+	return strings.Contains(value, "{{")
 }
 
 func materializeIntakeDefaults(

--- a/pkg/grpc/actions/factories/factory_app_templates_test.go
+++ b/pkg/grpc/actions/factories/factory_app_templates_test.go
@@ -146,6 +146,51 @@ func TestMaterializeCreateWithAgentUsesPlanningModel(t *testing.T) {
 	assert.Equal(t, 10, *agent.Concurrency.Max)
 }
 
+func TestDeriveFactoryInstallParamsSkipsRuntimeExpressions(t *testing.T) {
+	params := deriveFactoryInstallParams([]models.Node{
+		{
+			ID: "find-pull-request",
+			Configuration: map[string]any{
+				"repository": "{{ root().data.repository.full_name }}",
+				"base":       "{{ root().data.pull_request.base.ref }}",
+			},
+		},
+		{
+			ID: "runner",
+			Configuration: map[string]any{
+				"environment": []any{
+					map[string]any{"name": "REPO", "value": "{{ install_params.appRepository }}"},
+					map[string]any{"name": "BASE", "value": "{{ install_params.defaultBranch }}"},
+				},
+			},
+		},
+		{
+			ID: "on-pr-closed",
+			Configuration: map[string]any{
+				"repository": "acme/widgets",
+				"base":       "release",
+			},
+		},
+	})
+
+	assert.Equal(t, "acme/widgets", params["appRepository"])
+	assert.Equal(t, "acme/widgets", params["backlogRepository"])
+	assert.Equal(t, "release", params["defaultBranch"])
+}
+
+func TestDeriveFactoryInstallParamsWithOnlyExpressionsDerivesNothing(t *testing.T) {
+	params := deriveFactoryInstallParams([]models.Node{
+		{
+			ID: "find-pull-request",
+			Configuration: map[string]any{
+				"repository": "{{ root().data.repository.full_name }}",
+			},
+		},
+	})
+
+	assert.Empty(t, params)
+}
+
 func TestMaterializeIntakeDefaults(t *testing.T) {
 	source := models.FactoryIntakeSourceGitHubIssues
 	current, err := buildIntakeCanvas(intakeCanvasRequest{Source: source})


### PR DESCRIPTION
## Summary

- The reset-to-defaults flow derives install parameters from existing canvas nodes.
- The derivation copied runtime expressions such as `{{ root().data.repository.full_name }}` from action nodes into the `appRepository` parameter.
- The trigger configuration then received the literal expression as its repository. Webhook provisioning sent it to GitHub, GitHub returned 404, and the webhook moved to the failed state. The trigger stopped receiving events.
- The derivation now ignores values that contain template expressions. Only static values qualify as install parameters.

## Test plan

- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/factories`.
- [ ] Reset a factory app to defaults when an action node holds an expression repository.
- [ ] Confirm the trigger keeps a concrete repository and the webhook provisions.

Made with [Cursor](https://cursor.com)