### PR TITLE
feat: Open column automations in a board popup

### DIFF
--- a/pkg/integrations/harness/on_pipeline_completed_test.go
+++ b/pkg/integrations/harness/on_pipeline_completed_test.go
@@ -612,7 +612,7 @@ func Test__OnPipelineCompleted__HandleWebhook(t *testing.T) {
 		requests := &contexts.RequestContext{}
 		oldCheckpoint := time.Now().Add(-time.Hour).UnixMilli()
 		metadata := &contexts.MetadataContext{Metadata: OnPipelineCompletedMetadata{
-			LastExecutionEnded: time.Now().Add(-time.Hour).UnixMilli(),
+			LastExecutionEnded: oldCheckpoint,
 			LastExecutionID:    "exec-old",
 		}}
 		recentEndTs := time.Now().UnixMilli()

--- a/web_src/src/pages/factories/lib/columnAutomations.spec.ts
+++ b/web_src/src/pages/factories/lib/columnAutomations.spec.ts
@@ -6,6 +6,8 @@ import {
   applyColumnAutomationsOverlay,
   buildColumnAutomations,
   catalogForColumn,
+  columnAutomationOpenPath,
+  columnAutomationViewTabs,
   columnAutomationsEmptyCopy,
   columnAutomationsNeedRepair,
   columnTitleForKey,
@@ -13,6 +15,7 @@ import {
   phaseIndexFromColumnKey,
   takenCatalogIds,
 } from "./columnAutomations";
+import { factoryColumnAutomationViewPath, factoryIntakePath, factoryPRFeedbackPath } from "./factoryPagePaths";
 import { LINE_INTAKE_SOURCES } from "../pages/lineIntakeModel";
 import type { LinePhaseColumn } from "./linePhaseRuns";
 
@@ -240,6 +243,114 @@ describe("catalogForColumn", () => {
 
     expect(takenCatalogIds(automations, catalog)).toEqual([]);
     expect(catalog.map((entry) => entry.id)).toEqual(["agent-step", "custom"]);
+  });
+});
+
+describe("columnAutomationOpenPath", () => {
+  const nav = { organizationId: "org-1", factoryKey: "RF", lineId: "line-plan" };
+
+  it("opens an existing canvas automation in the board view popup", () => {
+    expect(
+      columnAutomationOpenPath(
+        {
+          id: "step-0-app-refund-implementer",
+          kind: "agent-step",
+          name: "Implement",
+          trigger: "On task in Implement",
+          action: "Run the Implement agent",
+          iconSrc: "",
+          iconAlt: "",
+          health: "healthy",
+          runningCount: 0,
+          catalogId: "agent-step",
+          canvasId: "app-refund-implementer",
+        },
+        nav,
+      ),
+    ).toBe(factoryColumnAutomationViewPath("org-1", "RF", "line-plan", "app-refund-implementer"));
+  });
+
+  it("does not open the full-screen editor for a canvas automation", () => {
+    const href = columnAutomationOpenPath(
+      {
+        id: "analysis-app-refund-backlog",
+        kind: "analysis",
+        name: "Task analysis",
+        trigger: "On task in Backlog",
+        action: "Score the task",
+        iconSrc: "",
+        iconAlt: "",
+        health: "healthy",
+        runningCount: 0,
+        catalogId: "analysis",
+        canvasId: "app-refund-backlog",
+      },
+      nav,
+    );
+
+    expect(href).toBe(factoryColumnAutomationViewPath("org-1", "RF", "line-plan", "app-refund-backlog"));
+    expect(href).not.toContain("/apps/");
+    expect(href).not.toContain("configure=1");
+  });
+
+  it("opens the intake settings popup on the first tab", () => {
+    expect(
+      columnAutomationOpenPath(
+        {
+          id: "intake-github",
+          kind: "intake",
+          name: "GitHub issues",
+          trigger: "On GitHub issue",
+          action: "Create a task in Backlog",
+          iconSrc: "",
+          iconAlt: "GitHub",
+          health: "healthy",
+          runningCount: 0,
+          catalogId: "github-issues",
+          canvasId: "app-github",
+        },
+        nav,
+      ),
+    ).toBe(factoryIntakePath("org-1", "RF", "line-plan", "intake-github"));
+  });
+
+  it("opens the PR feedback settings popup on the first tab", () => {
+    expect(
+      columnAutomationOpenPath(
+        {
+          id: "handler-checks",
+          kind: "pr-checks",
+          name: "Pull request checks",
+          trigger: "On failing pull request check",
+          action: "Fix the checks",
+          iconSrc: "",
+          iconAlt: "GitHub",
+          health: "healthy",
+          runningCount: 0,
+          catalogId: "checks",
+          canvasId: "app-pr-feedback",
+        },
+        nav,
+      ),
+    ).toBe(factoryPRFeedbackPath("org-1", "RF", "line-plan", undefined, "handler-checks"));
+  });
+});
+
+describe("columnAutomationViewTabs", () => {
+  it("shows only Automation when the canvas has no form and no agent", () => {
+    expect(columnAutomationViewTabs({ hasGeneral: false, hasAgent: false })).toEqual(["automation"]);
+  });
+
+  it("shows Agent then Automation when the canvas has an agent", () => {
+    expect(columnAutomationViewTabs({ hasGeneral: false, hasAgent: true })).toEqual(["agent", "automation"]);
+  });
+
+  it("shows General, Agent, then Automation when a form and an agent exist", () => {
+    expect(columnAutomationViewTabs({ hasGeneral: true, hasAgent: true })).toEqual(["general", "agent", "automation"]);
+  });
+
+  it("shows General then Automation when a form exists without an agent", () => {
+    expect(columnAutomationViewTabs({ hasGeneral: true, hasAgent: false })).toEqual(["general", "automation"]);
   });
 });
 

--- a/web_src/src/pages/factories/lib/columnAutomations.ts
+++ b/web_src/src/pages/factories/lib/columnAutomations.ts
@@ -3,6 +3,7 @@ import githubIcon from "@/assets/icons/integrations/github.svg";
 
 import { LINE_INTAKE_SOURCES, lineIntakeSourceForApiSource } from "../pages/lineIntakeModel";
 import { PR_FEEDBACK_SOURCES, prFeedbackSourceId } from "../pages/prFeedbackSettingsModel";
+import { factoryColumnAutomationViewPath, factoryIntakePath, factoryPRFeedbackPath } from "./factoryPagePaths";
 import { isActiveWorkOrderExecution } from "./workOrderExecutions";
 import { findBacklogAutomationApp, findClosureAutomationApp, type LinePhaseColumn } from "./linePhaseRuns";
 
@@ -381,6 +382,38 @@ export function runningCountForApp(appId: string | undefined, workOrders: Factor
   return count;
 }
 
+/** Path for an existing column automation. Opens the popup on the first tab. */
+export function columnAutomationOpenPath(
+  automation: ColumnAutomation,
+  args: { organizationId: string; factoryKey: string; lineId?: string },
+): string | undefined {
+  if (automation.kind === "intake") {
+    return factoryIntakePath(args.organizationId, args.factoryKey, args.lineId, automation.id);
+  }
+  if (automation.kind === "pr-discussion" || automation.kind === "pr-checks") {
+    return factoryPRFeedbackPath(args.organizationId, args.factoryKey, args.lineId, undefined, automation.id);
+  }
+  if (!automation.canvasId) {
+    return undefined;
+  }
+  return factoryColumnAutomationViewPath(args.organizationId, args.factoryKey, args.lineId, automation.canvasId);
+}
+
+export type ColumnAutomationViewTab = "general" | "agent" | "automation";
+
+/** Tab order: form first, then agent, then the canvas. */
+export function columnAutomationViewTabs(input: { hasGeneral: boolean; hasAgent: boolean }): ColumnAutomationViewTab[] {
+  const tabs: ColumnAutomationViewTab[] = [];
+  if (input.hasGeneral) {
+    tabs.push("general");
+  }
+  if (input.hasAgent) {
+    tabs.push("agent");
+  }
+  tabs.push("automation");
+  return tabs;
+}
+
 export function applyColumnAutomationsOverlay(
   automations: ColumnAutomation[],
   extra: ColumnAutomation[] | undefined,
@@ -429,4 +462,13 @@ export const COLUMN_AUTOMATIONS_COPY = {
   sourceTaken: "This automation is already configured.",
   needsRepairLabel: "Needs repair",
   disabledLabel: "Disabled",
+  editLabel: "Edit automation",
+  tabsLabel: "Automation sections",
+  generalTab: "General",
+  agentTab: "Agent",
+  automationTab: "Automation",
+  viewLoading: "The automation is loading.",
+  viewEmpty: "This automation has no canvas yet.",
+  viewError: "SuperPlane could not load the automation.",
+  viewRetry: "Try again",
 } as const;

--- a/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
@@ -11,7 +11,9 @@ import {
   factoryIntakePath,
   factoryPRFeedbackPath,
   factoryColumnAutomationsPath,
+  factoryColumnAutomationViewPath,
   columnAutomationsKeyFromSearch,
+  columnAutomationViewCanvasIdFromSearch,
   intakeSettingsTabFromSearch,
   intakeIdFromSearch,
   isIntakeSearchOpen,
@@ -163,6 +165,19 @@ describe("factoryColumnAutomationsPath", () => {
     expect(columnAutomationsKeyFromSearch("?automations=verify")).toBe("verify");
     expect(columnAutomationsKeyFromSearch("automations=done")).toBe("done");
     expect(columnAutomationsKeyFromSearch("")).toBeNull();
+  });
+});
+
+describe("factoryColumnAutomationViewPath", () => {
+  it("opens the line board on the automation view popup", () => {
+    expect(factoryColumnAutomationViewPath("org-1", "SP", "line-plan", "app-refund-implementer")).toBe(
+      "/org-1/workspaces/SP/lines/line-plan?automationView=app-refund-implementer",
+    );
+  });
+
+  it("reads the canvas id from the search string", () => {
+    expect(columnAutomationViewCanvasIdFromSearch("?automationView=app-1")).toBe("app-1");
+    expect(columnAutomationViewCanvasIdFromSearch("automations=phase-0")).toBeNull();
   });
 });
 

--- a/web_src/src/pages/factories/lib/factoryPagePaths.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.ts
@@ -89,7 +89,7 @@ export const INTAKE_SEARCH_PARAM = "intake";
  * intakes on the same source, so the identifier is the intake, not the source.
  */
 export const INTAKE_ID_SEARCH_PARAM = "intakeId";
