### PR TITLE
fix: load usage chart without opening the run

### DIFF
--- a/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.tsx
@@ -106,6 +106,7 @@ function SplitRunLoadedPage({ model }: { model: ReturnType<typeof useFactoryAppS
                   expanded
                   collapsible={false}
                   stream={model.stream}
+                  streamLoading={model.streamLoading}
                   selectedNodeId={model.nodeId}
                   onSelectNode={model.setNodeId}
                   organizationId={model.organizationId}

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
@@ -1306,7 +1306,12 @@ function resolvedUsageSeries(
   return fallbackSeries;
 }
 
-function isAgentUsageLoading(canStream: boolean, hasTurns: boolean, isStreaming: boolean, nodeRunning: boolean): boolean {
+function isAgentUsageLoading(
+  canStream: boolean,
+  hasTurns: boolean,
+  isStreaming: boolean,
+  nodeRunning: boolean,
+): boolean {
   return canStream && !hasTurns && (isStreaming || nodeRunning);
 }
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
@@ -410,6 +410,7 @@ export function PhaseLogCard({
   organizationId,
   canvasId,
   compactSessionLog = false,
+  streamLoading = false,
 }: {
   phase: SplitRunPhase;
   expanded: boolean;
@@ -429,12 +430,17 @@ export function PhaseLogCard({
   canvasId?: string;
   /** Collapse setup noise and bash in the Create with an Agent session log. */
   compactSessionLog?: boolean;
+  /** Live canvas or run details are still loading for this phase. */
+  streamLoading?: boolean;
 }) {
   const groups = groupSplitRunStream(stream ?? phase.stream);
   const producedArtifacts = artifactsProducedBySteps(groups, phase.artifacts);
   const producedPullRequests = pullRequestsProducedBySteps(groups);
   const rootRef = useRef<HTMLDivElement>(null);
   useLastRunningLine(rootRef, phase.status === "running");
+  const expectUsage = groups.some(
+    (group) => isRunnerComponent(group.line.component) && Boolean(group.line.executionId),
+  );
 
   useEffect(() => {
     if (!selectedNodeId) {
@@ -455,7 +461,7 @@ export function PhaseLogCard({
       data-testid={`split-run-phase-${phase.id}`}
       aria-current={expanded ? "step" : undefined}
     >
-      <PhaseAgentUsageProvider>
+      <PhaseAgentUsageProvider streamLoading={streamLoading} expectUsage={expectUsage}>
         <PhaseCollapsedUsageCollectors
           groups={groups}
           expanded={expanded}
@@ -870,13 +876,14 @@ function StreamNode({
   compactSessionLog: boolean;
 }) {
   const { line, notes, artifact, pullRequest } = group;
-  const { notes: liveNotes, usageSeries } = useRunnerNodeLiveNotes(line, organizationId, canvasId);
-  useReportPhaseAgentUsageSeries(
-    line.nodeId ?? line.id,
-    line.componentName,
-    usageSeries,
-    isRunnerComponent(line.component),
-  );
+  const { notes: liveNotes, usageSeries, usageLoading } = useRunnerNodeLiveNotes(line, organizationId, canvasId);
+  useReportPhaseAgentUsageSeries({
+    nodeId: line.nodeId ?? line.id,
+    fallbackName: line.componentName,
+    series: usageSeries,
+    enabled: isRunnerComponent(line.component),
+    loading: usageLoading,
+  });
   const merged = compactSessionLog
     ? mergePlanningSessionNotes(liveNotes, notes)
     : mergeLiveStreamNotes(liveNotes, notes);
@@ -1252,8 +1259,14 @@ function PhaseAgentUsageCollector({
   organizationId?: string;
   canvasId?: string;
 }) {
-  const { usageSeries } = useRunnerNodeLiveNotes(line, organizationId, canvasId);
-  useReportPhaseAgentUsageSeries(line.nodeId ?? line.id, line.componentName, usageSeries, true);
+  const { usageSeries, usageLoading } = useRunnerNodeLiveNotes(line, organizationId, canvasId);
+  useReportPhaseAgentUsageSeries({
+    nodeId: line.nodeId ?? line.id,
+    fallbackName: line.componentName,
+    series: usageSeries,
+    enabled: true,
+    loading: usageLoading,
+  });
   return null;
 }
 
@@ -1261,7 +1274,12 @@ function useRunnerNodeLiveNotes(
   line: SplitRunStreamLine,
   organizationId?: string,
   canvasId?: string,
-): { notes: SplitRunStreamLine[] | undefined; telemetry: AgentRunTelemetry; usageSeries: AgentPromptUsageSeries[] } {
+): {
+  notes: SplitRunStreamLine[] | undefined;
+  telemetry: AgentRunTelemetry;
+  usageSeries: AgentPromptUsageSeries[];
+  usageLoading: boolean;
+} {
   const canStream = Boolean(organizationId && canvasId && line.executionId && isRunnerComponent(line.component));
   const { sections, orphanLines, error, isStreaming, telemetry, usageSeries } = useLiveLogStream(
     canStream ? (line.executionId ?? "") : "",
@@ -1276,8 +1294,10 @@ function useRunnerNodeLiveNotes(
     [nextTelemetry],
   );
   const nextSeries = usageSeries && usageSeries.length > 0 ? usageSeries : fallbackSeries;
+  const hasTurns = nextSeries.some((item) => item.telemetry.turns.length > 0);
+  const usageLoading = canStream && isStreaming && !hasTurns;
   if (!canStream) {
-    return { notes: undefined, telemetry: nextTelemetry, usageSeries: nextSeries };
+    return { notes: undefined, telemetry: nextTelemetry, usageSeries: nextSeries, usageLoading: false };
   }
   return {
     notes: notesForLiveStream({
@@ -1290,5 +1310,6 @@ function useRunnerNodeLiveNotes(
     }),
     telemetry: nextTelemetry,
     usageSeries: nextSeries,
+    usageLoading,
   };
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
@@ -394,24 +394,7 @@ function isNestedHeaderControl(target: EventTarget | null): boolean {
   return target instanceof Element && Boolean(target.closest("a, button, [role='button']"));
 }
 
-export function PhaseLogCard({
-  phase,
-  expanded,
-  stream,
-  selectedNodeId,
-  onToggle,
-  onSelectNode,
-  onStop,
-  onRerun,
-  runHref,
-  editHref,
-  actionBusy = false,
-  collapsible = true,
-  organizationId,
-  canvasId,
-  compactSessionLog = false,
-  streamLoading = false,
-}: {
+type PhaseLogCardProps = {
   phase: SplitRunPhase;
   expanded: boolean;
   stream?: SplitRunStreamLine[];
@@ -432,15 +415,38 @@ export function PhaseLogCard({
   compactSessionLog?: boolean;
   /** Live canvas or run details are still loading for this phase. */
   streamLoading?: boolean;
-}) {
+  onUsageOpenChange?: (open: boolean) => void;
+};
+
+function phaseExpectsUsage(groups: StreamNodeGroup[]): boolean {
+  return groups.some((group) => isRunnerComponent(group.line.component) && Boolean(group.line.executionId));
+}
+
+export function PhaseLogCard({
+  phase,
+  expanded,
+  stream,
+  selectedNodeId,
+  onToggle,
+  onSelectNode,
+  onStop,
+  onRerun,
+  runHref,
+  editHref,
+  actionBusy = false,
+  collapsible = true,
+  organizationId,
+  canvasId,
+  compactSessionLog = false,
+  streamLoading = false,
+  onUsageOpenChange,
+}: PhaseLogCardProps) {
   const groups = groupSplitRunStream(stream ?? phase.stream);
   const producedArtifacts = artifactsProducedBySteps(groups, phase.artifacts);
   const producedPullRequests = pullRequestsProducedBySteps(groups);
   const rootRef = useRef<HTMLDivElement>(null);
   useLastRunningLine(rootRef, phase.status === "running");
-  const expectUsage = groups.some(
-    (group) => isRunnerComponent(group.line.component) && Boolean(group.line.executionId),
-  );
+  const expectUsage = phaseExpectsUsage(groups);
 
   useEffect(() => {
     if (!selectedNodeId) {
@@ -500,6 +506,7 @@ export function PhaseLogCard({
               runHref={runHref}
               editHref={editHref}
               actionBusy={actionBusy}
+              onUsageOpenChange={onUsageOpenChange}
             />
           )}
 
@@ -540,6 +547,7 @@ function AutomationHeader({
   runHref,
   editHref,
   actionBusy,
+  onUsageOpenChange,
 }: {
   phase: SplitRunPhase;
   expanded: boolean;
@@ -552,6 +560,7 @@ function AutomationHeader({
   runHref?: string;
   editHref?: string;
   actionBusy: boolean;
+  onUsageOpenChange?: (open: boolean) => void;
 }) {
   return (
     <div
@@ -601,7 +610,7 @@ function AutomationHeader({
             ))}
           </span>
         ) : null}
-        <PhaseMetrics phase={phase} />
+        <PhaseMetrics phase={phase} onUsageOpenChange={onUsageOpenChange} />
       </span>
     </div>
   );
@@ -796,7 +805,13 @@ function livePhaseSpend(agents: PhaseAgentUsageEntry[]): { tokens: number; cents
   return { tokens, cents };
 }
 
-function PhaseMetrics({ phase }: { phase: SplitRunPhase }) {
+function PhaseMetrics({
+  phase,
+  onUsageOpenChange,
+}: {
+  phase: SplitRunPhase;
+  onUsageOpenChange?: (open: boolean) => void;
+}) {
   const running = phase.status === "running";
   const { now, sampledAt } = useRunningLogClock(running, phase.duration);
   const clock = running
@@ -836,6 +851,7 @@ function PhaseMetrics({ phase }: { phase: SplitRunPhase }) {
           spendLabel={spendParts.join(" · ")}
           live={running}
           className={cn(LOG_FACE, "tabular-nums text-muted-foreground hover:text-foreground hover:underline")}
+          onOpenChange={onUsageOpenChange}
         />
       ) : null}
       {spendParts.length > 0 && restParts.length > 0 ? <span aria-hidden> · </span> : null}
@@ -1270,6 +1286,30 @@ function PhaseAgentUsageCollector({
   return null;
 }
 
+function liveLogFinishState(status: SplitRunPhaseStatus): "failed" | "passed" | null {
+  if (status === "failed") {
+    return "failed";
+  }
+  if (status === "passed") {
+    return "passed";
+  }
+  return null;
+}
+
+function resolvedUsageSeries(
+  usageSeries: AgentPromptUsageSeries[] | undefined,
+  fallbackSeries: AgentPromptUsageSeries[],
+): AgentPromptUsageSeries[] {
+  if (usageSeries && usageSeries.length > 0) {
+    return usageSeries;
+  }
+  return fallbackSeries;
+}
+
+function isAgentUsageLoading(canStream: boolean, hasTurns: boolean, isStreaming: boolean, nodeRunning: boolean): boolean {
+  return canStream && !hasTurns && (isStreaming || nodeRunning);
+}
+
 function useRunnerNodeLiveNotes(
   line: SplitRunStreamLine,
   organizationId?: string,
@@ -1284,7 +1324,7 @@ function useRunnerNodeLiveNotes(
   const { sections, orphanLines, error, isStreaming, telemetry, usageSeries } = useLiveLogStream(
     canStream ? (line.executionId ?? "") : "",
     line.status === "running",
-    line.status === "failed" ? "failed" : line.status === "passed" ? "passed" : null,
+    liveLogFinishState(line.status),
     null,
     { organizationId, canvasId },
   );
@@ -1293,9 +1333,9 @@ function useRunnerNodeLiveNotes(
     () => (nextTelemetry.turns.length > 0 ? [{ name: "", telemetry: nextTelemetry }] : EMPTY_USAGE_SERIES),
     [nextTelemetry],
   );
-  const nextSeries = usageSeries && usageSeries.length > 0 ? usageSeries : fallbackSeries;
+  const nextSeries = resolvedUsageSeries(usageSeries, fallbackSeries);
   const hasTurns = nextSeries.some((item) => item.telemetry.turns.length > 0);
-  const usageLoading = canStream && isStreaming && !hasTurns;
+  const usageLoading = isAgentUsageLoading(canStream, hasTurns, isStreaming, line.status === "running");
   if (!canStream) {
     return { notes: undefined, telemetry: nextTelemetry, usageSeries: nextSeries, usageLoading: false };
   }

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.usage.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.usage.spec.tsx
@@ -204,4 +204,82 @@ describe("PhaseLogCard usage", () => {
     expect(screen.getByText("1 turn · 1 tool call · 180 input")).toBeInTheDocument();
     expect(screen.getByText("1 turn · 1 tool call · 40 input")).toBeInTheDocument();
   });
+
+  it("loads the chart from a collapsed run without opening the log", async () => {
+    const user = userEvent.setup();
+    useLiveLogStreamMock.mockReturnValue({
+      ...idleLiveLogStream(vi.fn()),
+      telemetry: usageTelemetry(210, [{ kind: "bash", text: "git status" }]),
+    });
+
+    renderCard(
+      <PhaseLogCard
+        phase={{ ...PHASE, costCents: "45", totalTokens: "210" }}
+        expanded={false}
+        organizationId="org-1"
+        canvasId="canvas-1"
+        stream={[
+          line({
+            id: "planner-agent",
+            componentName: "Agent - Plan for GH Issue",
+            component: "runnerClaudeCode",
+            executionId: "exec-1",
+          }),
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Show usage" }));
+    expect(await screen.findByRole("heading", { name: "Plan usage" })).toBeInTheDocument();
+    expect(screen.getByText("1 turn · 1 tool call · 210 input")).toBeInTheDocument();
+    expect(screen.queryByText("No usage data yet.")).not.toBeInTheDocument();
+  });
+
+  it("shows a loading state while usage is still fetching on a collapsed run", async () => {
+    const user = userEvent.setup();
+    useLiveLogStreamMock.mockReturnValue({
+      ...idleLiveLogStream(vi.fn()),
+      isStreaming: true,
+    });
+
+    renderCard(
+      <PhaseLogCard
+        phase={{ ...PHASE, costCents: "45", totalTokens: "210" }}
+        expanded={false}
+        organizationId="org-1"
+        canvasId="canvas-1"
+        stream={[
+          line({
+            id: "planner-agent",
+            componentName: "Agent - Plan for GH Issue",
+            component: "runnerClaudeCode",
+            executionId: "exec-1",
+          }),
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Show usage" }));
+    expect(await screen.findByRole("heading", { name: "Plan usage" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Loading usage...");
+    expect(screen.queryByText("No usage data yet.")).not.toBeInTheDocument();
+  });
+
+  it("shows a loading state while the run stream is still loading", async () => {
+    const user = userEvent.setup();
+    renderCard(
+      <PhaseLogCard
+        phase={{ ...PHASE, costCents: "45", totalTokens: "210" }}
+        expanded={false}
+        streamLoading
+        organizationId="org-1"
+        canvasId="canvas-1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Show usage" }));
+    expect(await screen.findByRole("heading", { name: "Plan usage" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Loading usage...");
+    expect(screen.queryByText("No usage data yet.")).not.toBeInTheDocument();
+  });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.usage.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.usage.spec.tsx
@@ -265,6 +265,37 @@ describe("PhaseLogCard usage", () => {
     expect(screen.queryByText("No usage data yet.")).not.toBeInTheDocument();
   });
 
+  it("keeps the loading state while a running run reconnects without turns", async () => {
+    const user = userEvent.setup();
+    useLiveLogStreamMock.mockReturnValue({
+      ...idleLiveLogStream(vi.fn()),
+      isStreaming: false,
+    });
+
+    renderCard(
+      <PhaseLogCard
+        phase={{ ...PHASE, status: "running", costCents: "0", totalTokens: "210", duration: "12s" }}
+        expanded={false}
+        organizationId="org-1"
+        canvasId="canvas-1"
+        stream={[
+          line({
+            id: "planner-agent",
+            componentName: "Agent",
+            component: "runnerClaudeCode",
+            executionId: "exec-1",
+            status: "running",
+          }),
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Show usage" }));
+    expect(await screen.findByRole("heading", { name: "Plan usage" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Loading usage...");
+    expect(screen.queryByText("No usage data yet.")).not.toBeInTheDocument();
+  });
+
   it("shows a loading state while the run stream is still loading", async () => {
     const user = userEvent.setup();
     renderCard(
@@ -281,5 +312,20 @@ describe("PhaseLogCard usage", () => {
     expect(await screen.findByRole("heading", { name: "Plan usage" })).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("Loading usage...");
     expect(screen.queryByText("No usage data yet.")).not.toBeInTheDocument();
+  });
+
+  it("notifies the parent when the usage dialog opens from a collapsed run", async () => {
+    const user = userEvent.setup();
+    const onUsageOpenChange = vi.fn();
+    renderCard(
+      <PhaseLogCard
+        phase={{ ...PHASE, costCents: "45", totalTokens: "210" }}
+        expanded={false}
+        onUsageOpenChange={onUsageOpenChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Show usage" }));
+    expect(onUsageOpenChange).toHaveBeenCalledWith(true);
   });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseUsageChartButton.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseUsageChartButton.tsx
@@ -1,10 +1,16 @@
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { AgentRunUsageChart } from "@/ui/agentRun/AgentRunUsageChart";
+import { LoaderCircle } from "lucide-react";
 import { useState } from "react";
 
-import { usePhaseAgentUsageAgents } from "./phaseAgentUsageContext";
+import {
+  usePhaseAgentUsageAgents,
+  usePhaseAgentUsageLoading,
+  type PhaseAgentUsageEntry,
+} from "./phaseAgentUsageContext";
 
 export const SHOW_USAGE_LABEL = "Show usage";
+export const LOADING_USAGE_LABEL = "Loading usage...";
 
 export function PhaseUsageSpendButton({
   phaseId,
@@ -20,6 +26,7 @@ export function PhaseUsageSpendButton({
   className?: string;
 }) {
   const agents = usePhaseAgentUsageAgents();
+  const usageLoading = usePhaseAgentUsageLoading();
   const [open, setOpen] = useState(false);
 
   return (
@@ -44,22 +51,44 @@ export function PhaseUsageSpendButton({
             <DialogTitle>{phaseName} usage</DialogTitle>
             <DialogDescription>Token usage and tool calls for each agent in this automation.</DialogDescription>
           </DialogHeader>
-          <div className="min-w-0 space-y-8">
-            {agents.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No usage data yet.</p>
-            ) : (
-              agents.map((agent) => (
-                <AgentRunUsageChart
-                  key={agent.nodeId}
-                  telemetry={agent.telemetry}
-                  title={agents.length > 1 ? agent.name : undefined}
-                  live={live}
-                />
-              ))
-            )}
-          </div>
+          <PhaseUsageDialogBody agents={agents} usageLoading={usageLoading} live={live} />
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+function PhaseUsageDialogBody({
+  agents,
+  usageLoading,
+  live,
+}: {
+  agents: PhaseAgentUsageEntry[];
+  usageLoading: boolean;
+  live: boolean;
+}) {
+  const hasUsageTurns = agents.some((agent) => agent.telemetry.turns.length > 0);
+  if (usageLoading && !hasUsageTurns) {
+    return (
+      <p role="status" className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
+        <LoaderCircle className="size-3.5 shrink-0 animate-spin text-[color:var(--status-running-dot)]" aria-hidden />
+        {LOADING_USAGE_LABEL}
+      </p>
+    );
+  }
+  if (!hasUsageTurns) {
+    return <p className="text-sm text-muted-foreground">No usage data yet.</p>;
+  }
+  return (
+    <div className="min-w-0 space-y-8">
+      {agents.map((agent) => (
+        <AgentRunUsageChart
+          key={agent.nodeId}
+          telemetry={agent.telemetry}
+          title={agents.length > 1 ? agent.name : undefined}
+          live={live}
+        />
+      ))}
+    </div>
   );
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseUsageChartButton.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseUsageChartButton.tsx
@@ -18,12 +18,14 @@ export function PhaseUsageSpendButton({
   spendLabel,
   live = false,
   className,
+  onOpenChange,
 }: {
   phaseId: string;
   phaseName: string;
   spendLabel: string;
   live?: boolean;
   className?: string;
+  onOpenChange?: (open: boolean) => void;
 }) {
   const agents = usePhaseAgentUsageAgents();
   const usageLoading = usePhaseAgentUsageLoading();
@@ -37,11 +39,20 @@ export function PhaseUsageSpendButton({
         aria-label={SHOW_USAGE_LABEL}
         title={SHOW_USAGE_LABEL}
         className={className}
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          onOpenChange?.(true);
+          setOpen(true);
+        }}
       >
         {spendLabel}
       </button>
-      <Dialog open={open} onOpenChange={setOpen}>
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          onOpenChange?.(next);
+        }}
+      >
         <DialogContent
           size="large"
           className="max-h-[min(90vh,52rem)] w-[min(72rem,calc(100vw-2rem))] max-w-[min(72rem,calc(100vw-2rem))] min-w-0 overflow-x-hidden overflow-y-auto [grid-template-columns:minmax(0,1fr)]"

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -13,8 +13,7 @@ import { PhaseLogCard } from "./PhaseLogCard";
 import { DraftStartModelSelect } from "./DraftStartModelSelect";
 import { DRAFT_START_MODEL_AUTO, draftStartModelPayload, phaseWithRunnerModel } from "./draftStartModel";
 import { SplitRunReview } from "./SplitRunReview";
-import { attachArtifactsToStream } from "./attachStreamArtifacts";
-import { emptySplitRunCanvas } from "./splitRunCanvases";
+import { attachArtifactsToStream, type StreamArtifactIndex } from "./attachStreamArtifacts";
 import { resolveSplitRunVisual } from "./splitRunLiveCanvas";
 import {
   autoExpandedPhaseId,
@@ -99,45 +98,26 @@ export function WorkOrderSplitRunBody({
   follow: SplitRunFollow;
   onStreamTick: (tick: string) => void;
 }) {
-  const [phaseId, setPhaseId] = useState<SplitRunPhaseId>(fixture.currentPhaseId);
   const [openPhaseId, setOpenPhaseId] = useState<SplitRunPhaseId | null>(() => autoExpandedPhaseId(fixture));
   const [nodeId, setNodeId] = useState<string | null>(null);
+  const streamLengthsRef = useRef<Record<string, number>>({});
   const currentPhaseId = fixture.currentPhaseId;
   const expandedPhaseId = autoExpandedPhaseId(fixture);
   useEffect(() => {
-    setPhaseId(currentPhaseId);
     setOpenPhaseId(expandedPhaseId);
   }, [currentPhaseId, expandedPhaseId]);
-  const selectedPhase = fixture.phases.find((entry) => entry.id === phaseId) ?? fixture.phases[0];
-  const live = useSplitRunLiveCanvas(organizationId, selectedPhase);
   const artifactIndex = useSplitRunStreamArtifacts(organizationId, factoryId, orderId);
   const demoArtifacts = !organizationId;
-  const visual = useMemo(
-    () =>
-      selectedPhase
-        ? resolveSplitRunVisual(selectedPhase, live, { demoArtifacts })
-        : { canvas: emptySplitRunCanvas(), stream: undefined },
-    [demoArtifacts, live, selectedPhase],
+  const onStreamLength = useCallback(
+    (phaseId: string, length: number) => {
+      if (streamLengthsRef.current[phaseId] === length) {
+        return;
+      }
+      streamLengthsRef.current = { ...streamLengthsRef.current, [phaseId]: length };
+      onStreamTick(fixture.phases.map((entry) => streamLengthsRef.current[entry.id] ?? 0).join(":"));
+    },
+    [fixture.phases, onStreamTick],
   );
-  const streams = useMemo(() => {
-    const yamlOnly = { enabled: false, stream: [] };
-    return new Map(
-      fixture.phases.map((entry) => [
-        entry.id,
-        attachArtifactsToStream(
-          entry.id === selectedPhase?.id
-            ? visual.stream
-            : resolveSplitRunVisual(entry, yamlOnly, { demoArtifacts }).stream,
-          artifactIndex,
-          entry.runId,
-        ),
-      ]),
-    );
-  }, [artifactIndex, demoArtifacts, fixture.phases, selectedPhase?.id, visual.stream]);
-  const streamTick = useMemo(() => [...streams.values()].map((stream) => stream?.length ?? 0).join(":"), [streams]);
-  useEffect(() => {
-    onStreamTick(streamTick);
-  }, [onStreamTick, streamTick]);
   const liveOrder = Boolean(organizationId && factoryId && orderId);
   const automationStop = (entry: SplitRunPhase) => {
     const appId = entry.appId;
@@ -169,21 +149,22 @@ export function WorkOrderSplitRunBody({
       >
         {fixture.phases.map((entry) => (
           <li key={entry.id} className="min-w-0 first:mt-3">
-            <PhaseLogCard
-              phase={phaseWithRunnerModel(entry, entry.id === selectedPhase?.id ? live.canvas?.nodes : undefined)}
+            <SplitRunPhaseLogItem
+              entry={entry}
+              organizationId={organizationId}
+              factoryKey={factoryKey}
+              orderNumber={orderNumber}
+              lineId={lineId}
               expanded={entry.id === openPhaseId}
-              stream={streams.get(entry.id) ?? entry.stream}
               selectedNodeId={nodeId}
               onSelectNode={setNodeId}
-              organizationId={organizationId}
-              canvasId={entry.appId}
+              demoArtifacts={demoArtifacts}
+              artifactIndex={artifactIndex}
               onStop={automationStop(entry)}
               onRerun={automationRerun(entry)}
-              runHref={splitRunPhaseRunHref({ organizationId, factoryKey, orderNumber, lineId, phase: entry })}
-              editHref={splitRunPhaseAutomationHref({ organizationId, factoryKey, orderNumber, phase: entry })}
               actionBusy={footerActions.busy}
+              onStreamLength={onStreamLength}
               onToggle={() => {
-                setPhaseId(entry.id);
                 setNodeId(null);
                 setOpenPhaseId((current) => (current === entry.id ? null : entry.id));
               }}
@@ -195,6 +176,69 @@ export function WorkOrderSplitRunBody({
         <JumpToLatestPill onJumpToLatest={() => follow.setFollowing(true)} testId="split-run-older" />
       )}
     </div>
+  );
+}
+
+function SplitRunPhaseLogItem({
+  entry,
+  organizationId,
+  factoryKey,
+  orderNumber,
+  lineId,
+  expanded,
+  selectedNodeId,
+  onSelectNode,
+  demoArtifacts,
+  artifactIndex,
+  onStop,
+  onRerun,
+  actionBusy,
+  onStreamLength,
+  onToggle,
+}: {
+  entry: SplitRunPhase;
+  organizationId?: string;
+  factoryKey?: string;
+  orderNumber?: string;
+  lineId?: string;
+  expanded: boolean;
+  selectedNodeId?: string | null;
+  onSelectNode: (nodeId: string) => void;
+  demoArtifacts: boolean;
+  artifactIndex: StreamArtifactIndex;
+  onStop?: () => void;
+  onRerun?: () => void;
+  actionBusy: boolean;
+  onStreamLength: (phaseId: string, length: number) => void;
+  onToggle: () => void;
+}) {
+  const live = useSplitRunLiveCanvas(organizationId, entry);
+  const visual = useMemo(() => resolveSplitRunVisual(entry, live, { demoArtifacts }), [demoArtifacts, entry, live]);
+  const stream = useMemo(
+    () => attachArtifactsToStream(visual.stream, artifactIndex, entry.runId),
+    [artifactIndex, entry.runId, visual.stream],
+  );
+  useEffect(() => {
+    onStreamLength(entry.id, stream?.length ?? 0);
+  }, [entry.id, onStreamLength, stream?.length]);
+
+  return (
+    <PhaseLogCard
+      phase={phaseWithRunnerModel(entry, live.canvas?.nodes)}
+      expanded={expanded}
+      stream={stream ?? entry.stream}
+      streamLoading={live.isLoading}
+      selectedNodeId={selectedNodeId}
+      onSelectNode={onSelectNode}
+      organizationId={organizationId}
+      canvasId={entry.appId}
+      onStop={onStop}
+      onRerun={onRerun}
+      runHref={splitRunPhaseRunHref({ organizationId, factoryKey, orderNumber, lineId, phase: entry })}
+      editHref={splitRunPhaseAutomationHref({ organizationId, factoryKey, orderNumber, phase: entry })}
+      actionBusy={actionBusy}
+      onToggle={onToggle}
+    />
   );
 }
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -212,7 +212,8 @@ function SplitRunPhaseLogItem({
   onStreamLength: (phaseId: string, length: number) => void;
   onToggle: () => void;
 }) {
-  const live = useSplitRunLiveCanvas(organizationId, entry);
+  const [usageOpen, setUsageOpen] = useState(false);
+  const live = useSplitRunLiveCanvas(organizationId, expanded || usageOpen ? entry : undefined);
   const visual = useMemo(() => resolveSplitRunVisual(entry, live, { demoArtifacts }), [demoArtifacts, entry, live]);
   const stream = useMemo(
     () => attachArtifactsToStream(visual.stream, artifactIndex, entry.runId),
@@ -238,6 +239,7 @@ function SplitRunPhaseLogItem({
       editHref={splitRunPhaseAutomationHref({ organizationId, factoryKey, orderNumber, phase: entry })}
       actionBusy={actionBusy}
       onToggle={onToggle}
+      onUsageOpenChange={setUsageOpen}
     />
   );
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/phaseAgentUsageContext.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/phaseAgentUsageContext.tsx
@@ -11,29 +11,47 @@ export type PhaseAgentUsageEntry = {
   telemetry: AgentRunTelemetry;
 };
 
+type NodeUsageReport = {
+  entries: PhaseAgentUsageEntry[];
+  loading: boolean;
+};
+
 type PhaseAgentUsageContextValue = {
-  report: (nodeId: string, entries: PhaseAgentUsageEntry[]) => void;
+  report: (nodeId: string, entries: PhaseAgentUsageEntry[], loading?: boolean) => void;
   agents: PhaseAgentUsageEntry[];
+  isLoading: boolean;
 };
 
 const PhaseAgentUsageContext = createContext<PhaseAgentUsageContextValue>({
   report: () => undefined,
   agents: [],
+  isLoading: false,
 });
 
-export function PhaseAgentUsageProvider({ children }: { children: ReactNode }) {
-  const [byNode, setByNode] = useState<Record<string, PhaseAgentUsageEntry[]>>({});
-  const report = useCallback((nodeId: string, entries: PhaseAgentUsageEntry[]) => {
+export function PhaseAgentUsageProvider({
+  children,
+  streamLoading = false,
+  expectUsage = false,
+}: {
+  children: ReactNode;
+  streamLoading?: boolean;
+  expectUsage?: boolean;
+}) {
+  const [byNode, setByNode] = useState<Record<string, NodeUsageReport>>({});
+  const report = useCallback((nodeId: string, entries: PhaseAgentUsageEntry[], loading = false) => {
     setByNode((prev) => {
       const current = prev[nodeId];
-      if (sameUsageEntries(current, entries)) {
+      if (current && current.loading === loading && sameUsageEntries(current.entries, entries)) {
         return prev;
       }
-      return { ...prev, [nodeId]: entries };
+      return { ...prev, [nodeId]: { entries, loading } };
     });
   }, []);
-  const agents = useMemo(() => Object.values(byNode).flat(), [byNode]);
-  const value = useMemo(() => ({ report, agents }), [report, agents]);
+  const agents = useMemo(() => Object.values(byNode).flatMap((node) => node.entries), [byNode]);
+  const nodeLoading = Object.values(byNode).some((node) => node.loading);
+  const hasReport = Object.keys(byNode).length > 0;
+  const isLoading = streamLoading || nodeLoading || (expectUsage && !hasReport);
+  const value = useMemo(() => ({ report, agents, isLoading }), [report, agents, isLoading]);
 
   return <PhaseAgentUsageContext.Provider value={value}>{children}</PhaseAgentUsageContext.Provider>;
 }
@@ -42,24 +60,35 @@ export function usePhaseAgentUsageAgents(): PhaseAgentUsageEntry[] {
   return useContext(PhaseAgentUsageContext).agents;
 }
 
-export function useReportPhaseAgentUsage(nodeId: string, name: string, telemetry: AgentRunTelemetry, enabled: boolean) {
-  const series = useMemo(() => [{ name, telemetry }], [name, telemetry]);
-  useReportPhaseAgentUsageSeries(nodeId, name, series, enabled);
+export function usePhaseAgentUsageLoading(): boolean {
+  return useContext(PhaseAgentUsageContext).isLoading;
 }
 
-export function useReportPhaseAgentUsageSeries(
-  nodeId: string,
-  fallbackName: string,
-  series: AgentPromptUsageSeries[],
-  enabled: boolean,
-) {
+export function useReportPhaseAgentUsage(nodeId: string, name: string, telemetry: AgentRunTelemetry, enabled: boolean) {
+  const series = useMemo(() => [{ name, telemetry }], [name, telemetry]);
+  useReportPhaseAgentUsageSeries({ nodeId, fallbackName: name, series, enabled });
+}
+
+export function useReportPhaseAgentUsageSeries({
+  nodeId,
+  fallbackName,
+  series,
+  enabled,
+  loading = false,
+}: {
+  nodeId: string;
+  fallbackName: string;
+  series: AgentPromptUsageSeries[];
+  enabled: boolean;
+  loading?: boolean;
+}) {
   const { report } = useContext(PhaseAgentUsageContext);
   useEffect(() => {
     if (!enabled) {
       return;
     }
     if (series.length === 0) {
-      report(nodeId, [{ nodeId, name: fallbackName, telemetry: EMPTY_TELEMETRY }]);
+      report(nodeId, loading ? [] : [{ nodeId, name: fallbackName, telemetry: EMPTY_TELEMETRY }], loading);
       return;
     }
     report(
@@ -69,8 +98,9 @@ export function useReportPhaseAgentUsageSeries(
         name: item.name || fallbackName,
         telemetry: item.telemetry,
       })),
+      loading,
     );
-  }, [enabled, fallbackName, nodeId, report, series]);
+  }, [enabled, fallbackName, loading, nodeId, report, series]);
 }
 
 function sameUsageEntries(current: PhaseAgentUsageEntry[] | undefined, next: PhaseAgentUsageEntry[]): boolean {

--- a/web_src/src/pages/factories/pages/work-order-split-run/useFactoryAppSplitRunPage.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/useFactoryAppSplitRunPage.ts
@@ -140,6 +140,7 @@ export function useFactoryAppSplitRunPage() {
     setNodeId,
     split,
     stream,
+    streamLoading: live.isLoading,
     subtitle: resolveFactoryAppCanvasSubtitle({ factoryName: factory?.name }),
   };
 }


### PR DESCRIPTION
The usage modal showed an empty state when a work order run was collapsed.
The chart loaded only after the user opened that run in the task log.
This change loads usage for each automation even when the row stays closed.
The modal shows a loading status while SuperPlane fetches the data.





<!-- greptile_comment -->

<sub>Reviews (3): Last reviewed commit: ["format"](https://github.com/superplanehq/superplane/commit/d4f0eb6d2f91611c9c4358001b528174275c6630) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61333250)</sub>

<!-- /greptile_comment -->