-/** Opens intake settings on a tab: general, runs, or automation. */
+/** Opens intake settings on a tab: general, agent, runs, or automation. */
 export const INTAKE_SETTINGS_SEARCH_PARAM = "settings";
 
 export function factoryIntakePath(
@@ -121,7 +121,7 @@ export function intakeSettingsTabFromSearch(search: string): string | null {
 }
 
 export const PR_FEEDBACK_SEARCH_PARAM = "prFeedback";
-/** Opens PR feedback settings on a tab: general or automation. */
+/** Opens PR feedback settings on a tab: general, agent, or automation. */
 export const PR_FEEDBACK_SETTINGS_SEARCH_PARAM = "prFeedbackSettings";
 export const PR_FEEDBACK_HANDLER_SEARCH_PARAM = "prFeedbackHandler";
 
@@ -175,6 +175,25 @@ export function factoryColumnAutomationsPath(
 export function columnAutomationsKeyFromSearch(search: string): string | null {
   const query = search.startsWith("?") ? search.slice(1) : search;
   return new URLSearchParams(query).get(COLUMN_AUTOMATIONS_SEARCH_PARAM);
+}
+
+/** Opens the column-automation view popup on the line board. Value is the canvas id. */
+export const COLUMN_AUTOMATION_VIEW_SEARCH_PARAM = "automationView";
+
+export function factoryColumnAutomationViewPath(
+  organizationId: string,
+  factoryKey: string,
+  lineId: string | null | undefined,
+  canvasId: string,
+) {
+  const params = new URLSearchParams();
+  params.set(COLUMN_AUTOMATION_VIEW_SEARCH_PARAM, canvasId);
+  return `${factoryHomePath(organizationId, factoryKey, lineId)}?${params.toString()}`;
+}
+
+export function columnAutomationViewCanvasIdFromSearch(search: string): string | null {
+  const query = search.startsWith("?") ? search.slice(1) : search;
+  return new URLSearchParams(query).get(COLUMN_AUTOMATION_VIEW_SEARCH_PARAM);
 }
 
 export function factorySetupPath(organizationId: string, factoryKey: string) {

--- a/web_src/src/pages/factories/pages/ColumnAutomationViewPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationViewPopup.spec.tsx
@@ -1,0 +1,132 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+import { prepareData } from "@/pages/app/workflowPageHelpers";
+import { TooltipProvider } from "@/ui/tooltip";
+
+import { ColumnAutomationViewPopup } from "./ColumnAutomationViewPopup";
+import { PLANNING_REVIEW_DRAFT } from "./planningReviewMockup";
+import type { IntakeAutomationGraph } from "./useIntakeAutomationCanvas";
+
+vi.mock("@monaco-editor/react", () => ({
+  Editor: ({ value, onChange }: { value?: string; onChange?: (value: string | undefined) => void }) => (
+    <textarea value={value ?? ""} onChange={(event) => onChange?.(event.target.value)} />
+  ),
+}));
+
+const EDIT_HREF = "/org-1/workspaces/RF/apps/app-refund-implementer?configure=1&agent=1&from=lines&lineId=line-plan";
+
+function implementGraph(): IntakeAutomationGraph {
+  const { nodes, edges } = prepareData(
+    {
+      metadata: { id: "app-refund-implementer", name: "Implement", factoryId: "factory-1" },
+      spec: {
+        nodes: [
+          { id: "on-run", name: "On run", type: "TYPE_TRIGGER", component: "onRun" },
+          { id: "agent", name: "Implement From Task Description", type: "TYPE_ACTION", component: "runnerClaudeCode" },
+        ],
+        edges: [{ channel: "default", sourceId: "on-run", targetId: "agent" }],
+      },
+    },
+    [{ name: "onRun", label: "On run" }],
+    [{ name: "runnerClaudeCode", label: "Claude Code" }],
+    {},
+    {},
+    {},
+    "app-refund-implementer",
+    new QueryClient(),
+    null,
+    "live",
+  );
+  return { nodes, edges, factoryId: "factory-1" };
+}
+
+function renderPopup(props: Partial<Parameters<typeof ColumnAutomationViewPopup>[0]> = {}) {
+  return render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter>
+        <ThemeProvider>
+          <TooltipProvider>
+            <ColumnAutomationViewPopup
+              title="Implement"
+              graph={implementGraph()}
+              editHref={EDIT_HREF}
+              onClose={vi.fn()}
+              {...props}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ColumnAutomationViewPopup", () => {
+  it("shows the automation canvas in the board popup", () => {
+    renderPopup();
+
+    expect(screen.getByTestId("column-automation-view")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Implement" })).toBeInTheDocument();
+    const canvas = screen.getByTestId("column-automation-view-canvas");
+    expect(canvas).toHaveAccessibleName("Automation");
+    expect(within(canvas).getAllByText("On run").length).toBeGreaterThan(0);
+    expect(within(canvas).getAllByText("Implement From Task Description").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("column-automation-view-edit")).toHaveAttribute("href", EDIT_HREF);
+    expect(document.querySelector(".sp-canvas-editing")).toBeNull();
+  });
+
+  it("closes from the popup chrome", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderPopup({ onClose });
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows loading copy when the canvas is not ready", () => {
+    renderPopup({ graph: { nodes: [], edges: [] }, loading: true, editHref: undefined });
+
+    expect(screen.getByTestId("column-automation-view-canvas")).toHaveTextContent("The automation is loading.");
+  });
+
+  it("hides tabs when the automation has no form and no agent", () => {
+    renderPopup();
+
+    expect(screen.queryByTestId("column-automation-view-tab-agent")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("column-automation-view-tab-automation")).not.toBeInTheDocument();
+  });
+
+  it("shows Agent and Automation tabs when the canvas has an agent", async () => {
+    const user = userEvent.setup();
+    renderPopup({
+      agent: { draft: PLANNING_REVIEW_DRAFT, organizationId: "org-1", onSave: vi.fn() },
+    });
+
+    expect(screen.getByTestId("column-automation-view-tab-agent")).toHaveAttribute("data-state", "active");
+    expect(screen.getByTestId("column-automation-view-tab-automation")).toHaveTextContent("Automation");
+    expect(screen.getByTestId("planning-review-editor")).toBeInTheDocument();
+    expect(screen.getByTestId("planning-review-save")).toHaveTextContent("Save Agent");
+    expect(screen.queryByTestId("planning-review-automation-note")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("column-automation-view-tab-automation"));
+    expect(screen.getByTestId("column-automation-view-canvas")).toBeInTheDocument();
+  });
+
+  it("puts General first when a form and an agent exist", () => {
+    renderPopup({
+      general: <p data-testid="column-automation-view-general">Name and filters</p>,
+      agent: { draft: PLANNING_REVIEW_DRAFT, onSave: vi.fn() },
+      initialTab: "general",
+    });
+
+    const tabs = screen.getAllByRole("tab").map((tab) => tab.textContent);
+    expect(tabs).toEqual(["General", "Agent", "Automation"]);
+    expect(screen.getByTestId("column-automation-view-general")).toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/ColumnAutomationViewPopup.stories.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationViewPopup.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { QueryClient } from "@tanstack/react-query";
+
+import { prepareData } from "@/pages/app/workflowPageHelpers";
+
+import { ComponentStoryShell } from "../__fixtures__/ComponentStoryShell";
+import { ColumnAutomationViewPopup } from "./ColumnAutomationViewPopup";
+import { PLANNING_REVIEW_DRAFT } from "./planningReviewMockup";
+import type { IntakeAutomationGraph } from "./useIntakeAutomationCanvas";
+
+function implementGraph(): IntakeAutomationGraph {
+  const { nodes, edges } = prepareData(
+    {
+      metadata: { id: "app-refund-implementer", name: "Implement", factoryId: "factory-1" },
+      spec: {
+        nodes: [
+          { id: "on-run", name: "On run", type: "TYPE_TRIGGER", component: "onRun" },
+          { id: "agent", name: "Implement From Task Description", type: "TYPE_ACTION", component: "runnerClaudeCode" },
+        ],
+        edges: [{ channel: "default", sourceId: "on-run", targetId: "agent" }],
+      },
+    },
+    [{ name: "onRun", label: "On run" }],
+    [{ name: "runnerClaudeCode", label: "Claude Code" }],
+    {},
+    {},
+    {},
+    "app-refund-implementer",
+    new QueryClient(),
+    null,
+    "live",
+  );
+  return { nodes, edges, factoryId: "factory-1" };
+}
+
+const meta = {
+  title: "Factories/Components/ColumnAutomationViewPopup",
+  component: ColumnAutomationViewPopup,
+  parameters: { layout: "fullscreen" },
+  args: {
+    title: "Implement",
+    graph: implementGraph(),
+    editHref: "/org-1/workspaces/RF/apps/app-refund-implementer?configure=1&agent=1",
+    onClose: () => undefined,
+  },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="relative min-h-[720px] bg-gray-50 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta<typeof ColumnAutomationViewPopup>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const View: Story = {
+  name: "View",
+};
+
+export const Loading: Story = {
+  name: "Loading",
+  args: {
+    graph: { nodes: [], edges: [] },
+    loading: true,
+    editHref: undefined,
+  },
+};
+
+export const WithAgent: Story = {
+  name: "Agent and Automation",
+  args: {
+    agent: { draft: PLANNING_REVIEW_DRAFT, organizationId: "org-1" },
+  },
+};
+
+export const WithGeneralAndAgent: Story = {
+  name: "General, Agent, and Automation",
+  args: {
+    general: <p className="px-6 py-6 text-sm text-muted-foreground">Name and source filters.</p>,
+    agent: { draft: PLANNING_REVIEW_DRAFT, organizationId: "org-1" },
+    initialTab: "general",
+  },
+};

--- a/web_src/src/pages/factories/pages/ColumnAutomationViewPopup.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationViewPopup.tsx
@@ -54,52 +54,105 @@ export function ColumnAutomationViewPopup({
   return (
     <PopupShell testId="column-automation-view" canvas fixed onDismiss={onClose}>
       <PopupHeader title={title} onClose={onClose}>
-        {tabs.length > 1 ? (
-          <Tabs value={tab} onValueChange={(value) => setUserTab(value as ColumnAutomationViewTab)} className="mt-3">
-            <TabsList aria-label={COLUMN_AUTOMATIONS_COPY.tabsLabel}>
-              {tabs.includes("general") ? (
-                <TabsTrigger value="general" data-testid="column-automation-view-tab-general">
-                  <Settings />
-                  {COLUMN_AUTOMATIONS_COPY.generalTab}
-                </TabsTrigger>
-              ) : null}
-              {tabs.includes("agent") ? (
-                <TabsTrigger value="agent" data-testid="column-automation-view-tab-agent">
-                  <Bot />
-                  {COLUMN_AUTOMATIONS_COPY.agentTab}
-                </TabsTrigger>
-              ) : null}
-              <TabsTrigger value="automation" data-testid="column-automation-view-tab-automation">
-                <Workflow />
-                {COLUMN_AUTOMATIONS_COPY.automationTab}
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-        ) : null}
+        <ColumnAutomationViewTabs tabs={tabs} tab={tab} onTabChange={setUserTab} />
       </PopupHeader>
-      {tab === "general" && general ? (
-        general
-      ) : tab === "agent" && agent ? (
-        <PlanningReviewEditor
-          key={agent.draft?.components[0]?.id ?? "agent"}
-          initialDraft={agent.draft}
-          onSave={agent.onSave}
-          organizationId={agent.organizationId}
-          isLoading={agent.isLoading}
-          showAutomationNote={false}
-          showCancel={false}
-        />
-      ) : (
-        <AutomationViewBody
-          title={title}
-          graph={graph}
-          loading={loading}
-          error={error}
-          onRetry={onRetry}
-          editHref={editHref}
-        />
-      )}
+      <ColumnAutomationViewBody
+        tab={tab}
+        title={title}
+        graph={graph}
+        loading={loading}
+        error={error}
+        onRetry={onRetry}
+        editHref={editHref}
+        general={general}
+        agent={agent}
+      />
     </PopupShell>
+  );
+}
+
+function ColumnAutomationViewTabs({
+  tabs,
+  tab,
+  onTabChange,
+}: {
+  tabs: ColumnAutomationViewTab[];
+  tab: ColumnAutomationViewTab;
+  onTabChange: (tab: ColumnAutomationViewTab) => void;
+}) {
+  if (tabs.length <= 1) {
+    return null;
+  }
+  return (
+    <Tabs value={tab} onValueChange={(value) => onTabChange(value as ColumnAutomationViewTab)} className="mt-3">
+      <TabsList aria-label={COLUMN_AUTOMATIONS_COPY.tabsLabel}>
+        {tabs.includes("general") ? (
+          <TabsTrigger value="general" data-testid="column-automation-view-tab-general">
+            <Settings />
+            {COLUMN_AUTOMATIONS_COPY.generalTab}
+          </TabsTrigger>
+        ) : null}
+        {tabs.includes("agent") ? (
+          <TabsTrigger value="agent" data-testid="column-automation-view-tab-agent">
+            <Bot />
+            {COLUMN_AUTOMATIONS_COPY.agentTab}
+          </TabsTrigger>
+        ) : null}
+        <TabsTrigger value="automation" data-testid="column-automation-view-tab-automation">
+          <Workflow />
+          {COLUMN_AUTOMATIONS_COPY.automationTab}
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}
+
+function ColumnAutomationViewBody({
+  tab,
+  title,
+  graph,
+  loading,
+  error,
+  onRetry,
+  editHref,
+  general,
+  agent,
+}: {
+  tab: ColumnAutomationViewTab;
+  title: string;
+  graph?: IntakeAutomationGraph;
+  loading: boolean;
+  error: boolean;
+  onRetry?: () => void;
+  editHref?: string;
+  general?: ReactNode;
+  agent?: PlanningReviewAgentSlot;
+}) {
+  if (tab === "general" && general) {
+    return general;
+  }
+  if (tab === "agent" && agent) {
+    return (
+      <PlanningReviewEditor
+        key={agent.draft?.components[0]?.id ?? "agent"}
+        initialDraft={agent.draft}
+        onSave={agent.onSave}
+        organizationId={agent.organizationId}
+        isLoading={agent.isLoading}
+        showAutomationNote={false}
+        showCancel={false}
+      />
+    );
+  }
+  return (
+    <AutomationViewBody
+      title={title}
+      graph={graph}
+      loading={loading}
+      error={error}
+      onRetry={onRetry}
+      editHref={editHref}
+    />
   );
 }
 

--- a/web_src/src/pages/factories/pages/ColumnAutomationViewPopup.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationViewPopup.tsx
@@ -1,0 +1,215 @@
+import { Link } from "@/components/Link/link";
+import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/buttonVariants";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Bot, Settings, Workflow } from "lucide-react";
+import { useState, type ReactNode } from "react";
+
+import {
+  COLUMN_AUTOMATIONS_COPY,
+  columnAutomationViewTabs,
+  type ColumnAutomationViewTab,
+} from "../lib/columnAutomations";
+import { factoryAppConfigurePath } from "../lib/factoryPagePaths";
+import { useColumnCanvasAgentEditor } from "./useColumnCanvasAgentEditor";
+import { PlanningReviewEditor, type PlanningReviewAgentSlot } from "./PlanningReviewEditor";
+import { SettingsAutomationCanvas } from "./SettingsAutomationCanvas";
+import { useIntakeAutomationCanvas, type IntakeAutomationGraph } from "./useIntakeAutomationCanvas";
+import { PopupHeader, PopupShell } from "./work-order-popup-redesign/popupShared";
+
+interface ColumnAutomationViewPopupProps {
+  title: string;
+  graph?: IntakeAutomationGraph;
+  loading?: boolean;
+  error?: boolean;
+  onRetry?: () => void;
+  editHref?: string;
+  onClose: () => void;
+  general?: ReactNode;
+  agent?: PlanningReviewAgentSlot;
+  initialTab?: ColumnAutomationViewTab;
+}
+
+/** Read-only automation canvas in the board popup. Edit opens the full editor. */
+export function ColumnAutomationViewPopup({
+  title,
+  graph,
+  loading = false,
+  error = false,
+  onRetry,
+  editHref,
+  onClose,
+  general,
+  agent,
+  initialTab,
+}: ColumnAutomationViewPopupProps) {
+  const hasGeneral = Boolean(general);
+  const hasAgent = Boolean(agent);
+  const tabs = columnAutomationViewTabs({ hasGeneral, hasAgent });
+  const [userTab, setUserTab] = useState<ColumnAutomationViewTab | undefined>(() =>
+    initialTab && tabs.includes(initialTab) ? initialTab : undefined,
+  );
+  const tab = userTab && tabs.includes(userTab) ? userTab : (tabs[0] ?? "automation");
+
+  return (
+    <PopupShell testId="column-automation-view" canvas fixed onDismiss={onClose}>
+      <PopupHeader title={title} onClose={onClose}>
+        {tabs.length > 1 ? (
+          <Tabs value={tab} onValueChange={(value) => setUserTab(value as ColumnAutomationViewTab)} className="mt-3">
+            <TabsList aria-label={COLUMN_AUTOMATIONS_COPY.tabsLabel}>
+              {tabs.includes("general") ? (
+                <TabsTrigger value="general" data-testid="column-automation-view-tab-general">
+                  <Settings />
+                  {COLUMN_AUTOMATIONS_COPY.generalTab}
+                </TabsTrigger>
+              ) : null}
+              {tabs.includes("agent") ? (
+                <TabsTrigger value="agent" data-testid="column-automation-view-tab-agent">
+                  <Bot />
+                  {COLUMN_AUTOMATIONS_COPY.agentTab}
+                </TabsTrigger>
+              ) : null}
+              <TabsTrigger value="automation" data-testid="column-automation-view-tab-automation">
+                <Workflow />
+                {COLUMN_AUTOMATIONS_COPY.automationTab}
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+        ) : null}
+      </PopupHeader>
+      {tab === "general" && general ? (
+        general
+      ) : tab === "agent" && agent ? (
+        <PlanningReviewEditor
+          key={agent.draft?.components[0]?.id ?? "agent"}
+          initialDraft={agent.draft}
+          onSave={agent.onSave}
+          organizationId={agent.organizationId}
+          isLoading={agent.isLoading}
+          showAutomationNote={false}
+          showCancel={false}
+        />
+      ) : (
+        <AutomationViewBody
+          title={title}
+          graph={graph}
+          loading={loading}
+          error={error}
+          onRetry={onRetry}
+          editHref={editHref}
+        />
+      )}
+    </PopupShell>
+  );
+}
+
+export function ColumnAutomationViewHost({
+  organizationId,
+  factoryKey,
+  lineId,
+  canvasId,
+  title,
+  onClose,
+  general,
+  initialTab,
+}: {
+  organizationId: string;
+  factoryKey: string;
+  lineId?: string;
+  canvasId: string;
+  title: string;
+  onClose: () => void;
+  general?: ReactNode;
+  initialTab?: ColumnAutomationViewTab;
+}) {
+  const automation = useIntakeAutomationCanvas(organizationId, canvasId);
+  const agent = useColumnCanvasAgentEditor(organizationId, canvasId);
+  return (
+    <ColumnAutomationViewPopup
+      title={automation.name?.trim() || title}
+      graph={automation.graph}
+      loading={automation.isLoading}
+      error={automation.isError}
+      onRetry={() => void automation.refetch()}
+      editHref={factoryAppConfigurePath(organizationId, factoryKey, canvasId, { from: "lines", lineId })}
+      onClose={onClose}
+      general={general}
+      agent={
+        agent.agentNode
+          ? {
+              draft: agent.draft ?? undefined,
+              isLoading: agent.isLoading || !agent.draft,
+              organizationId,
+              onSave: agent.save,
+            }
+          : undefined
+      }
+      initialTab={initialTab}
+    />
+  );
+}
+
+function AutomationViewBody({
+  title,
+  graph,
+  loading,
+  error,
+  onRetry,
+  editHref,
+}: {
+  title: string;
+  graph?: IntakeAutomationGraph;
+  loading: boolean;
+  error: boolean;
+  onRetry?: () => void;
+  editHref?: string;
+}) {
+  if (!graph || graph.nodes.length === 0) {
+    return (
+      <section
+        className="flex min-h-0 flex-1 flex-col items-start gap-3 px-6 py-6"
+        aria-label="Automation"
+        data-testid="column-automation-view-canvas"
+      >
+        <p className="workspace-body-text text-muted-foreground">{viewEmptyMessage(loading, error)}</p>
+        {error && onRetry ? (
+          <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+            {COLUMN_AUTOMATIONS_COPY.viewRetry}
+          </Button>
+        ) : null}
+        {editHref ? (
+          <Link href={editHref} className={buttonVariants({ size: "sm" })}>
+            {COLUMN_AUTOMATIONS_COPY.editLabel}
+          </Link>
+        ) : null}
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className="flex min-h-0 min-w-0 flex-1 flex-col"
+      aria-label="Automation"
+      data-testid="column-automation-view-canvas"
+    >
+      <div className="flex shrink-0 items-center justify-between gap-2 px-5 pt-3 pb-2">
+        <p className="min-w-0 truncate text-[15px] font-semibold tracking-[-0.02em] text-foreground">{title}</p>
+        {editHref ? (
+          <Link href={editHref} className={buttonVariants({ size: "sm" })} data-testid="column-automation-view-edit">
+            {COLUMN_AUTOMATIONS_COPY.editLabel}
+          </Link>
+        ) : null}
+      </div>
+      <div className="min-h-[18rem] flex-1">
+        <SettingsAutomationCanvas graph={graph} />
+      </div>
+    </section>
+  );
+}
+
+function viewEmptyMessage(loading: boolean, error: boolean): string {
+  if (loading) {
+    return COLUMN_AUTOMATIONS_COPY.viewLoading;
+  }
+  return error ? COLUMN_AUTOMATIONS_COPY.viewError : COLUMN_AUTOMATIONS_COPY.viewEmpty;
+}

--- a/web_src/src/pages/factories/pages/IntakeSettingsHost.tsx
+++ b/web_src/src/pages/factories/pages/IntakeSettingsHost.tsx
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 
 import { factoryAppConfigurePath } from "../lib/factoryPagePaths";
 import { IntakeSourceSettingsPopup } from "./IntakeSourceSettingsPopup";
+import { useColumnCanvasAgentEditor } from "./useColumnCanvasAgentEditor";
 import {
   intakeSettingsToApi,
   type IntakeAutomationRun,
@@ -37,6 +38,7 @@ export function IntakeSettingsHost({
   onClose,
 }: IntakeSettingsHostProps) {
   const automation = useIntakeAutomationCanvas(organizationId, intake.appId);
+  const agent = useColumnCanvasAgentEditor(organizationId, intake.appId);
   const runs = useIntakeAutomationRuns(organizationId, factoryId, intake);
   const updateIntake = useUpdateFactoryIntake(organizationId, factoryId);
   const editAutomationHref = intake.appId
@@ -76,6 +78,16 @@ export function IntakeSettingsHost({
       }
       onOpenRun={onOpenRun}
       editAutomationHref={editAutomationHref}
+      agent={
+        agent.agentNode
+          ? {
+              draft: agent.draft ?? undefined,
+              isLoading: agent.isLoading || !agent.draft,
+              organizationId,
+              onSave: agent.save,
+            }
+          : undefined
+      }
       onClose={onClose}
       initialTab={initialTab}
       fixed

--- a/web_src/src/pages/factories/pages/IntakeSettingsRuns.tsx
+++ b/web_src/src/pages/factories/pages/IntakeSettingsRuns.tsx
@@ -1,0 +1,163 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import {
+  INTAKE_SETTINGS_COPY,
+  intakePlacementActivity,
+  intakePlacementLabel,
+  intakeRelativeTime,
+  type IntakeAutomationRun,
+  type IntakeTicketPlacement,
+} from "./intakeSourceSettingsModel";
+
+const PLACEMENT_CHIP_CLASS: Record<IntakeTicketPlacement, string> = {
+  progressed:
+    "border-[color:var(--status-running-border)] bg-[color:var(--status-running-bg)] text-[color:var(--status-running-fg)]",
+  backlog:
+    "border-[color:var(--status-draft-border)] bg-[color:var(--status-draft-bg)] text-[color:var(--status-draft-fg)]",
+  rejected:
+    "border-[color:var(--status-failed-border)] bg-[color:var(--status-failed-bg)] text-[color:var(--status-failed-fg)]",
+  "below-threshold":
+    "border-[color:var(--status-cancelled-border)] bg-[color:var(--status-cancelled-bg)] text-[color:var(--status-cancelled-fg)]",
+};
+
+const PLACEMENT_DOT_CLASS: Record<IntakeTicketPlacement, string> = {
+  progressed: "bg-[color:var(--status-running-dot)]",
+  backlog: "bg-[color:var(--status-draft-dot)]",
+  rejected: "bg-[color:var(--status-failed-dot)]",
+  "below-threshold": "bg-[color:var(--status-cancelled-dot)]",
+};
+
+export function IntakeRunsList({
+  runs,
+  loading,
+  error,
+  onRetry,
+  onOpenRun,
+}: {
+  runs: IntakeAutomationRun[];
+  loading: boolean;
+  error: boolean;
+  onRetry?: () => void;
+  onOpenRun?: (run: IntakeAutomationRun) => void;
+}) {
+  if (loading) {
+    return (
+      <p className="workspace-body-text px-6 py-6 text-muted-foreground" data-testid="intake-source-runs">
+        {INTAKE_SETTINGS_COPY.runsLoading}
+      </p>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-3 px-6 py-6" data-testid="intake-source-runs">
+        <p className="workspace-body-text text-destructive">{INTAKE_SETTINGS_COPY.runsError}</p>
+        {onRetry ? (
+          <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+            {INTAKE_SETTINGS_COPY.retryRuns}
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (runs.length === 0) {
+    return (
+      <p className="workspace-body-text px-6 py-6 text-muted-foreground" data-testid="intake-source-runs">
+        {INTAKE_SETTINGS_COPY.runsEmpty}
+      </p>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+      <ul
+        className="mx-auto flex w-full max-w-2xl flex-col gap-2"
+        data-testid="intake-source-runs"
+        aria-label={INTAKE_SETTINGS_COPY.runsTab}
+      >
+        {runs.map((run) => (
+          <li key={run.id}>
+            <IntakeRunCard run={run} onOpenRun={onOpenRun} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function IntakeRunCard({
+  run,
+  onOpenRun,
+}: {
+  run: IntakeAutomationRun;
+  onOpenRun?: (run: IntakeAutomationRun) => void;
+}) {
+  const placementLabel = intakePlacementLabel(run);
+  const activity = intakePlacementActivity(run);
+
+  return (
+    <article
+      className="group relative w-full rounded-lg border border-border bg-card p-3.5 shadow-sm transition hover:border-foreground/20 hover:shadow"
+      data-testid={`intake-source-run-${run.id}`}
+    >
+      {onOpenRun ? (
+        <button
+          type="button"
+          className="absolute inset-0 z-0 rounded-lg"
+          aria-label={INTAKE_SETTINGS_COPY.viewRunFor(run.title)}
+          onClick={() => onOpenRun(run)}
+        />
+      ) : null}
+      <div className="relative z-10 pointer-events-none">
+        <div className="flex items-start gap-3">
+          <span className="relative mt-1.5 size-2 shrink-0" title={placementLabel} aria-label={placementLabel}>
+            {run.placement === "progressed" ? (
+              <span
+                className={cn(
+                  "absolute inset-0 animate-ping rounded-full opacity-60",
+                  PLACEMENT_DOT_CLASS[run.placement],
+                )}
+                aria-hidden
+              />
+            ) : null}
+            <span className={cn("relative block size-2 rounded-full", PLACEMENT_DOT_CLASS[run.placement])} />
+          </span>
+          <h3 className="min-w-0 flex-1 text-[13px] font-medium leading-snug tracking-[-0.01em] text-foreground">
+            {run.title}
+          </h3>
+        </div>
+
+        <dl className="mt-3 grid grid-cols-3 gap-3">
+          <div>
+            <dt className="text-[11px] font-medium text-muted-foreground">{INTAKE_SETTINGS_COPY.runWhen}</dt>
+            <dd className="mt-0.5 text-[13px] tabular-nums text-foreground">{intakeRelativeTime(run.ranMinutesAgo)}</dd>
+          </div>
+          <div>
+            <dt className="text-[11px] font-medium text-muted-foreground">{INTAKE_SETTINGS_COPY.analysisWhen}</dt>
+            <dd className="mt-0.5 text-[13px] tabular-nums text-foreground">
+              {intakeRelativeTime(run.analyzedMinutesAgo)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[11px] font-medium text-muted-foreground">{INTAKE_SETTINGS_COPY.scoreWhen}</dt>
+            <dd className="mt-0.5 text-[13px] font-medium tabular-nums text-foreground">{run.confidencePct}%</dd>
+          </div>
+        </dl>
+
+        <div className="mt-3 flex items-start gap-2">
+          <Badge variant="outline" className={cn("mt-0.5", PLACEMENT_CHIP_CLASS[run.placement])}>
+            {placementLabel}
+          </Badge>
+          {activity ? <p className="min-w-0 text-[12px] leading-5 text-muted-foreground">{activity}</p> : null}
+        </div>
+
+        {onOpenRun ? (
+          <p className="mt-3 text-[12px] font-medium text-foreground">{INTAKE_SETTINGS_COPY.viewRun}</p>
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.spec.tsx
@@ -13,8 +13,17 @@ import {
   DEFAULT_GITHUB_INTAKE_SETTINGS,
   GITHUB_INTAKE_RUNS,
   type IntakeAutomationRun,
+  type IntakeSettingsTab,
 } from "./intakeSourceSettingsModel";
+import { PLANNING_REVIEW_DRAFT } from "./planningReviewMockup";
 import type { IntakeAutomationGraph } from "./useIntakeAutomationCanvas";
+import type { PlanningReviewAgentSlot } from "./PlanningReviewEditor";
+
+vi.mock("@monaco-editor/react", () => ({
+  Editor: ({ value, onChange }: { value?: string; onChange?: (value: string | undefined) => void }) => (
+    <textarea value={value ?? ""} onChange={(event) => onChange?.(event.target.value)} />
+  ),
+}));
 
 const githubAutomationGraph = githubIntakeGraph();
 
@@ -65,7 +74,8 @@ function renderPopup(
     onOpenRun?: (run: IntakeAutomationRun) => void;
     runs?: IntakeAutomationRun[];
     editAutomationHref?: string;
-    initialTab?: "general" | "runs" | "automation";
+    agent?: PlanningReviewAgentSlot;
+    initialTab?: IntakeSettingsTab;
   } = {},
 ) {
   return render(
@@ -80,6 +90,7 @@ function renderPopup(
               onOpenRun={props.onOpenRun}
               runs={props.runs}
               editAutomationHref={props.editAutomationHref}
+              agent={props.agent}
               onClose={props.onClose ?? vi.fn()}
               initialTab={props.initialTab}
               fixed={false}
@@ -108,6 +119,7 @@ describe("IntakeSourceSettingsPopup", () => {
     expect(screen.getByRole("radio", { name: "Any assignment" })).toBeChecked();
     expect(screen.getByRole("tab", { name: "General" })).toHaveAttribute("data-state", "active");
     expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual(["General", "Runs", "Automation"]);
+    expect(screen.queryByTestId("intake-settings-tab-agent")).not.toBeInTheDocument();
     expect(screen.queryByTestId("intake-source-automation")).not.toBeInTheDocument();
     expect(screen.queryByTestId("intake-source-runs")).not.toBeInTheDocument();
   });
@@ -172,6 +184,25 @@ describe("IntakeSourceSettingsPopup", () => {
 
     await user.click(screen.getByRole("button", { name: "View run for Handle duplicate refunds on retry" }));
     expect(onOpenRun).toHaveBeenCalledWith(expect.objectContaining({ id: "gh-issue-1", placement: "progressed" }));
+  });
+
+  it("puts Agent after General when the intake canvas has an agent", async () => {
+    const user = userEvent.setup();
+    renderPopup({
+      agent: { draft: PLANNING_REVIEW_DRAFT, organizationId: "org-1", onSave: vi.fn() },
+    });
+
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "General",
+      "Agent",
+      "Runs",
+      "Automation",
+    ]);
+
+    await user.click(screen.getByTestId("intake-settings-tab-agent"));
+    expect(screen.getByTestId("planning-review-editor")).toBeInTheDocument();
+    expect(screen.getByTestId("planning-review-save")).toHaveTextContent("Save Agent");
+    expect(screen.queryByTestId("planning-review-automation-note")).not.toBeInTheDocument();
   });
 
   it("saves the edited configuration", async () => {

--- a/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.tsx
+++ b/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.tsx
@@ -1,28 +1,23 @@
 import { Link } from "@/components/Link/link";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { buttonVariants } from "@/components/ui/buttonVariants";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { cn } from "@/lib/utils";
 import { Bot, History, Settings, Workflow } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import {
   INTAKE_SETTINGS_COPY,
-  intakePlacementActivity,
-  intakePlacementLabel,
-  intakeRelativeTime,
   intakeSettingsTabs,
   normalizeIntakeSourceSettings,
   type IntakeAutomationRun,
   type IntakeListenMode,
   type IntakeSettingsTab,
   type IntakeSourceSettings,
-  type IntakeTicketPlacement,
 } from "./intakeSourceSettingsModel";
 import { GitHubIntakeFilterFields } from "./GitHubIntakeFilterFields";
+import { IntakeRunsList } from "./IntakeSettingsRuns";
 import { IntakeSettingsRadioOption } from "./IntakeSettingsRadioOption";
 import { PlanningReviewEditor, type PlanningReviewAgentSlot } from "./PlanningReviewEditor";
 import { SettingsAutomationCanvas } from "./SettingsAutomationCanvas";
@@ -89,9 +84,9 @@ export function IntakeSourceSettingsPopup({
     }
   }, [tab, hasAgent]);
 
-  function update<K extends keyof IntakeSourceSettings>(key: K, value: IntakeSourceSettings[K]) {
+  const update = <K extends keyof IntakeSourceSettings>(key: K, value: IntakeSourceSettings[K]) => {
     setDraft((current) => ({ ...current, [key]: value }));
-  }
+  };
 
   return (
     <PopupShell testId="intake-source-settings" canvas fixed={fixed} onDismiss={onClose}>
@@ -119,104 +114,210 @@ export function IntakeSourceSettingsPopup({
           </TabsList>
         </Tabs>
       </PopupHeader>
-      {tab === "automation" ? (
-        <IntakeAutomationTab
-          graph={automationGraph}
-          title={settings.name}
-          editHref={editAutomationHref}
-          loading={automationLoading}
-          error={automationError}
-          onRetry={onRetryAutomation}
-        />
-      ) : tab === "agent" && agent ? (
-        <PlanningReviewEditor
-          key={agent.draft?.components[0]?.id ?? "agent"}
-          initialDraft={agent.draft}
-          onSave={agent.onSave}
-          organizationId={agent.organizationId}
-          isLoading={agent.isLoading}
-          showAutomationNote={false}
-          showCancel={false}
-        />
-      ) : tab === "runs" ? (
-        <IntakeRunsList
-          runs={runs}
-          loading={runsLoading}
-          error={runsError}
-          onRetry={onRetryRuns}
-          onOpenRun={onOpenRun}
-        />
-      ) : (
-        <>
-          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
-            <div className="mx-auto flex w-full max-w-xl flex-col gap-6">
-              <section>
-                <Label htmlFor="intake-source-name">{INTAKE_SETTINGS_COPY.nameLabel}</Label>
-                <p className="workspace-body-text mt-1 text-muted-foreground">{INTAKE_SETTINGS_COPY.nameHelper}</p>
-                <Input
-                  id="intake-source-name"
-                  className="mt-2"
-                  value={draft.name}
-                  onChange={(event) => update("name", event.target.value)}
-                  data-testid="intake-source-name"
-                />
-              </section>
-
-              <fieldset className="min-w-0">
-                <legend className="text-sm font-medium text-gray-800 dark:text-gray-100">
-                  {INTAKE_SETTINGS_COPY.listenLabel}
-                </legend>
-                <div className="mt-2 flex flex-col gap-2">
-                  <IntakeSettingsRadioOption
-                    name="intake-listen-mode"
-                    value="listen"
-                    checked={draft.listenMode === "listen"}
-                    title={INTAKE_SETTINGS_COPY.listenOption}
-                    helper={INTAKE_SETTINGS_COPY.listenHelper}
-                    onChange={() => update("listenMode", "listen" satisfies IntakeListenMode)}
-                  />
-                  <IntakeSettingsRadioOption
-                    name="intake-listen-mode"
-                    value="schedule"
-                    checked={draft.listenMode === "schedule"}
-                    title={INTAKE_SETTINGS_COPY.scheduleOption}
-                    helper={INTAKE_SETTINGS_COPY.scheduleHelper}
-                    disabled
-                    onChange={() => update("listenMode", "schedule" satisfies IntakeListenMode)}
-                  />
-                </div>
-              </fieldset>
-
-              <GitHubIntakeFilterFields sourceId={sourceId} settings={draft} onSettingsChange={setDraft} />
-            </div>
-          </div>
-          <footer className="flex shrink-0 items-center justify-between gap-3 border-t border-border px-5 py-3">
-            {saveError ? (
-              <p className="workspace-body-text text-destructive" role="alert">
-                {saveError}
-              </p>
-            ) : (
-              <span />
-            )}
-            <Button
-              type="button"
-              disabled={savePending}
-              onClick={async () => {
-                try {
-                  await onSave(normalizeIntakeSourceSettings(draft));
-                  onClose();
-                } catch {
-                  // The parent supplies the actionable error message.
-                }
-              }}
-              data-testid="intake-source-settings-save"
-            >
-              {savePending ? INTAKE_SETTINGS_COPY.saving : INTAKE_SETTINGS_COPY.save}
-            </Button>
-          </footer>
-        </>
-      )}
+      <IntakeSettingsTabPanel
+        tab={tab}
+        settings={settings}
+        sourceId={sourceId}
+        draft={draft}
+        agent={agent}
+        automationGraph={automationGraph}
+        automationLoading={automationLoading}
+        automationError={automationError}
+        onRetryAutomation={onRetryAutomation}
+        runs={runs}
+        runsLoading={runsLoading}
+        runsError={runsError}
+        onRetryRuns={onRetryRuns}
+        onOpenRun={onOpenRun}
+        editAutomationHref={editAutomationHref}
+        savePending={savePending}
+        saveError={saveError}
+        onUpdate={update}
+        onDraftChange={setDraft}
+        onSave={onSave}
+        onClose={onClose}
+      />
     </PopupShell>
+  );
+}
+
+function IntakeSettingsTabPanel({
+  tab,
+  settings,
+  sourceId,
+  draft,
+  agent,
+  automationGraph,
+  automationLoading,
+  automationError,
+  onRetryAutomation,
+  runs,
+  runsLoading,
+  runsError,
+  onRetryRuns,
+  onOpenRun,
+  editAutomationHref,
+  savePending,
+  saveError,
+  onUpdate,
+  onDraftChange,
+  onSave,
+  onClose,
+}: {
+  tab: IntakeSettingsTab;
+  settings: IntakeSourceSettings;
+  sourceId: LineIntakeSourceId;
+  draft: IntakeSourceSettings;
+  agent?: PlanningReviewAgentSlot;
+  automationGraph?: IntakeAutomationGraph;
+  automationLoading: boolean;
+  automationError: boolean;
+  onRetryAutomation?: () => void;
+  runs: IntakeAutomationRun[];
+  runsLoading: boolean;
+  runsError: boolean;
+  onRetryRuns?: () => void;
+  onOpenRun?: (run: IntakeAutomationRun) => void;
+  editAutomationHref?: string;
+  savePending?: boolean;
+  saveError?: string;
+  onUpdate: <K extends keyof IntakeSourceSettings>(key: K, value: IntakeSourceSettings[K]) => void;
+  onDraftChange: (next: IntakeSourceSettings) => void;
+  onSave: (next: IntakeSourceSettings) => Promise<void> | void;
+  onClose: () => void;
+}) {
+  if (tab === "automation") {
+    return (
+      <IntakeAutomationTab
+        graph={automationGraph}
+        title={settings.name}
+        editHref={editAutomationHref}
+        loading={automationLoading}
+        error={automationError}
+        onRetry={onRetryAutomation}
+      />
+    );
+  }
+  if (tab === "agent" && agent) {
+    return (
+      <PlanningReviewEditor
+        key={agent.draft?.components[0]?.id ?? "agent"}
+        initialDraft={agent.draft}
+        onSave={agent.onSave}
+        organizationId={agent.organizationId}
+        isLoading={agent.isLoading}
+        showAutomationNote={false}
+        showCancel={false}
+      />
+    );
+  }
+  if (tab === "runs") {
+    return (
+      <IntakeRunsList runs={runs} loading={runsLoading} error={runsError} onRetry={onRetryRuns} onOpenRun={onOpenRun} />
+    );
+  }
+  return (
+    <IntakeGeneralTab
+      sourceId={sourceId}
+      draft={draft}
+      savePending={savePending}
+      saveError={saveError}
+      onUpdate={onUpdate}
+      onDraftChange={onDraftChange}
+      onSave={onSave}
+      onClose={onClose}
+    />
+  );
+}
+
+function IntakeGeneralTab({
+  sourceId,
+  draft,
+  savePending,
+  saveError,
+  onUpdate,
+  onDraftChange,
+  onSave,
+  onClose,
+}: {
+  sourceId: LineIntakeSourceId;
+  draft: IntakeSourceSettings;
+  savePending?: boolean;
+  saveError?: string;
+  onUpdate: <K extends keyof IntakeSourceSettings>(key: K, value: IntakeSourceSettings[K]) => void;
+  onDraftChange: (next: IntakeSourceSettings) => void;
+  onSave: (next: IntakeSourceSettings) => Promise<void> | void;
+  onClose: () => void;
+}) {
+  return (
+    <>
+      <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+        <div className="mx-auto flex w-full max-w-xl flex-col gap-6">
+          <section>
+            <Label htmlFor="intake-source-name">{INTAKE_SETTINGS_COPY.nameLabel}</Label>
+            <p className="workspace-body-text mt-1 text-muted-foreground">{INTAKE_SETTINGS_COPY.nameHelper}</p>
+            <Input
+              id="intake-source-name"
+              className="mt-2"
+              value={draft.name}
+              onChange={(event) => onUpdate("name", event.target.value)}
+              data-testid="intake-source-name"
+            />
+          </section>
+
+          <fieldset className="min-w-0">
+            <legend className="text-sm font-medium text-gray-800 dark:text-gray-100">
+              {INTAKE_SETTINGS_COPY.listenLabel}
+            </legend>
+            <div className="mt-2 flex flex-col gap-2">
+              <IntakeSettingsRadioOption
+                name="intake-listen-mode"
+                value="listen"
+                checked={draft.listenMode === "listen"}
+                title={INTAKE_SETTINGS_COPY.listenOption}
+                helper={INTAKE_SETTINGS_COPY.listenHelper}
+                onChange={() => onUpdate("listenMode", "listen" satisfies IntakeListenMode)}
+              />
+              <IntakeSettingsRadioOption
+                name="intake-listen-mode"
+                value="schedule"
+                checked={draft.listenMode === "schedule"}
+                title={INTAKE_SETTINGS_COPY.scheduleOption}
+                helper={INTAKE_SETTINGS_COPY.scheduleHelper}
+                disabled
+                onChange={() => onUpdate("listenMode", "schedule" satisfies IntakeListenMode)}
+              />
+            </div>
+          </fieldset>
+
+          <GitHubIntakeFilterFields sourceId={sourceId} settings={draft} onSettingsChange={onDraftChange} />
+        </div>
+      </div>
+      <footer className="flex shrink-0 items-center justify-between gap-3 border-t border-border px-5 py-3">
+        {saveError ? (
+          <p className="workspace-body-text text-destructive" role="alert">
+            {saveError}
+          </p>
+        ) : (
+          <span />
+        )}
+        <Button
+          type="button"
+          disabled={savePending}
+          onClick={async () => {
+            try {
+              await onSave(normalizeIntakeSourceSettings(draft));
+              onClose();
+            } catch {
+              // The parent supplies the actionable error message.
+            }
+          }}
+          data-testid="intake-source-settings-save"
+        >
+          {savePending ? INTAKE_SETTINGS_COPY.saving : INTAKE_SETTINGS_COPY.save}
+        </Button>
+      </footer>
+    </>
   );
 }
 
@@ -304,156 +405,5 @@ function IntakeAutomationEmpty({
         </Link>
       ) : null}
     </section>
-  );
-}
-
-const PLACEMENT_CHIP_CLASS: Record<IntakeTicketPlacement, string> = {
-  progressed:
-    "border-[color:var(--status-running-border)] bg-[color:var(--status-running-bg)] text-[color:var(--status-running-fg)]",
-  backlog:
-    "border-[color:var(--status-draft-border)] bg-[color:var(--status-draft-bg)] text-[color:var(--status-draft-fg)]",
-  rejected:
-    "border-[color:var(--status-failed-border)] bg-[color:var(--status-failed-bg)] text-[color:var(--status-failed-fg)]",
-  "below-threshold":
-    "border-[color:var(--status-cancelled-border)] bg-[color:var(--status-cancelled-bg)] text-[color:var(--status-cancelled-fg)]",
-};
-
-const PLACEMENT_DOT_CLASS: Record<IntakeTicketPlacement, string> = {
-  progressed: "bg-[color:var(--status-running-dot)]",
-  backlog: "bg-[color:var(--status-draft-dot)]",
-  rejected: "bg-[color:var(--status-failed-dot)]",
-  "below-threshold": "bg-[color:var(--status-cancelled-dot)]",
-};
-
-function IntakeRunsList({
-  runs,
-  loading,
-  error,
-  onRetry,
-  onOpenRun,
-}: {
-  runs: IntakeAutomationRun[];
-  loading: boolean;
-  error: boolean;
-  onRetry?: () => void;
-  onOpenRun?: (run: IntakeAutomationRun) => void;
-}) {
-  if (loading) {
-    return (
-      <p className="workspace-body-text px-6 py-6 text-muted-foreground" data-testid="intake-source-runs">
-        {INTAKE_SETTINGS_COPY.runsLoading}
-      </p>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center gap-3 px-6 py-6" data-testid="intake-source-runs">
-        <p className="workspace-body-text text-destructive">{INTAKE_SETTINGS_COPY.runsError}</p>
-        {onRetry ? (
-          <Button type="button" variant="outline" size="sm" onClick={onRetry}>
-            {INTAKE_SETTINGS_COPY.retryRuns}
-          </Button>
-        ) : null}
-      </div>
-    );
-  }
-
-  if (runs.length === 0) {
-    return (
-      <p className="workspace-body-text px-6 py-6 text-muted-foreground" data-testid="intake-source-runs">
-        {INTAKE_SETTINGS_COPY.runsEmpty}
-      </p>
-    );
-  }
-
-  return (
-    <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
-      <ul
-        className="mx-auto flex w-full max-w-2xl flex-col gap-2"
-        data-testid="intake-source-runs"
-        aria-label={INTAKE_SETTINGS_COPY.runsTab}
-      >
-        {runs.map((run) => (
-          <li key={run.id}>
-            <IntakeRunCard run={run} onOpenRun={onOpenRun} />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-function IntakeRunCard({
-  run,
-  onOpenRun,
-}: {
-  run: IntakeAutomationRun;
-  onOpenRun?: (run: IntakeAutomationRun) => void;
-}) {
-  const placementLabel = intakePlacementLabel(run);
-  const activity = intakePlacementActivity(run);
-
-  return (
-    <article
-      className="group relative w-full rounded-lg border border-border bg-card p-3.5 shadow-sm transition hover:border-foreground/20 hover:shadow"
-      data-testid={`intake-source-run-${run.id}`}
-    >
-      {onOpenRun ? (
-        <button
-          type="button"
-          className="absolute inset-0 z-0 rounded-lg"
-          aria-label={INTAKE_SETTINGS_COPY.viewRunFor(run.title)}
-          onClick={() => onOpenRun(run)}
-        />
-      ) : null}
-      <div className="relative z-10 pointer-events-none">
-        <div className="flex items-start gap-3">
-          <span className="relative mt-1.5 size-2 shrink-0" title={placementLabel} aria-label={placementLabel}>
-            {run.placement === "progressed" ? (
-              <span
-                className={cn(
-                  "absolute inset-0 animate-ping rounded-full opacity-60",
-                  PLACEMENT_DOT_CLASS[run.placement],
-                )}
-                aria-hidden
-              />
-            ) : null}
-            <span className={cn("relative block size-2 rounded-full", PLACEMENT_DOT_CLASS[run.placement])} />
-          </span>
-          <h3 className="min-w-0 flex-1 text-[13px] font-medium leading-snug tracking-[-0.01em] text-foreground">
-            {run.title}
-          </h3>
-        </div>
-
-        <dl className="mt-3 grid grid-cols-3 gap-3">
-          <div>
-            <dt className="text-[11px] font-medium text-muted-foreground">{INTAKE_SETTINGS_COPY.runWhen}</dt>
-            <dd className="mt-0.5 text-[13px] tabular-nums text-foreground">{intakeRelativeTime(run.ranMinutesAgo)}</dd>
-          </div>
-          <div>
-            <dt className="text-[11px] font-medium text-muted-foreground">{INTAKE_SETTINGS_COPY.analysisWhen}</dt>
-            <dd className="mt-0.5 text-[13px] tabular-nums text-foreground">
-              {intakeRelativeTime(run.analyzedMinutesAgo)}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-[11px] font-medium text-muted-foreground">{INTAKE_SETTINGS_COPY.scoreWhen}</dt>
-            <dd className="mt-0.5 text-[13px] font-medium tabular-nums text-foreground">{run.confidencePct}%</dd>
-          </div>
-        </dl>
-
-        <div className="mt-3 flex items-start gap-2">
-          <Badge variant="outline" className={cn("mt-0.5", PLACEMENT_CHIP_CLASS[run.placement])}>
-            {placementLabel}
-          </Badge>
-          {activity ? <p className="min-w-0 text-[12px] leading-5 text-muted-foreground">{activity}</p> : null}
-        </div>
-
-        {onOpenRun ? (
-          <p className="mt-3 text-[12px] font-medium text-foreground">{INTAKE_SETTINGS_COPY.viewRun}</p>
-        ) : null}
-      </div>
-    </article>
   );
 }

--- a/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.tsx
+++ b/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Bot, History, Settings, Workflow } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
 
 import {
   INTAKE_SETTINGS_COPY,
@@ -182,7 +182,7 @@ function IntakeSettingsTabPanel({
   savePending?: boolean;
   saveError?: string;
   onUpdate: <K extends keyof IntakeSourceSettings>(key: K, value: IntakeSourceSettings[K]) => void;
-  onDraftChange: (next: IntakeSourceSettings) => void;
+  onDraftChange: Dispatch<SetStateAction<IntakeSourceSettings>>;
   onSave: (next: IntakeSourceSettings) => Promise<void> | void;
   onClose: () => void;
 }) {
@@ -245,7 +245,7 @@ function IntakeGeneralTab({
   savePending?: boolean;
   saveError?: string;
   onUpdate: <K extends keyof IntakeSourceSettings>(key: K, value: IntakeSourceSettings[K]) => void;
-  onDraftChange: (next: IntakeSourceSettings) => void;
+  onDraftChange: Dispatch<SetStateAction<IntakeSourceSettings>>;
   onSave: (next: IntakeSourceSettings) => Promise<void> | void;
   onClose: () => void;
 }) {

--- a/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.tsx
+++ b/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
-import { History, Settings, Workflow } from "lucide-react";
+import { Bot, History, Settings, Workflow } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import {
@@ -14,6 +14,7 @@ import {
   intakePlacementActivity,
   intakePlacementLabel,
   intakeRelativeTime,
+  intakeSettingsTabs,
   normalizeIntakeSourceSettings,
   type IntakeAutomationRun,
   type IntakeListenMode,
@@ -23,6 +24,7 @@ import {
 } from "./intakeSourceSettingsModel";
 import { GitHubIntakeFilterFields } from "./GitHubIntakeFilterFields";
 import { IntakeSettingsRadioOption } from "./IntakeSettingsRadioOption";
+import { PlanningReviewEditor, type PlanningReviewAgentSlot } from "./PlanningReviewEditor";
 import { SettingsAutomationCanvas } from "./SettingsAutomationCanvas";
 import { PopupHeader, PopupShell } from "./work-order-popup-redesign/popupShared";
 import type { IntakeAutomationGraph } from "./useIntakeAutomationCanvas";
@@ -44,6 +46,7 @@ interface IntakeSourceSettingsPopupProps {
   saveError?: string;
   onOpenRun?: (run: IntakeAutomationRun) => void;
   editAutomationHref?: string;
+  agent?: PlanningReviewAgentSlot;
   onClose: () => void;
   fixed?: boolean;
   initialTab?: IntakeSettingsTab;
@@ -65,16 +68,26 @@ export function IntakeSourceSettingsPopup({
   saveError,
   onOpenRun,
   editAutomationHref,
+  agent,
   onClose,
   fixed = true,
   initialTab = "general",
 }: IntakeSourceSettingsPopupProps) {
+  const tabs = intakeSettingsTabs(Boolean(agent));
+  const hasAgent = Boolean(agent);
   const [draft, setDraft] = useState(settings);
-  const [tab, setTab] = useState<IntakeSettingsTab>(initialTab);
+  const [tab, setTab] = useState<IntakeSettingsTab>(() => (tabs.includes(initialTab) ? initialTab : "general"));
 
   useEffect(() => {
     setDraft(settings);
   }, [settings]);
+
+  useEffect(() => {
+    const next = intakeSettingsTabs(hasAgent);
+    if (!next.includes(tab)) {
+      setTab("general");
+    }
+  }, [tab, hasAgent]);
 
   function update<K extends keyof IntakeSourceSettings>(key: K, value: IntakeSourceSettings[K]) {
     setDraft((current) => ({ ...current, [key]: value }));
@@ -89,6 +102,12 @@ export function IntakeSourceSettingsPopup({
               <Settings />
               {INTAKE_SETTINGS_COPY.generalTab}
             </TabsTrigger>
+            {tabs.includes("agent") ? (
+              <TabsTrigger value="agent" data-testid="intake-settings-tab-agent">
+                <Bot />
+                {INTAKE_SETTINGS_COPY.agentTab}
+              </TabsTrigger>
+            ) : null}
             <TabsTrigger value="runs" data-testid="intake-settings-tab-runs">
               <History />
               {INTAKE_SETTINGS_COPY.runsTab}
@@ -108,6 +127,16 @@ export function IntakeSourceSettingsPopup({
           loading={automationLoading}
           error={automationError}
           onRetry={onRetryAutomation}
+        />
+      ) : tab === "agent" && agent ? (
+        <PlanningReviewEditor
+          key={agent.draft?.components[0]?.id ?? "agent"}
+          initialDraft={agent.draft}
+          onSave={agent.onSave}
+          organizationId={agent.organizationId}
+          isLoading={agent.isLoading}
+          showAutomationNote={false}
+          showCancel={false}
         />
       ) : tab === "runs" ? (
         <IntakeRunsList

--- a/web_src/src/pages/factories/pages/Lines.stories.tsx
+++ b/web_src/src/pages/factories/pages/Lines.stories.tsx
@@ -220,6 +220,20 @@ export const LineBoardDoneAutomationsOpen: Story = {
   },
 };
 
+export const LineBoardAutomationView: Story = {
+  name: "Line board — automation view popup",
+  render: () => {
+    const line = REFUND_FACTORY_LINES[0];
+    return (
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${line.id}?automationView=app-refund-implementer`}
+        factoriesFixture={columnAutomationsFixture}
+        appFixture={refundLineCanvasFixture()}
+      />
+    );
+  },
+};
+
 export const LineBoardAddAutomationPicker: Story = {
   name: "Line board — add automation picker",
   parameters: {

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { FactoriesFactory, FactoriesFactoryIntake, FactoriesWorkOrder, FactoryApp } from "@/api-client";
 import type * as canvasData from "@/hooks/useCanvasData";
-import { editFactoryLinePath, factoryAppConfigurePath } from "../lib/factoryPagePaths";
+import { editFactoryLinePath, factoryAppConfigurePath, factoryColumnAutomationViewPath } from "../lib/factoryPagePaths";
 import {
   ACME_ONBOARDING_FACTORY,
   ACME_ONBOARDING_FACTORY_KEY,
@@ -412,7 +412,7 @@ describe("LinesPage board", () => {
     );
   });
 
-  it("opens intake settings when an automation row is clicked", async () => {
+  it("opens intake settings on the first tab when an automation row is clicked", async () => {
     useFactoryIntakes.mockReturnValue({ data: [GITHUB_ISSUES_INTAKE] });
     const user = userEvent.setup();
     renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?automations=backlog`);
@@ -420,6 +420,53 @@ describe("LinesPage board", () => {
     await user.click(screen.getByTestId(`column-automation-row-${GITHUB_ISSUES_INTAKE_ID}`));
 
     expect(screen.getByTestId("lines-test-location")).toHaveTextContent(`intake=1&intakeId=${GITHUB_ISSUES_INTAKE_ID}`);
+    expect(screen.getByTestId("lines-test-location")).not.toHaveTextContent("settings=automation");
+    expect(screen.getByTestId("intake-source-settings")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "General" })).toHaveAttribute("data-state", "active");
+  });
+
+  it("opens an existing phase automation in the board view popup", async () => {
+    useFactoryApps.mockReturnValue({ data: [{ id: "app-refund-implementer", name: "Implement" }] });
+    const user = userEvent.setup();
+    renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?automations=phase-0`);
+
+    await user.click(screen.getByTestId("column-automation-row-step-0-app-refund-implementer"));
+
+    const location = screen.getByTestId("lines-test-location");
+    expect(location).toHaveTextContent(
+      factoryColumnAutomationViewPath("org-1", PRIMARY_FACTORY_KEY, REFUND_LINE_PLAN_ID, "app-refund-implementer"),
+    );
+    expect(location).not.toHaveTextContent("/apps/");
+    expect(location).not.toHaveTextContent("configure=1");
+    expect(screen.getByTestId("column-automation-view")).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("column-automation-view")).getByRole("heading", { name: "Implement" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("column-automation-view-tab-agent")).toHaveAttribute("data-state", "active");
+    expect(screen.getByTestId("planning-review-editor")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("column-automation-view-tab-automation"));
+    expect(screen.getByRole("link", { name: "Edit automation" })).toHaveAttribute(
+      "href",
+      factoryAppConfigurePath("org-1", PRIMARY_FACTORY_KEY, "app-refund-implementer", {
+        from: "lines",
+        lineId: REFUND_LINE_PLAN_ID,
+      }),
+    );
+  });
+
+  it("opens an existing analysis automation in the board view popup", async () => {
+    useFactoryApps.mockReturnValue({ data: [{ id: "app-refund-backlog", name: "Ingest" }] });
+    const user = userEvent.setup();
+    renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?automations=backlog`);
+
+    await user.click(screen.getByTestId("column-automation-row-analysis-app-refund-backlog"));
+
+    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
+      factoryColumnAutomationViewPath("org-1", PRIMARY_FACTORY_KEY, REFUND_LINE_PLAN_ID, "app-refund-backlog"),
+    );
+    expect(screen.getByTestId("column-automation-view")).toBeInTheDocument();
+    expect(screen.getByTestId("lines-test-location")).not.toHaveTextContent("configure=1");
   });
 
   it("opens the phase automations menu from the indicator", async () => {

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -106,6 +106,7 @@ import {
   factoryIntakePath,
   factoryPRFeedbackPath,
   columnAutomationsKeyFromSearch,
+  columnAutomationViewCanvasIdFromSearch,
   firstFactoryLineId,
   workOrderDetailPath,
   workOrderBoardLineIdFromSearch,
@@ -125,6 +126,7 @@ import {
 import {
   applyColumnAutomationsOverlay,
   buildColumnAutomations,
+  columnAutomationOpenPath,
   catalogEntryToAutomation,
   catalogForColumn,
   isColumnKey,
@@ -148,6 +150,7 @@ import {
 } from "./lineIntakeModel";
 import { isIntakeSettingsTab } from "./intakeSourceSettingsModel";
 import { useFactoryPreviewFlag } from "./factoryPreviewFlagsContext";
+import { ColumnAutomationViewHost } from "./ColumnAutomationViewPopup";
 import { IntakeSettingsHost } from "./IntakeSettingsHost";
 import { PRFeedbackSettingsHost } from "./PRFeedbackSettingsHost";
 import {
@@ -207,6 +210,7 @@ export function LinesPage() {
   const intakeOpen = isIntakeSearchOpen(search);
   const intakeId = intakeIdFromSearch(search);
   const intakeSettingsTab = intakeSettingsTabFromSearch(search);
+  const automationViewCanvasId = columnAutomationViewCanvasIdFromSearch(search);
   const prFeedbackOpen = isPRFeedbackSearchOpen(search);
   const prFeedbackSettingsTab = prFeedbackSettingsTabFromSearch(search);
   const prFeedbackHandlerId = prFeedbackHandlerIdFromSearch(search);
@@ -438,6 +442,16 @@ export function LinesPage() {
         onSelect={createPRFeedbackFromSource}
         takenSourceIds={takenPRFeedbackSources}
       />
+      {automationViewCanvasId ? (
+        <ColumnAutomationViewHost
+          organizationId={organizationId}
+          factoryKey={factoryKey}
+          lineId={selectedLine.id}
+          canvasId={automationViewCanvasId}
+          title={factoryApps.find((app) => app.id === automationViewCanvasId)?.name?.trim() || "Automation"}
+          onClose={() => navigate(factoryHomePath(organizationId, factoryKey, selectedLine.id))}
+        />
+      ) : null}
       {prFeedbackOpen ? (
         <PRFeedbackSettingsHost
           organizationId={organizationId}
@@ -725,18 +739,9 @@ function LineDetail({
 
   const handleRowAction = (automation: ColumnAutomation, action: ColumnAutomationRowAction) => {
     if (action === "settings") {
-      if (automation.kind === "intake") {
-        navigate(factoryIntakePath(organizationId, factoryKey, line.id, automation.id));
-        return;
-      }
-      if (automation.kind === "pr-discussion" || automation.kind === "pr-checks") {
-        navigate(factoryPRFeedbackPath(organizationId, factoryKey, line.id, undefined, automation.id));
-        return;
-      }
-      if (automation.canvasId) {
-        navigate(
-          factoryAppConfigurePath(organizationId, factoryKey, automation.canvasId, { from: "lines", lineId: line.id }),
-        );
+      const href = columnAutomationOpenPath(automation, { organizationId, factoryKey, lineId: line.id });
+      if (href) {
+        navigate(href);
       }
       return;
     }

--- a/web_src/src/pages/factories/pages/PRFeedbackSettingsHost.tsx
+++ b/web_src/src/pages/factories/pages/PRFeedbackSettingsHost.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { factoryAppConfigurePath } from "../lib/factoryPagePaths";
 import { AddPRFeedbackPicker } from "./AddPRFeedbackPicker";
 import { PRFeedbackSettingsPopup } from "./PRFeedbackSettingsPopup";
+import { useColumnCanvasAgentEditor } from "./useColumnCanvasAgentEditor";
 import {
   PR_FEEDBACK_SETTINGS_COPY,
   apiPRFeedbackSource,
@@ -168,6 +169,7 @@ function PRFeedbackSettingsLoaded({
 }) {
   const [saveError, setSaveError] = useState<string | undefined>();
   const automation = useIntakeAutomationCanvas(organizationId, canvasId);
+  const agent = useColumnCanvasAgentEditor(organizationId, canvasId);
   const updateHandler = useUpdateFactoryPRFeedbackHandler(organizationId, factoryId);
   const deleteHandler = useDeleteFactoryPRFeedbackHandler(organizationId, factoryId);
   const editAutomationHref = canvasId
@@ -213,6 +215,16 @@ function PRFeedbackSettingsLoaded({
           : undefined
       }
       editAutomationHref={editAutomationHref}
+      agent={
+        agent.agentNode
+          ? {
+              draft: agent.draft ?? undefined,
+              isLoading: agent.isLoading || !agent.draft,
+              organizationId,
+              onSave: agent.save,
+            }
+          : undefined
+      }
       onClose={onClose}
       initialTab={initialTab}
     />

--- a/web_src/src/pages/factories/pages/PRFeedbackSettingsPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/PRFeedbackSettingsPopup.spec.tsx
@@ -11,8 +11,16 @@ import { prepareData } from "@/pages/app/workflowPageHelpers";
 import { TooltipProvider } from "@/ui/tooltip";
 
 import { PRFeedbackSettingsPopup } from "./PRFeedbackSettingsPopup";
+import { PLANNING_REVIEW_DRAFT } from "./planningReviewMockup";
 import type { PRFeedbackDraftSettings } from "./prFeedbackSettingsModel";
 import type { IntakeAutomationGraph } from "./useIntakeAutomationCanvas";
+import type { PlanningReviewAgentSlot } from "./PlanningReviewEditor";
+
+vi.mock("@monaco-editor/react", () => ({
+  Editor: ({ value, onChange }: { value?: string; onChange?: (value: string | undefined) => void }) => (
+    <textarea value={value ?? ""} onChange={(event) => onChange?.(event.target.value)} />
+  ),
+}));
 
 vi.mock("@/hooks/useIntegrations", () => ({
   useConnectedIntegrations: vi.fn(() => ({ data: [] })),
@@ -294,6 +302,50 @@ describe("PRFeedbackSettingsPopup additional integrations", () => {
 });
 
 describe("PRFeedbackSettingsPopup automation", () => {
+  it("hides the Agent tab when the canvas has no agent", () => {
+    renderAutomationPopup();
+
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual(["General", "Automation"]);
+    expect(screen.queryByTestId("pr-feedback-settings-tab-agent")).not.toBeInTheDocument();
+  });
+
+  it("puts Agent between General and Automation when the canvas has an agent", async () => {
+    const user = userEvent.setup();
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter>
+          <ThemeProvider>
+            <TooltipProvider>
+              <PRFeedbackSettingsPopup
+                settings={discussionDraft()}
+                healthy
+                automationGraph={automationGraph}
+                agent={
+                  {
+                    draft: PLANNING_REVIEW_DRAFT,
+                    organizationId: "org-1",
+                    onSave: vi.fn(),
+                  } satisfies PlanningReviewAgentSlot
+                }
+                onSave={vi.fn()}
+                onClose={vi.fn()}
+                initialTab="general"
+                fixed={false}
+              />
+            </TooltipProvider>
+          </ThemeProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual(["General", "Agent", "Automation"]);
+
+    await user.click(screen.getByTestId("pr-feedback-settings-tab-agent"));
+    expect(screen.getByTestId("planning-review-editor")).toBeInTheDocument();
+    expect(screen.getByTestId("planning-review-save")).toHaveTextContent("Save Agent");
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+  });
+
   it("shows the automation in display mode at native zoom", () => {
     renderAutomationPopup();
 

--- a/web_src/src/pages/factories/pages/PRFeedbackSettingsPopup.tsx
+++ b/web_src/src/pages/factories/pages/PRFeedbackSettingsPopup.tsx
@@ -1,5 +1,5 @@
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Settings, Workflow } from "lucide-react";
+import { Bot, Settings, Workflow } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { PRFeedbackAutomationTab, PRFeedbackSettingsFooter } from "./PRFeedbackSettingsChrome";
@@ -9,10 +9,12 @@ import {
   PRFeedbackHealthSection,
   PRFeedbackTextField,
 } from "./PRFeedbackSettingsFields";
+import { PlanningReviewEditor, type PlanningReviewAgentSlot } from "./PlanningReviewEditor";
 import { PopupHeader, PopupShell } from "./work-order-popup-redesign/popupShared";
 import {
   PR_FEEDBACK_SETTINGS_COPY,
   appendUniqueTrimmedString,
+  prFeedbackSettingsTabs,
   type PRFeedbackDraftSettings,
   type PRFeedbackSettingsTab,
 } from "./prFeedbackSettingsModel";
@@ -32,6 +34,7 @@ interface PRFeedbackSettingsPopupProps {
   deletePending?: boolean;
   saveError?: string;
   editAutomationHref?: string;
+  agent?: PlanningReviewAgentSlot;
   onClose: () => void;
   fixed?: boolean;
   initialTab?: PRFeedbackSettingsTab;
@@ -51,13 +54,23 @@ export function PRFeedbackSettingsPopup({
   deletePending = false,
   saveError,
   editAutomationHref,
+  agent,
   onClose,
   fixed = true,
   initialTab = "general",
 }: PRFeedbackSettingsPopupProps) {
+  const tabs = prFeedbackSettingsTabs(Boolean(agent));
   const [draft, setDraft] = useState(settings);
-  const [tab, setTab] = useState<PRFeedbackSettingsTab>(initialTab);
+  const [tab, setTab] = useState<PRFeedbackSettingsTab>(() => (tabs.includes(initialTab) ? initialTab : "general"));
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const hasAgent = Boolean(agent);
+
+  useEffect(() => {
+    const next = prFeedbackSettingsTabs(hasAgent);
+    if (!next.includes(tab)) {
+      setTab("general");
+    }
+  }, [tab, hasAgent]);
 
   useEffect(() => {
     setDraft(settings);
@@ -76,6 +89,12 @@ export function PRFeedbackSettingsPopup({
               <Settings />
               {PR_FEEDBACK_SETTINGS_COPY.generalTab}
             </TabsTrigger>
+            {tabs.includes("agent") ? (
+              <TabsTrigger value="agent" data-testid="pr-feedback-settings-tab-agent">
+                <Bot />
+                {PR_FEEDBACK_SETTINGS_COPY.agentTab}
+              </TabsTrigger>
+            ) : null}
             <TabsTrigger value="automation" data-testid="pr-feedback-settings-tab-automation">
               <Workflow />
               {PR_FEEDBACK_SETTINGS_COPY.automationTab}
@@ -91,6 +110,16 @@ export function PRFeedbackSettingsPopup({
           loading={automationLoading}
           error={automationError}
           onRetry={onRetryAutomation}
+        />
+      ) : tab === "agent" && agent ? (
+        <PlanningReviewEditor
+          key={agent.draft?.components[0]?.id ?? "agent"}
+          initialDraft={agent.draft}
+          onSave={agent.onSave}
+          organizationId={agent.organizationId}
+          isLoading={agent.isLoading}
+          showAutomationNote={false}
+          showCancel={false}
         />
       ) : (
         <PRFeedbackGeneralTab

--- a/web_src/src/pages/factories/pages/PlanningReviewEditor.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewEditor.tsx
@@ -122,7 +122,3 @@ export function PlanningReviewEditor({
     </div>
   );
 }
-
-export function planningReviewEditorTitle(draft: PlanningReviewDraft): string {
-  return draft.components[0]?.title ?? "Editing Agent";
-}

--- a/web_src/src/pages/factories/pages/PlanningReviewEditor.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewEditor.tsx
@@ -1,0 +1,128 @@
+import { Link } from "@/components/Link/link";
+import { Button } from "@/components/ui/button";
+import { Workflow } from "lucide-react";
+import { useState } from "react";
+
+import { PlanningReviewForm } from "./PlanningReviewForm";
+import { PlanningReviewNav } from "./PlanningReviewNav";
+import {
+  PLANNING_REVIEW_DRAFT,
+  singleAgentDraft,
+  type PlanningReviewDraft,
+  type PlanningReviewStep,
+} from "./planningReviewMockup";
+import { PLANNING_REVIEW_DEFAULT_SECTION, type PlanningReviewSectionId } from "./planningReviewSections";
+import { PopupBody } from "./work-order-popup-redesign/popupShared";
+
+function AutomationNote({ href }: { href?: string }) {
+  return (
+    <p
+      className="flex min-w-0 flex-1 items-center gap-2.5 text-[12px] leading-5 text-muted-foreground"
+      data-testid="planning-review-automation-note"
+    >
+      <Workflow className="size-4 shrink-0" aria-hidden />
+      <span className="min-w-0">
+        Agents are part of an automation. Open the automation to add an agent or to change the order of the steps.
+      </span>
+      {href ? (
+        <Link
+          href={href}
+          data-testid="planning-review-edit-automation"
+          className="shrink-0 font-medium text-foreground underline underline-offset-2 hover:text-primary"
+        >
+          Edit Automation
+        </Link>
+      ) : null}
+    </p>
+  );
+}
+
+export type PlanningReviewAgentSlot = {
+  draft?: PlanningReviewDraft;
+  isLoading?: boolean;
+  organizationId?: string;
+  onSave?: (draft: PlanningReviewDraft) => void | Promise<void>;
+};
+
+/** Agent editor body. The column menu popup and the automation view Agent tab share this. */
+export function PlanningReviewEditor({
+  initialDraft = PLANNING_REVIEW_DRAFT,
+  onSave,
+  onCancel,
+  organizationId,
+  automationHref,
+  isLoading = false,
+  showAutomationNote = true,
+  showCancel = true,
+}: {
+  initialDraft?: PlanningReviewDraft;
+  onSave?: (draft: PlanningReviewDraft) => void | Promise<void>;
+  onCancel?: () => void;
+  organizationId?: string;
+  automationHref?: string;
+  isLoading?: boolean;
+  showAutomationNote?: boolean;
+  showCancel?: boolean;
+}) {
+  const [draft, setDraft] = useState(() => singleAgentDraft(initialDraft));
+  const [isSaving, setIsSaving] = useState(false);
+  const [section, setSection] = useState<PlanningReviewSectionId>(PLANNING_REVIEW_DEFAULT_SECTION);
+  const saveDisabled = isLoading || isSaving || draft.components.length === 0;
+  const stepCount = ((draft.components[0]?.configuration.steps as PlanningReviewStep[]) ?? []).length;
+
+  const handleSave = async () => {
+    if (!onSave) {
+      onCancel?.();
+      return;
+    }
+    setIsSaving(true);
+    try {
+      await onSave(draft);
+      onCancel?.();
+    } catch {
+      // Caller reports the error and keeps the editor open.
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col" data-testid="planning-review-editor">
+      {isLoading ? (
+        <PopupBody className="bg-muted px-6 py-5">
+          <p className="px-1 py-6 text-sm text-muted-foreground" data-testid="planning-review-loading">
+            Loading agent…
+          </p>
+        </PopupBody>
+      ) : (
+        <div className="flex min-h-0 flex-1">
+          <PlanningReviewNav active={section} onSelect={setSection} stepCount={stepCount} />
+          <PopupBody className="min-w-0 bg-muted px-6 py-5">
+            <PlanningReviewForm draft={draft} onChange={setDraft} organizationId={organizationId} section={section} />
+          </PopupBody>
+        </div>
+      )}
+      <footer className="flex shrink-0 items-center gap-4 border-t border-border px-6 py-4">
+        {showAutomationNote ? <AutomationNote href={automationHref} /> : <span className="min-w-0 flex-1" />}
+        {showCancel ? (
+          <Button type="button" variant="outline" className="shrink-0" onClick={onCancel} disabled={isSaving}>
+            Cancel
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          className="shrink-0"
+          onClick={() => void handleSave()}
+          disabled={saveDisabled}
+          data-testid="planning-review-save"
+        >
+          {isSaving ? "Saving…" : "Save Agent"}
+        </Button>
+      </footer>
+    </div>
+  );
+}
+
+export function planningReviewEditorTitle(draft: PlanningReviewDraft): string {
+  return draft.components[0]?.title ?? "Editing Agent";
+}

--- a/web_src/src/pages/factories/pages/PlanningReviewPopup.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewPopup.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { PlanningReviewEditor, planningReviewEditorTitle } from "./PlanningReviewEditor";
+import { PlanningReviewEditor } from "./PlanningReviewEditor";
 import { PLANNING_REVIEW_DRAFT, singleAgentDraft, type PlanningReviewDraft } from "./planningReviewMockup";
 import { PopupHeader, PopupShell } from "./work-order-popup-redesign/popupShared";
 
@@ -24,7 +24,7 @@ export function PlanningReviewPopup({
   isLoading?: boolean;
 }) {
   const [draft] = useState(() => singleAgentDraft(initialDraft));
-  const title = isLoading ? "Editing Agent" : planningReviewEditorTitle(draft);
+  const title = isLoading ? "Editing Agent" : (draft.components[0]?.title ?? "Editing Agent");
   const description = isLoading ? undefined : draft.components[0]?.description;
 
   return (

--- a/web_src/src/pages/factories/pages/PlanningReviewPopup.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewPopup.tsx
@@ -1,50 +1,8 @@
-import { Link } from "@/components/Link/link";
-import { Button } from "@/components/ui/button";
-import { Workflow } from "lucide-react";
 import { useState } from "react";
 
-import { PlanningReviewForm } from "./PlanningReviewForm";
-import { PlanningReviewNav } from "./PlanningReviewNav";
-import { PLANNING_REVIEW_DEFAULT_SECTION, type PlanningReviewSectionId } from "./planningReviewSections";
-import {
-  PLANNING_REVIEW_DRAFT,
-  singleAgentDraft,
-  type PlanningReviewDraft,
-  type PlanningReviewStep,
-} from "./planningReviewMockup";
-import { PopupBody, PopupHeader, PopupShell } from "./work-order-popup-redesign/popupShared";
-
-function planningReviewPopupTitle(draft: PlanningReviewDraft): string {
-  return draft.components[0]?.title ?? "Editing Agent";
-}
-
-/**
- * Note that puts the agent in context. Agents run as part of an automation,
- * so the full automation editor stays one click away. It sits in the footer
- * because it explains the screen, it is not an action on the agent.
- */
-function AutomationNote({ href }: { href?: string }) {
-  return (
-    <p
-      className="flex min-w-0 flex-1 items-center gap-2.5 text-[12px] leading-5 text-muted-foreground"
-      data-testid="planning-review-automation-note"
-    >
-      <Workflow className="size-4 shrink-0" aria-hidden />
-      <span className="min-w-0">
-        Agents are part of an automation. Open the automation to add an agent or to change the order of the steps.
-      </span>
-      {href ? (
-        <Link
-          href={href}
-          data-testid="planning-review-edit-automation"
-          className="shrink-0 font-medium text-foreground underline underline-offset-2 hover:text-primary"
-        >
-          Edit Automation
-        </Link>
-      ) : null}
-    </p>
-  );
-}
+import { PlanningReviewEditor, planningReviewEditorTitle } from "./PlanningReviewEditor";
+import { PLANNING_REVIEW_DRAFT, singleAgentDraft, type PlanningReviewDraft } from "./planningReviewMockup";
+import { PopupHeader, PopupShell } from "./work-order-popup-redesign/popupShared";
 
 /**
  * Simple editing mode for one agent in a phase. Extra agents stay on the
@@ -65,30 +23,9 @@ export function PlanningReviewPopup({
   automationHref?: string;
   isLoading?: boolean;
 }) {
-  const [draft, setDraft] = useState(() => singleAgentDraft(initialDraft));
-  const [isSaving, setIsSaving] = useState(false);
-  const [section, setSection] = useState<PlanningReviewSectionId>(PLANNING_REVIEW_DEFAULT_SECTION);
-
-  const title = isLoading ? "Editing Agent" : planningReviewPopupTitle(draft);
+  const [draft] = useState(() => singleAgentDraft(initialDraft));
+  const title = isLoading ? "Editing Agent" : planningReviewEditorTitle(draft);
   const description = isLoading ? undefined : draft.components[0]?.description;
-  const saveDisabled = isLoading || isSaving || draft.components.length === 0;
-  const stepCount = ((draft.components[0]?.configuration.steps as PlanningReviewStep[]) ?? []).length;
-
-  const handleSave = async () => {
-    if (!onSave) {
-      onClose();
-      return;
-    }
-    setIsSaving(true);
-    try {
-      await onSave(draft);
-      onClose();
-    } catch {
-      // Caller reports the error and keeps this popup open.
-    } finally {
-      setIsSaving(false);
-    }
-  };
 
   return (
     <PopupShell testId="lines-planning-review" fixed onDismiss={onClose}>
@@ -99,35 +36,14 @@ export function PlanningReviewPopup({
           </p>
         ) : null}
       </PopupHeader>
-      {isLoading ? (
-        <PopupBody className="bg-muted px-6 py-5">
-          <p className="px-1 py-6 text-sm text-muted-foreground" data-testid="planning-review-loading">
-            Loading agent…
-          </p>
-        </PopupBody>
-      ) : (
-        <div className="flex min-h-0 flex-1">
-          <PlanningReviewNav active={section} onSelect={setSection} stepCount={stepCount} />
-          <PopupBody className="min-w-0 bg-muted px-6 py-5">
-            <PlanningReviewForm draft={draft} onChange={setDraft} organizationId={organizationId} section={section} />
-          </PopupBody>
-        </div>
-      )}
-      <footer className="flex shrink-0 items-center gap-4 border-t border-border px-6 py-4">
-        <AutomationNote href={automationHref} />
-        <Button type="button" variant="outline" className="shrink-0" onClick={onClose} disabled={isSaving}>
-          Cancel
-        </Button>
-        <Button
-          type="button"
-          className="shrink-0"
-          onClick={() => void handleSave()}
-          disabled={saveDisabled}
-          data-testid="planning-review-save"
-        >
-          {isSaving ? "Saving…" : "Save Agent"}
-        </Button>
-      </footer>
+      <PlanningReviewEditor
+        initialDraft={initialDraft}
+        onSave={onSave}
+        onCancel={onClose}
+        organizationId={organizationId}
+        automationHref={automationHref}
+        isLoading={isLoading}
+      />
     </PopupShell>
   );
 }

--- a/web_src/src/pages/factories/pages/intakeSourceSettingsModel.spec.ts
+++ b/web_src/src/pages/factories/pages/intakeSourceSettingsModel.spec.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_GITHUB_INTAKE_SETTINGS,
   GITHUB_INTAKE_RUNS,
   isIntakeSettingsTab,
+  intakeSettingsTabs,
   intakePlacementActivity,
   intakePlacementLabel,
   intakeRelativeTime,
@@ -45,11 +46,14 @@ describe("intakeSourceSettingsModel", () => {
     expect(intakeRelativeTime(180)).toBe("3h ago");
   });
 
-  it("accepts only the three settings tabs", () => {
+  it("accepts the intake settings tabs", () => {
     expect(isIntakeSettingsTab("automation")).toBe(true);
     expect(isIntakeSettingsTab("runs")).toBe(true);
+    expect(isIntakeSettingsTab("agent")).toBe(true);
     expect(isIntakeSettingsTab("general")).toBe(true);
     expect(isIntakeSettingsTab("listen")).toBe(false);
+    expect(intakeSettingsTabs(false)).toEqual(["general", "runs", "automation"]);
+    expect(intakeSettingsTabs(true)).toEqual(["general", "agent", "runs", "automation"]);
   });
 
   it("defaults the authors filter to off", () => {

--- a/web_src/src/pages/factories/pages/intakeSourceSettingsModel.ts
+++ b/web_src/src/pages/factories/pages/intakeSourceSettingsModel.ts
@@ -4,10 +4,14 @@ import { formatTimeAgo } from "@/lib/date";
 export type IntakeListenMode = "listen" | "schedule";
 export type IntakeLabelFilterMode = "include" | "exclude";
 export type IntakeAssignmentFilter = "any" | "assigned" | "unassigned";
-export type IntakeSettingsTab = "general" | "runs" | "automation";
+export type IntakeSettingsTab = "general" | "agent" | "runs" | "automation";
 
 export function isIntakeSettingsTab(value: string | null | undefined): value is IntakeSettingsTab {
-  return value === "general" || value === "runs" || value === "automation";
+  return value === "general" || value === "agent" || value === "runs" || value === "automation";
+}
+
+export function intakeSettingsTabs(hasAgent: boolean): IntakeSettingsTab[] {
+  return hasAgent ? ["general", "agent", "runs", "automation"] : ["general", "runs", "automation"];
 }
 export type IntakeTicketPlacement = "backlog" | "rejected" | "progressed" | "below-threshold";
 export type IntakeLineStage = "implement" | "verify" | "done";
@@ -51,6 +55,7 @@ export const INTAKE_SETTINGS_COPY = {
   title: "Intake GitHub issues",
   tabsLabel: "Intake settings",
   generalTab: "General",
+  agentTab: "Agent",
   automationTab: "Automation",
   editAutomation: "Edit automation",
   automationLoading: "The automation is loading.",

--- a/web_src/src/pages/factories/pages/prFeedbackSettingsModel.spec.ts
+++ b/web_src/src/pages/factories/pages/prFeedbackSettingsModel.spec.ts
@@ -13,6 +13,8 @@ import {
   waitingOnChecksWorkOrderIds,
   appendUniqueTrimmedString,
   hasAvailablePRFeedbackSource,
+  isPRFeedbackSettingsTab,
+  prFeedbackSettingsTabs,
   takenPRFeedbackSourceIds,
   normalizePRFeedbackDraft,
   oldestActivePRFeedbackRun,
@@ -42,6 +44,17 @@ function discussionDraft(overrides: Partial<PRFeedbackDraftSettings> = {}): PRFe
     ...overrides,
   };
 }
+
+describe("PR feedback settings tabs", () => {
+  it("accepts General, Agent, and Automation", () => {
+    expect(isPRFeedbackSettingsTab("general")).toBe(true);
+    expect(isPRFeedbackSettingsTab("agent")).toBe(true);
+    expect(isPRFeedbackSettingsTab("automation")).toBe(true);
+    expect(isPRFeedbackSettingsTab("runs")).toBe(false);
+    expect(prFeedbackSettingsTabs(false)).toEqual(["general", "automation"]);
+    expect(prFeedbackSettingsTabs(true)).toEqual(["general", "agent", "automation"]);
+  });
+});
 
 describe("oldestActivePRFeedbackRun", () => {
   it("returns the oldest pending or started run", () => {

--- a/web_src/src/pages/factories/pages/prFeedbackSettingsModel.ts
+++ b/web_src/src/pages/factories/pages/prFeedbackSettingsModel.ts
@@ -10,11 +10,15 @@ import githubIcon from "@/assets/icons/integrations/github.svg";
 
 import { isActiveCanvasRun } from "../lib/workOrderPullRequest";
 
-export type PRFeedbackSettingsTab = "general" | "automation";
+export type PRFeedbackSettingsTab = "general" | "agent" | "automation";
 export type PRFeedbackSourceId = "discussion" | "checks";
 
 export function isPRFeedbackSettingsTab(value: string | null | undefined): value is PRFeedbackSettingsTab {
-  return value === "general" || value === "automation";
+  return value === "general" || value === "agent" || value === "automation";
+}
+
+export function prFeedbackSettingsTabs(hasAgent: boolean): PRFeedbackSettingsTab[] {
+  return hasAgent ? ["general", "agent", "automation"] : ["general", "automation"];
 }
 
 export interface PRFeedbackSource {
@@ -85,6 +89,7 @@ export interface PRFeedbackDraftSettings {
 export const PR_FEEDBACK_SETTINGS_COPY = {
   tabsLabel: "PR feedback settings",
   generalTab: "General",
+  agentTab: "Agent",
   automationTab: "Automation",
   nameLabel: "Name",
   nameHelper: "This name appears in the workspace app list.",

--- a/web_src/src/pages/factories/pages/useIntakeAutomationCanvas.ts
+++ b/web_src/src/pages/factories/pages/useIntakeAutomationCanvas.ts
@@ -10,6 +10,7 @@ export interface IntakeAutomationGraph {
 
 interface IntakeAutomationCanvasResult {
   graph: IntakeAutomationGraph;
+  name?: string;
   isLoading: boolean;
   isError: boolean;
   refetch: () => Promise<unknown>;
@@ -33,6 +34,7 @@ export function useIntakeAutomationCanvas(
       edges: prepared.edges,
       factoryId: query.data?.metadata?.factoryId,
     },
+    name: query.data?.metadata?.name,
     isLoading: enabled && (query.isPending || prepared.isLoading),
     isError: query.isError,
     refetch: query.refetch,


### PR DESCRIPTION
A click on an existing automation opened the full editor. Operators need to view the canvas and edit the agent without leaving the board.

Open the popup on the first tab: General when a form exists, Agent when the canvas has an agent, otherwise Automation.







<!-- greptile_comment -->

<sub>Reviews (4): Last reviewed commit: ["fix: Widen intake draft setter for filte..."](https://github.com/superplanehq/superplane/commit/6671147772be1c07efb2e4f359b906cbac471e8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61342841)</sub>

<!-- /greptile_comment -->