### PR TITLE
fix: Route Unknown Sign-In to Create Account

### DIFF
--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -143,6 +143,10 @@ func (a *Handler) RegisterRoutes(router *mux.Router) {
 }
 
 func (a *Handler) handleAuth(w http.ResponseWriter, r *http.Request) {
+	if a.completePendingOAuthSignup(w, r) {
+		return
+	}
+
 	gothUser, err := gothic.CompleteUserAuth(w, r)
 	if err == nil {
 		a.finishProviderAuth(w, r, gothUser)
@@ -210,6 +214,10 @@ func (a *Handler) handleDevAuth(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		a.completeProviderLink(w, r, mockUser, state)
+		return
+	}
+
+	if a.completePendingOAuthSignup(w, r) {
 		return
 	}
 
@@ -301,6 +309,7 @@ func (a *Handler) handleProviderAuthError(w http.ResponseWriter, r *http.Request
 	}
 
 	if errors.Is(err, errSignupRequired) {
+		a.setPendingOAuthSignupCookie(w, r, gothUser)
 		http.Redirect(w, r, getSignupRequiredRedirectURL(r), http.StatusSeeOther)
 		return
 	}
@@ -331,6 +340,8 @@ func (a *Handler) handleSuccessfulAuth(w http.ResponseWriter, r *http.Request, g
 		return
 	}
 
+	clearPendingOAuthSignupCookie(w, r)
+
 	redirectURL := a.getPostAuthRedirectURL(r, wasCreated)
 	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 }
@@ -339,6 +350,7 @@ func (a *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {
 	gothic.Logout(w, r)
 
 	ClearAccountCookie(w, r)
+	clearPendingOAuthSignupCookie(w, r)
 
 	http.Redirect(w, r, getPostLogoutRedirectURL(r), http.StatusTemporaryRedirect)
 }
@@ -561,6 +573,23 @@ func (a *Handler) handleMagicCodeRequest(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if err := a.checkSignupPolicy(email, r); err != nil {
+		if errors.Is(err, errSignupRequired) {
+			writeSignupRequiredJSON(w)
+			return
+		}
+		if errors.Is(err, models.ErrAccountBlocked) {
+			successResponse()
+			return
+		}
+		if errors.Is(err, errSignupDisabled) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
+		successResponse()
+		return
+	}
+
 	count, err := models.CountRecentMagicCodes(email, time.Now().Add(-magicCodeRateWindow))
 	if err != nil {
 		log.Errorf("Failed to count recent magic codes for %s: %v", email, err)
@@ -640,6 +669,10 @@ func (a *Handler) handleMagicCodeVerify(w http.ResponseWriter, r *http.Request) 
 	// 2. Check signup policy without creating any records. Only reachable
 	//    with a valid code, so a 403 does not leak account existence.
 	if err := a.checkSignupPolicy(email, r); err != nil {
+		if errors.Is(err, errSignupRequired) {
+			writeSignupRequiredJSON(w)
+			return
+		}
 		http.Error(w, err.Error(), errorStatusForAccountError(err))
 		return
 	}
@@ -1055,8 +1088,25 @@ func (a *Handler) SignupsBlockedByEnvironment() bool {
 	return a.blockSignup
 }
 
+func writeSignupRequiredJSON(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", jsonContentType)
+	w.WriteHeader(http.StatusForbidden)
+	if err := json.NewEncoder(w).Encode(map[string]string{"error": authErrorSignupRequired}); err != nil {
+		log.Errorf("Error encoding signup required response: %v", err)
+	}
+}
+
+func inviteRedirectPath(r *http.Request) string {
+	formRedirect := strings.TrimSpace(r.FormValue("redirect"))
+	if isValidRedirectURL(formRedirect) {
+		return formRedirect
+	}
+
+	return getRedirectURL(r)
+}
+
 func allowSignupFromInvite(r *http.Request) bool {
-	redirectURL := getRedirectURL(r)
+	redirectURL := inviteRedirectPath(r)
 	if !strings.HasPrefix(redirectURL, "/invite/") {
 		return false
 	}

--- a/pkg/authentication/authentication_test.go
+++ b/pkg/authentication/authentication_test.go
@@ -631,6 +631,245 @@ func TestWritePostAuthRedirect(t *testing.T) {
 	})
 }
 
+func TestHandler_handleMagicCodeRequest_SignupRequired(t *testing.T) {
+	t.Run("rejects unknown email on login without sending a code", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		handler.magicCodeEnabled = true
+		email := "new-login-code@example.com"
+
+		form := url.Values{"email": {email}}
+		req := httptest.NewRequest(http.MethodPost, "/auth/magic-code/request", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		recorder := httptest.NewRecorder()
+
+		handler.handleMagicCodeRequest(recorder, req)
+
+		assert.Equal(t, http.StatusForbidden, recorder.Code)
+		var body map[string]string
+		require.NoError(t, json.NewDecoder(recorder.Body).Decode(&body))
+		assert.Equal(t, authErrorSignupRequired, body["error"])
+
+		count, err := models.CountRecentMagicCodes(email, time.Now().Add(-time.Hour))
+		require.NoError(t, err)
+		assert.Zero(t, count)
+	})
+
+	t.Run("sends a code when signup intent is present", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		handler.magicCodeEnabled = true
+		email := "new-signup-code@example.com"
+
+		form := url.Values{"email": {email}, "signup": {"true"}}
+		req := httptest.NewRequest(http.MethodPost, "/auth/magic-code/request", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		recorder := httptest.NewRecorder()
+
+		handler.handleMagicCodeRequest(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		count, err := models.CountRecentMagicCodes(email, time.Now().Add(-time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count)
+	})
+
+	t.Run("sends a code from login when an invite redirect is present", func(t *testing.T) {
+		handler, r := setupAuthHandler(t, false)
+		handler.magicCodeEnabled = true
+		invite, err := models.FindInviteLinkByOrganizationID(database.Conn(), r.Organization.ID.String())
+		if err != nil {
+			invite, err = models.CreateInviteLink(database.Conn(), r.Organization.ID)
+		}
+		require.NoError(t, err)
+		email := "invite-login-code@example.com"
+
+		form := url.Values{"email": {email}, "redirect": {"/invite/" + invite.Token.String()}}
+		req := httptest.NewRequest(http.MethodPost, "/auth/magic-code/request", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		recorder := httptest.NewRecorder()
+
+		handler.handleMagicCodeRequest(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		count, err := models.CountRecentMagicCodes(email, time.Now().Add(-time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count)
+	})
+}
+
+func TestHandler_handleMagicCodeVerify_SignupRequiredJSON(t *testing.T) {
+	handler, _ := setupAuthHandler(t, false)
+	handler.magicCodeEnabled = true
+	email := "verify-signup-required@example.com"
+	code := "654321"
+	_, err := models.CreateAccountMagicCode(email, crypto.HashToken(code), time.Now().Add(time.Hour))
+	require.NoError(t, err)
+
+	form := url.Values{"email": {email}, "code": {code}}
+	req := httptest.NewRequest(http.MethodPost, "/auth/magic-code/verify", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+
+	handler.handleMagicCodeVerify(recorder, req)
+
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&body))
+	assert.Equal(t, authErrorSignupRequired, body["error"])
+	_, err = models.FindAccountByEmail(email)
+	assert.Error(t, err)
+}
+
+func TestHandler_pendingOAuthSignup(t *testing.T) {
+	googleUser := goth.User{
+		UserID:      "pending-google-1",
+		Email:       "pending-google@example.com",
+		Name:        "Pending Google",
+		NickName:    "pendinggoogle",
+		Provider:    "google",
+		AccessToken: "google-access-token",
+	}
+
+	t.Run("stores a pending cookie when Google signup is required", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		req := mux.SetURLVars(
+			httptest.NewRequest(http.MethodGet, "/auth/google", nil),
+			map[string]string{"provider": "google"},
+		)
+		recorder := httptest.NewRecorder()
+
+		handler.completeProviderAuth(recorder, req, googleUser)
+
+		assert.Equal(t, http.StatusSeeOther, recorder.Code)
+		assert.Equal(t, "/login?auth_error=signup_required&provider=google", recorder.Header().Get("Location"))
+		cookie := pendingOAuthSignupCookieFromRecorder(t, recorder)
+		assert.NotEmpty(t, cookie.Value)
+		_, err := models.FindAccountByEmail(googleUser.Email)
+		assert.Error(t, err)
+	})
+
+	t.Run("creates the Google account from the pending cookie without a new OAuth start", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		seed := httptest.NewRecorder()
+		handler.setPendingOAuthSignupCookie(seed, httptest.NewRequest(http.MethodGet, "/", nil), googleUser)
+
+		req := mux.SetURLVars(
+			httptest.NewRequest(http.MethodGet, "/auth/google?signup=true", nil),
+			map[string]string{"provider": "google"},
+		)
+		req.AddCookie(pendingOAuthSignupCookieFromRecorder(t, seed))
+		recorder := httptest.NewRecorder()
+
+		handler.handleAuth(recorder, req)
+
+		assert.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+		account, err := models.FindAccountByEmail(googleUser.Email)
+		require.NoError(t, err)
+		assert.Equal(t, googleUser.Name, account.Name)
+		assert.True(t, pendingOAuthSignupCookieCleared(recorder))
+	})
+
+	t.Run("creates the GitHub account from the pending cookie", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		githubUser := goth.User{
+			UserID:      "pending-github-1",
+			Email:       "pending-github@example.com",
+			Name:        "Pending GitHub",
+			NickName:    "pendinggithub",
+			Provider:    "github",
+			AccessToken: "github-access-token",
+		}
+		seed := httptest.NewRecorder()
+		handler.setPendingOAuthSignupCookie(seed, httptest.NewRequest(http.MethodGet, "/", nil), githubUser)
+
+		req := mux.SetURLVars(
+			httptest.NewRequest(http.MethodGet, "/auth/github?signup=true", nil),
+			map[string]string{"provider": "github"},
+		)
+		req.AddCookie(pendingOAuthSignupCookieFromRecorder(t, seed))
+		recorder := httptest.NewRecorder()
+
+		handler.handleAuth(recorder, req)
+
+		account, err := models.FindAccountByEmail(githubUser.Email)
+		require.NoError(t, err)
+		assert.Equal(t, githubUser.Name, account.Name)
+	})
+
+	t.Run("does not create an account when the cookie provider does not match", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		seed := httptest.NewRecorder()
+		handler.setPendingOAuthSignupCookie(seed, httptest.NewRequest(http.MethodGet, "/", nil), googleUser)
+
+		req := mux.SetURLVars(
+			httptest.NewRequest(http.MethodGet, "/auth/github?signup=true", nil),
+			map[string]string{"provider": "github"},
+		)
+		req.AddCookie(pendingOAuthSignupCookieFromRecorder(t, seed))
+
+		_, ok := handler.gothUserFromPendingOAuthSignup(req, "github")
+		assert.False(t, ok)
+		_, err := models.FindAccountByEmail(googleUser.Email)
+		assert.Error(t, err)
+	})
+
+	t.Run("completes signup from the pending cookie in the development handler", func(t *testing.T) {
+		r := support.Setup(t)
+		t.Cleanup(func() { r.Close() })
+		handler := NewHandler(jwt.NewSigner("test-secret"), r.Encryptor, r.AuthService, "development", "/templates", false, false, false)
+
+		seed := httptest.NewRecorder()
+		handler.setPendingOAuthSignupCookie(seed, httptest.NewRequest(http.MethodGet, "/", nil), googleUser)
+
+		req := mux.SetURLVars(
+			httptest.NewRequest(http.MethodGet, "/auth/google?signup=true", nil),
+			map[string]string{"provider": "google"},
+		)
+		req.AddCookie(pendingOAuthSignupCookieFromRecorder(t, seed))
+		recorder := httptest.NewRecorder()
+
+		handler.handleDevAuth(recorder, req)
+
+		account, err := models.FindAccountByEmail(googleUser.Email)
+		require.NoError(t, err)
+		assert.Equal(t, googleUser.Name, account.Name)
+		_, err = models.FindAccountByEmail("dev@superplane.local")
+		assert.Error(t, err)
+	})
+
+	t.Run("clears the pending cookie on logout", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		req := httptest.NewRequest(http.MethodGet, "/logout", nil)
+		recorder := httptest.NewRecorder()
+
+		handler.handleLogout(recorder, req)
+
+		assert.True(t, pendingOAuthSignupCookieCleared(recorder))
+	})
+}
+
+func pendingOAuthSignupCookieFromRecorder(t *testing.T, recorder *httptest.ResponseRecorder) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == pendingOAuthSignupCookie {
+			return cookie
+		}
+	}
+
+	t.Fatal("pending OAuth signup cookie not set")
+	return nil
+}
+
+func pendingOAuthSignupCookieCleared(recorder *httptest.ResponseRecorder) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == pendingOAuthSignupCookie && cookie.MaxAge < 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 func TestHandler_handlePasswordSignup(t *testing.T) {
 	t.Run("should route new cloud users through welcome with original redirect", func(t *testing.T) {
 		r := support.Setup(t)

--- a/pkg/authentication/authentication_test.go
+++ b/pkg/authentication/authentication_test.go
@@ -743,6 +743,8 @@ func TestHandler_pendingOAuthSignup(t *testing.T) {
 		assert.Equal(t, "/login?auth_error=signup_required&provider=google", recorder.Header().Get("Location"))
 		cookie := pendingOAuthSignupCookieFromRecorder(t, recorder)
 		assert.NotEmpty(t, cookie.Value)
+		assert.Equal(t, http.SameSiteStrictMode, cookie.SameSite)
+		assert.True(t, cookie.HttpOnly)
 		_, err := models.FindAccountByEmail(googleUser.Email)
 		assert.Error(t, err)
 	})

--- a/pkg/authentication/pending_oauth_signup.go
+++ b/pkg/authentication/pending_oauth_signup.go
@@ -106,7 +106,8 @@ func pendingOAuthSignupCookieValue(r *http.Request, value string, maxAge int) *h
 		MaxAge:   maxAge,
 		HttpOnly: true,
 		Secure:   r.TLS != nil,
-		SameSite: http.SameSiteLaxMode,
+		// Strict keeps a cross-site GET from completing signup with this cookie.
+		SameSite: http.SameSiteStrictMode,
 	}
 }
 

--- a/pkg/authentication/pending_oauth_signup.go
+++ b/pkg/authentication/pending_oauth_signup.go
@@ -1,0 +1,141 @@
+package authentication
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/markbates/goth"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	pendingOAuthSignupCookie   = "pending_oauth_signup"
+	pendingOAuthSignupTTL      = 15 * time.Minute
+	pendingOAuthSignupType     = "pending_oauth_signup"
+	pendingOAuthSignupClaimTyp = "typ"
+)
+
+func (a *Handler) setPendingOAuthSignupCookie(w http.ResponseWriter, r *http.Request, user goth.User) {
+	if a.jwtSigner == nil {
+		return
+	}
+
+	token, err := a.jwtSigner.GenerateWithClaims(pendingOAuthSignupTTL, map[string]string{
+		pendingOAuthSignupClaimTyp: pendingOAuthSignupType,
+		"provider":                 user.Provider,
+		"provider_id":              user.UserID,
+		"email":                    user.Email,
+		"name":                     user.Name,
+		"nick":                     user.NickName,
+		"avatar":                   user.AvatarURL,
+		"access_token":             user.AccessToken,
+		"refresh_token":            user.RefreshToken,
+		"expires_at":               formatPendingOAuthExpiry(user.ExpiresAt),
+	})
+	if err != nil {
+		log.Errorf("Failed to sign pending OAuth signup cookie for %s: %v", user.Email, err)
+		return
+	}
+
+	http.SetCookie(w, pendingOAuthSignupCookieValue(r, token, int(pendingOAuthSignupTTL.Seconds())))
+}
+
+func (a *Handler) gothUserFromPendingOAuthSignup(r *http.Request, provider string) (goth.User, bool) {
+	cookie, err := r.Cookie(pendingOAuthSignupCookie)
+	if err != nil || cookie.Value == "" || a.jwtSigner == nil {
+		return goth.User{}, false
+	}
+
+	claims, err := a.jwtSigner.ValidateAndGetClaims(cookie.Value)
+	if err != nil {
+		return goth.User{}, false
+	}
+
+	if claimString(claims[pendingOAuthSignupClaimTyp]) != pendingOAuthSignupType {
+		return goth.User{}, false
+	}
+
+	pendingProvider := claimString(claims["provider"])
+	if pendingProvider == "" || pendingProvider != provider {
+		return goth.User{}, false
+	}
+
+	email := claimString(claims["email"])
+	userID := claimString(claims["provider_id"])
+	if email == "" || userID == "" {
+		return goth.User{}, false
+	}
+
+	return goth.User{
+		Provider:     pendingProvider,
+		UserID:       userID,
+		Email:        email,
+		Name:         claimString(claims["name"]),
+		NickName:     claimString(claims["nick"]),
+		AvatarURL:    claimString(claims["avatar"]),
+		AccessToken:  claimString(claims["access_token"]),
+		RefreshToken: claimString(claims["refresh_token"]),
+		ExpiresAt:    parsePendingOAuthExpiry(claimString(claims["expires_at"])),
+	}, true
+}
+
+func (a *Handler) completePendingOAuthSignup(w http.ResponseWriter, r *http.Request) bool {
+	if !isSignupIntentFromRequest(r) {
+		return false
+	}
+
+	user, ok := a.gothUserFromPendingOAuthSignup(r, muxProvider(r))
+	if !ok {
+		return false
+	}
+
+	a.finishProviderAuth(w, r, user)
+	return true
+}
+
+func clearPendingOAuthSignupCookie(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, pendingOAuthSignupCookieValue(r, "", -1))
+}
+
+func pendingOAuthSignupCookieValue(r *http.Request, value string, maxAge int) *http.Cookie {
+	return &http.Cookie{
+		Name:     pendingOAuthSignupCookie,
+		Value:    value,
+		Path:     "/",
+		MaxAge:   maxAge,
+		HttpOnly: true,
+		Secure:   r.TLS != nil,
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+func formatPendingOAuthExpiry(expiresAt time.Time) string {
+	if expiresAt.IsZero() {
+		return ""
+	}
+
+	return expiresAt.UTC().Format(time.RFC3339)
+}
+
+func parsePendingOAuthExpiry(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}
+	}
+
+	return parsed
+}
+
+func claimString(value any) string {
+	text, _ := value.(string)
+	return text
+}
+
+func muxProvider(r *http.Request) string {
+	return mux.Vars(r)["provider"]
+}

--- a/test/e2e/login_page_test.go
+++ b/test/e2e/login_page_test.go
@@ -148,109 +148,162 @@ func (steps *TestLoginPageSteps) SetInvalidAuthCookie() {
 }
 
 const googleDevAccountEmail = "dev@superplane.local"
+const pendingOAuthSignupCookieName = "pending_oauth_signup"
 
 func TestGoogleSSONoAccountSignup(t *testing.T) {
-	t.Run("google sign-in without an account asks to create one", func(t *testing.T) {
-		steps := &googleSSONoAccountSteps{t: t}
+	runProviderSSONoAccountSignup(t, providerSSOCase{
+		provider:      "google",
+		continueLabel: "Continue with Google",
+		accountBody:   "This Google account does not have a SuperPlane account.",
+		screenshot:    "sso-no-account",
+	})
+}
+
+func TestGitHubSSONoAccountSignup(t *testing.T) {
+	runProviderSSONoAccountSignup(t, providerSSOCase{
+		provider:      "github",
+		continueLabel: "Continue with GitHub",
+		accountBody:   "This GitHub account does not have a SuperPlane account.",
+		screenshot:    "sso-github-no-account",
+	})
+}
+
+type providerSSOCase struct {
+	provider      string
+	continueLabel string
+	accountBody   string
+	screenshot    string
+}
+
+func runProviderSSONoAccountSignup(t *testing.T, spec providerSSOCase) {
+	t.Helper()
+
+	t.Run(spec.provider+" sign-in without an account asks to create one", func(t *testing.T) {
+		steps := &providerSSONoAccountSteps{t: t, spec: spec}
 		steps.start()
 		steps.visitLoginPage()
 		steps.capture("01-login")
-		steps.clickContinueWithGoogle()
+		steps.clickContinue()
 		steps.assertNoAccountPromptVisible()
+		steps.assertPendingOAuthCookie(true)
 		steps.capture("02-prompt")
 		steps.clickCreateAccount()
 		steps.assertAccountCreatedAndSignedIn()
+		steps.assertPendingOAuthCookie(false)
 		steps.capture("03-after-create")
 	})
 
 	t.Run("use a different account returns to sign in", func(t *testing.T) {
-		steps := &googleSSONoAccountSteps{t: t}
+		steps := &providerSSONoAccountSteps{t: t, spec: spec}
 		steps.start()
 		steps.visitLoginPage()
-		steps.clickContinueWithGoogle()
+		steps.clickContinue()
 		steps.assertNoAccountPromptVisible()
 		steps.clickUseADifferentAccount()
 		steps.assertLoginPageVisible()
+		steps.assertPendingOAuthCookie(false)
 	})
 
-	t.Run("existing google user signs in from the login page", func(t *testing.T) {
-		steps := &googleSSONoAccountSteps{t: t}
+	t.Run("existing "+spec.provider+" user signs in from the login page", func(t *testing.T) {
+		steps := &providerSSONoAccountSteps{t: t, spec: spec}
 		steps.start()
-		steps.givenTheGoogleDevAccountExists()
+		steps.givenTheDevAccountExists()
 		steps.visitLoginPage()
-		steps.clickContinueWithGoogle()
+		steps.clickContinue()
 		steps.assertLeftLoginPage()
 	})
 }
 
-type googleSSONoAccountSteps struct {
+type providerSSONoAccountSteps struct {
 	t       *testing.T
 	session *session.TestSession
+	spec    providerSSOCase
 }
 
-func (s *googleSSONoAccountSteps) start() {
+func (s *providerSSONoAccountSteps) start() {
 	s.session = ctx.NewSession(s.t)
 	s.session.Start()
 }
 
-func (s *googleSSONoAccountSteps) visitLoginPage() {
+func (s *providerSSONoAccountSteps) visitLoginPage() {
 	s.session.Visit("/login")
-	s.session.AssertVisible(q.Text("Continue with Google"))
+	s.session.AssertVisible(q.Text(s.spec.continueLabel))
 }
 
-func (s *googleSSONoAccountSteps) clickContinueWithGoogle() {
-	s.session.Click(q.Text("Continue with Google"))
+func (s *providerSSONoAccountSteps) clickContinue() {
+	s.session.Click(q.Text(s.spec.continueLabel))
 }
 
-func (s *googleSSONoAccountSteps) assertNoAccountPromptVisible() {
+func (s *providerSSONoAccountSteps) assertNoAccountPromptVisible() {
 	s.session.AssertVisible(q.Text("No account found"))
-	s.session.AssertVisible(q.Text("This Google account does not have a SuperPlane account."))
+	s.session.AssertVisible(q.Text(s.spec.accountBody))
 	s.session.AssertVisible(q.Text("Create an account to continue."))
 	s.session.AssertVisible(q.Text("Create account"))
 	s.session.AssertVisible(q.Text("Use a different account"))
 	s.session.AssertURLContains("auth_error=signup_required")
-	s.session.AssertURLContains("provider=google")
+	s.session.AssertURLContains("provider=" + s.spec.provider)
 }
 
-func (s *googleSSONoAccountSteps) clickCreateAccount() {
+func (s *providerSSONoAccountSteps) clickCreateAccount() {
 	s.session.Click(q.Text("Create account"))
 }
 
-func (s *googleSSONoAccountSteps) clickUseADifferentAccount() {
+func (s *providerSSONoAccountSteps) clickUseADifferentAccount() {
 	s.session.Click(q.Text("Use a different account"))
 }
 
-func (s *googleSSONoAccountSteps) assertAccountCreatedAndSignedIn() {
+func (s *providerSSONoAccountSteps) assertAccountCreatedAndSignedIn() {
 	waitErr := s.session.Page().WaitForURL("**/welcome**", pw.PageWaitForURLOptions{
 		Timeout: pw.Float(s.sessionTimeout()),
 	})
 	require.NoError(s.t, waitErr)
+	assert.NotContains(s.t, s.session.Page().URL(), "auth_error=signup_required")
 
 	account, err := models.FindAccountByEmail(googleDevAccountEmail)
 	require.NoError(s.t, err)
 	assert.Equal(s.t, googleDevAccountEmail, account.Email)
 }
 
-func (s *googleSSONoAccountSteps) assertLoginPageVisible() {
+func (s *providerSSONoAccountSteps) assertLoginPageVisible() {
 	s.session.AssertVisible(q.Text("Welcome to SuperPlane"))
-	s.session.AssertVisible(q.Text("Continue with Google"))
+	s.session.AssertVisible(q.Text(s.spec.continueLabel))
 	assert.NotContains(s.t, s.session.Page().URL(), "auth_error=signup_required")
 }
 
-func (s *googleSSONoAccountSteps) givenTheGoogleDevAccountExists() {
+func (s *providerSSONoAccountSteps) givenTheDevAccountExists() {
 	_, err := models.CreateAccount("Dev User", googleDevAccountEmail)
 	require.NoError(s.t, err)
 }
 
-func (s *googleSSONoAccountSteps) assertLeftLoginPage() {
+func (s *providerSSONoAccountSteps) assertLeftLoginPage() {
 	s.session.WaitUntilURLDoesNotContain("/login")
 	currentURL := s.session.Page().URL()
 	assert.NotContains(s.t, currentURL, "auth_error=signup_required")
 }
 
-func (s *googleSSONoAccountSteps) capture(name string) {
+func (s *providerSSONoAccountSteps) assertPendingOAuthCookie(present bool) {
+	cookies, err := s.session.Page().Context().Cookies()
+	require.NoError(s.t, err)
+
+	found := false
+	for _, cookie := range cookies {
+		if cookie.Name == pendingOAuthSignupCookieName && cookie.Value != "" {
+			found = true
+			break
+		}
+	}
+
+	if present {
+		assert.True(s.t, found, "expected pending OAuth signup cookie")
+		return
+	}
+
+	assert.False(s.t, found, "expected pending OAuth signup cookie to be cleared")
+}
+
+func (s *providerSSONoAccountSteps) capture(name string) {
 	s.session.Sleep(300)
-	path := fmt.Sprintf("/app/tmp/screenshots/sso-no-account-%s.png", name)
+	path := fmt.Sprintf("/app/tmp/screenshots/%s-%s.png", s.spec.screenshot, name)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		s.t.Fatalf("screenshot dir %s: %v", path, err)
 	}
@@ -264,6 +317,6 @@ func (s *googleSSONoAccountSteps) capture(name string) {
 	}
 }
 
-func (s *googleSSONoAccountSteps) sessionTimeout() float64 {
+func (s *providerSSONoAccountSteps) sessionTimeout() float64 {
 	return 15000
 }

--- a/test/e2e/magic_code_login_test.go
+++ b/test/e2e/magic_code_login_test.go
@@ -86,6 +86,46 @@ func TestMagicCodeLogin(t *testing.T) {
 		steps.clickMagicCodeToggle()
 		steps.assertMagicCodeFormVisible()
 	})
+
+	t.Run("new user on login sees create prompt then receives a code", func(t *testing.T) {
+		steps := &magicCodeSteps{t: t}
+		steps.start()
+		steps.visitLoginPage()
+		email := support.RandomName("magic") + "@superplane.local"
+		steps.enterEmailAndRequestCode(email)
+		steps.assertEmailSignupPromptVisible()
+		steps.assertMagicCodeCount(email, 0)
+		steps.assertSignupRequiredErrorHidden()
+		steps.clickCreateAccount()
+		steps.assertCodeStepVisible()
+		steps.assertMagicCodeCount(email, 1)
+		steps.insertKnownMagicCode(email, "222222")
+		steps.enterCodeAndCreate("222222")
+		steps.assertAccountCreated(email)
+	})
+
+	t.Run("use a different account on email prompt returns to the email form", func(t *testing.T) {
+		steps := &magicCodeSteps{t: t}
+		steps.start()
+		steps.visitLoginPage()
+		email := support.RandomName("magic") + "@superplane.local"
+		steps.enterEmailAndRequestCode(email)
+		steps.assertEmailSignupPromptVisible()
+		steps.clickUseADifferentAccount()
+		steps.assertMagicCodeFormVisible()
+		steps.assertMagicCodeCount(email, 0)
+	})
+
+	t.Run("new user on signup receives a code without the create prompt", func(t *testing.T) {
+		steps := &magicCodeSteps{t: t}
+		steps.start()
+		steps.visitSignupPage()
+		email := support.RandomName("magic") + "@superplane.local"
+		steps.enterEmailAndRequestCode(email)
+		steps.assertCodeStepVisible()
+		steps.assertSignupRequiredErrorHidden()
+		steps.assertMagicCodeCount(email, 1)
+	})
 }
 
 type magicCodeSteps struct {
@@ -100,6 +140,11 @@ func (s *magicCodeSteps) start() {
 
 func (s *magicCodeSteps) visitLoginPage() {
 	s.session.Visit("/login")
+	s.session.Sleep(500)
+}
+
+func (s *magicCodeSteps) visitSignupPage() {
+	s.session.Visit("/signup")
 	s.session.Sleep(500)
 }
 
@@ -141,6 +186,42 @@ func (s *magicCodeSteps) enterCodeAndSubmit(code string) {
 	s.session.FillIn(q.Locator(`input[name="code"]`), code)
 	s.session.Click(q.Text("Sign in"))
 	s.session.Sleep(1500)
+}
+
+func (s *magicCodeSteps) enterCodeAndCreate(code string) {
+	s.session.FillIn(q.Locator(`input[name="code"]`), code)
+	s.session.Click(q.Text("Create account"))
+	s.session.Sleep(1500)
+}
+
+func (s *magicCodeSteps) assertEmailSignupPromptVisible() {
+	s.session.AssertVisible(q.Text("No account found"))
+	s.session.AssertVisible(q.Text("This email does not have a SuperPlane account."))
+	s.session.AssertVisible(q.Text("Create an account to continue."))
+	s.session.AssertVisible(q.Text("Create account"))
+	s.session.AssertVisible(q.Text("Use a different account"))
+}
+
+func (s *magicCodeSteps) clickCreateAccount() {
+	s.session.Click(q.Text("Create account"))
+	s.session.Sleep(500)
+}
+
+func (s *magicCodeSteps) clickUseADifferentAccount() {
+	s.session.Click(q.Text("Use a different account"))
+	s.session.Sleep(300)
+}
+
+func (s *magicCodeSteps) assertMagicCodeCount(email string, expected int64) {
+	count, err := models.CountRecentMagicCodes(strings.ToLower(strings.TrimSpace(email)), time.Now().Add(-time.Hour))
+	require.NoError(s.t, err)
+	assert.Equal(s.t, expected, count)
+}
+
+func (s *magicCodeSteps) assertSignupRequiredErrorHidden() {
+	content, err := s.session.Page().Content()
+	require.NoError(s.t, err)
+	assert.NotContains(s.t, content, "signup must be started from the signup page")
 }
 
 func (s *magicCodeSteps) assertRedirectedToOrganization() {

--- a/test/e2e/test_context.go
+++ b/test/e2e/test_context.go
@@ -70,6 +70,10 @@ func (s *TestContext) Start() {
 		os.Setenv("GOOGLE_CLIENT_ID", "e2e-google-client-id")
 		os.Setenv("GOOGLE_CLIENT_SECRET", "e2e-google-client-secret")
 	}
+	if os.Getenv("GITHUB_CLIENT_ID") == "" {
+		os.Setenv("GITHUB_CLIENT_ID", "e2e-github-client-id")
+		os.Setenv("GITHUB_CLIENT_SECRET", "e2e-github-client-secret")
+	}
 
 	s.AgentProvider = support.NewAgentProvider()
 	s.ResetAgentProvider()

--- a/web_src/src/pages/auth/Login.spec.tsx
+++ b/web_src/src/pages/auth/Login.spec.tsx
@@ -1,6 +1,41 @@
-import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { Login } from "./Login";
 import { getSignupUnavailableReason } from "./signupUnavailableReason";
+
+vi.mock("@/contexts/useAccount", () => ({
+  useAccount: () => ({ account: null, loading: false }),
+}));
+
+vi.mock("@/hooks/useReportPageReady", () => ({
+  useReportPageReady: () => undefined,
+}));
+
+const authConfig = {
+  providers: [] as string[],
+  passwordLoginEnabled: false,
+  signupEnabled: true,
+  signupsBlockedByEnvironment: false,
+  magicCodeEnabled: true,
+};
+
+function mockAuthConfig() {
+  return {
+    ok: true,
+    json: async () => authConfig,
+  } as Response;
+}
+
+function renderLogin(path = "/login", mode?: "login" | "signup") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Login mode={mode} />
+    </MemoryRouter>,
+  );
+}
 
 describe("getSignupUnavailableReason", () => {
   it("does not use waitlist state when signup is available", () => {
@@ -17,5 +52,169 @@ describe("getSignupUnavailableReason", () => {
 
   it("uses closed state when signups are blocked by environment", () => {
     expect(getSignupUnavailableReason(true, true, true)).toBe("closed");
+  });
+});
+
+describe("Login magic code signup required", () => {
+  beforeEach(() => {
+    authConfig.magicCodeEnabled = true;
+    authConfig.signupEnabled = true;
+    vi.restoreAllMocks();
+  });
+
+  it("shows the create prompt when a login code request returns signup_required", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/auth/config") {
+        return mockAuthConfig();
+      }
+
+      if (url === "/auth/magic-code/request") {
+        return {
+          ok: false,
+          status: 403,
+          text: async () => JSON.stringify({ error: "signup_required" }),
+        } as Response;
+      }
+
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderLogin();
+
+    await screen.findByRole("button", { name: "Continue with email" });
+    await user.type(screen.getByPlaceholderText("you@example.com"), "new@example.com");
+    await user.click(screen.getByRole("button", { name: "Continue with email" }));
+
+    expect(await screen.findByText("No account found")).toBeInTheDocument();
+    expect(screen.getByText("This email does not have a SuperPlane account.")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Enter 6-digit code")).not.toBeInTheDocument();
+    expect(screen.queryByText("signup must be started from the signup page")).not.toBeInTheDocument();
+  });
+
+  it("sends the code with signup intent after Create account", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/auth/config") {
+        return mockAuthConfig();
+      }
+
+      if (url === "/auth/magic-code/request") {
+        const body = String(init?.body ?? "");
+        if (body.includes("signup=true")) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ message: "sent" }),
+            text: async () => JSON.stringify({ message: "sent" }),
+          } as Response;
+        }
+
+        return {
+          ok: false,
+          status: 403,
+          text: async () => JSON.stringify({ error: "signup_required" }),
+        } as Response;
+      }
+
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderLogin();
+
+    await screen.findByRole("button", { name: "Continue with email" });
+    await user.type(screen.getByPlaceholderText("you@example.com"), "new@example.com");
+    await user.click(screen.getByRole("button", { name: "Continue with email" }));
+    await screen.findByRole("button", { name: "Create account" });
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+
+    expect(await screen.findByText("Check your email")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Enter 6-digit code")).toBeInTheDocument();
+
+    const signupRequest = fetchMock.mock.calls.find(([, init]) => String(init?.body ?? "").includes("signup=true"));
+    expect(signupRequest).toBeDefined();
+  });
+
+  it("opens the create prompt when verify returns signup_required", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/auth/config") {
+        return mockAuthConfig();
+      }
+
+      if (url === "/auth/magic-code/request") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ message: "sent" }),
+          text: async () => JSON.stringify({ message: "sent" }),
+        } as Response;
+      }
+
+      if (String(url).startsWith("/auth/magic-code/verify")) {
+        return {
+          ok: false,
+          status: 403,
+          clone: () => ({
+            text: async () => JSON.stringify({ error: "signup_required" }),
+          }),
+          text: async () => JSON.stringify({ error: "signup_required" }),
+        } as Response;
+      }
+
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderLogin("/signup", "signup");
+
+    await screen.findByRole("button", { name: "Continue with email" });
+    await user.type(screen.getByPlaceholderText("you@example.com"), "new@example.com");
+    await user.click(screen.getByRole("button", { name: "Continue with email" }));
+    await screen.findByPlaceholderText("Enter 6-digit code");
+    await user.type(screen.getByPlaceholderText("Enter 6-digit code"), "123456");
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+
+    expect(await screen.findByText("No account found")).toBeInTheDocument();
+    expect(screen.queryByText("signup must be started from the signup page")).not.toBeInTheDocument();
+  });
+
+  it("shows the closed notice when signups are blocked", async () => {
+    authConfig.signupEnabled = false;
+    authConfig.signupsBlockedByEnvironment = true;
+    const user = userEvent.setup();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/auth/config") {
+        return mockAuthConfig();
+      }
+
+      if (url === "/auth/magic-code/request") {
+        return {
+          ok: false,
+          status: 403,
+          text: async () => JSON.stringify({ error: "signup_required" }),
+        } as Response;
+      }
+
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderLogin();
+
+    await screen.findByRole("button", { name: "Continue with email" });
+    await user.type(screen.getByPlaceholderText("you@example.com"), "new@example.com");
+    await user.click(screen.getByRole("button", { name: "Continue with email" }));
+
+    expect(await screen.findByText("Signups are closed")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to sign in" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create account" })).not.toBeInTheDocument();
+    expect(screen.queryByText('{"error":"signup_required"}')).not.toBeInTheDocument();
   });
 });

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -29,7 +29,9 @@ import {
   getLogoutHref,
   getSignupRequiredAccountBody,
   getSignupRequiredCreateHref,
+  isEmailAuthProvider,
   isKnownAuthProvider,
+  isSignupRequiredErrorBody,
   shouldShowSignupRequiredPrompt,
 } from "./signupRequiredPrompt";
 import { getSignupUnavailableReason } from "./signupUnavailableReason";
@@ -173,6 +175,9 @@ const getMagicCodeVerifyError = async (response: Response) => {
     if (errorText === ACCOUNT_BLOCKED_MESSAGE) {
       return ACCOUNT_BLOCKED_MESSAGE;
     }
+    if (isSignupRequiredErrorBody(errorText)) {
+      return "Create an account to continue.";
+    }
     return errorText || "Sign-up is not allowed.";
   }
 
@@ -249,6 +254,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const [magicCodeStep, setMagicCodeStep] = useState<MagicCodeStep>("email");
   const [magicCodeEmail, setMagicCodeEmail] = useState("");
   const [magicCode, setMagicCode] = useState("");
+  const [emailSignupRequired, setEmailSignupRequired] = useState(false);
   const [showPasswordLogin, setShowPasswordLogin] = useState(false);
 
   const [lastUsedMethod, setLastUsedMethod] = useState<LastUsedLoginMethod | null>(null);
@@ -309,6 +315,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
     setFormError(null);
     setMagicCodeStep("email");
     setMagicCode("");
+    setEmailSignupRequired(false);
     setShowPasswordLogin(false);
   }, [mode]);
 
@@ -410,7 +417,8 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const showProviderButtons = hasProviders && (!isSignupMode || canSignup);
   const canUseMagicCode = authConfig.magicCodeEnabled && (!isSignupMode || canSignup);
   const useMagicCodePrimary = canUseMagicCode && !showPasswordLogin;
-  const isSignupRequiredReturn = authError === SIGNUP_REQUIRED_AUTH_ERROR;
+  const signupRequiredProvider = emailSignupRequired ? "email" : authProvider;
+  const isSignupRequiredReturn = authError === SIGNUP_REQUIRED_AUTH_ERROR || emailSignupRequired;
   const showSignupUnavailable = !configLoading && !canSignup && (isSignupMode || isSignupRequiredReturn);
   const hasConfiguredSignupWaitlist = hasSignupWaitlistConfig();
   const signupUnavailableReason = getSignupUnavailableReason(
@@ -426,10 +434,41 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const showStandaloneProductUpdatesOptIn =
     isSignupMode && canSignup && magicCodeStep === "email" && !canSignupWithPassword && !useMagicCodePrimary;
   const visibleFormError = formError ?? authErrorMessage;
-  const showSignupRequiredPrompt = !configLoading && shouldShowSignupRequiredPrompt(authError, canSignup);
+  const showSignupRequiredPrompt =
+    !configLoading && (shouldShowSignupRequiredPrompt(authError, canSignup) || (emailSignupRequired && canSignup));
   const showAuthMethods = !configLoading && !isSignupRequiredReturn;
-  const signupRequiredCreateHref = getSignupRequiredCreateHref(authProvider, redirectQuery);
+  const signupRequiredCreateHref = getSignupRequiredCreateHref(signupRequiredProvider, redirectQuery);
   const logoutHref = getLogoutHref(redirectQuery);
+
+  const requestMagicCode = async (signup: boolean) => {
+    const response = await fetch("/auth/magic-code/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: buildMagicCodeRequestBody(magicCodeEmail, signup, redirectTarget),
+    });
+
+    if (response.ok) {
+      setEmailSignupRequired(false);
+      if (signup) {
+        setIsSignupMode(true);
+      }
+      setMagicCodeStep("code");
+      setSubmitLoading(false);
+      return;
+    }
+
+    const errorBody = (await response.text()).trim();
+    if (response.status === 403 && isSignupRequiredErrorBody(errorBody)) {
+      setEmailSignupRequired(true);
+      setFormError(null);
+      setSubmitLoading(false);
+      return;
+    }
+
+    clearSignupPreference(signup);
+    setFormError(errorBody || "Failed to send code. Please try again.");
+    setSubmitLoading(false);
+  };
 
   const handleMagicCodeRequest = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -445,26 +484,47 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
     setSubmitLoading(true);
 
     try {
-      const response = await fetch("/auth/magic-code/request", {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: buildMagicCodeRequestBody(magicCodeEmail, isSignupMode, redirectTarget),
-      });
-
-      if (!response.ok) {
-        clearSignupPreference(isSignupMode);
-        setFormError("Failed to send code. Please try again.");
-        setSubmitLoading(false);
-        return;
-      }
-
-      setMagicCodeStep("code");
-      setSubmitLoading(false);
+      await requestMagicCode(isSignupMode);
     } catch {
       clearSignupPreference(isSignupMode);
       setFormError("Network error occurred");
       setSubmitLoading(false);
     }
+  };
+
+  const handleEmailCreateAccount = async () => {
+    setFormError(null);
+    saveSignupPreference(true, signupProductUpdatesOptIn, magicCodeEmail);
+    setSubmitLoading(true);
+
+    try {
+      await requestMagicCode(true);
+    } catch {
+      clearSignupPreference(true);
+      setFormError("Network error occurred");
+      setSubmitLoading(false);
+    }
+  };
+
+  const handleClearEmailSignupRequired = () => {
+    setEmailSignupRequired(false);
+    setMagicCodeStep("email");
+    setMagicCode("");
+    setFormError(null);
+  };
+
+  const applyMagicCodeVerifyFailure = async (response: Response) => {
+    const errorBody = await response.clone().text();
+    if (response.status === 403 && isSignupRequiredErrorBody(errorBody)) {
+      setEmailSignupRequired(true);
+      setFormError(null);
+      setSubmitLoading(false);
+      return;
+    }
+
+    clearSignupPreference(isSignupMode);
+    setFormError(await getMagicCodeVerifyError(response));
+    setSubmitLoading(false);
   };
 
   const handleMagicCodeVerify = async (e: React.FormEvent) => {
@@ -494,9 +554,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
       });
 
       if (!response.ok) {
-        clearSignupPreference(isSignupMode);
-        setFormError(await getMagicCodeVerifyError(response));
-        setSubmitLoading(false);
+        await applyMagicCodeVerifyFailure(response);
         return;
       }
 
@@ -682,25 +740,46 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
           {!configLoading && showSignupRequiredPrompt && (
             <div className="space-y-4">
               <p className="text-left text-sm leading-6 text-gray-600 dark:text-gray-400">
-                {getSignupRequiredAccountBody(authProvider)}
+                {getSignupRequiredAccountBody(signupRequiredProvider)}
               </p>
               <ProductUpdatesOptIn checked={signupProductUpdatesOptIn} onCheckedChange={setSignupProductUpdatesOptIn} />
-              <Button className="w-full" asChild>
-                <a
-                  href={signupRequiredCreateHref}
-                  onClick={() => {
-                    saveSignupPreference(true, signupProductUpdatesOptIn);
-                    if (isKnownAuthProvider(authProvider)) {
-                      recordLastUsedLoginMethod(authProvider);
-                    }
-                  }}
-                >
-                  Create account
-                </a>
-              </Button>
-              <Button variant="outline" className="w-full" asChild>
-                <a href={logoutHref}>Use a different account</a>
-              </Button>
+              {isEmailAuthProvider(signupRequiredProvider) ? (
+                <>
+                  <LoadingButton
+                    type="button"
+                    className="w-full"
+                    loading={submitLoading}
+                    loadingText="Sending code..."
+                    onClick={() => {
+                      void handleEmailCreateAccount();
+                    }}
+                  >
+                    Create account
+                  </LoadingButton>
+                  <Button variant="outline" className="w-full" type="button" onClick={handleClearEmailSignupRequired}>
+                    Use a different account
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button className="w-full" asChild>
+                    <a
+                      href={signupRequiredCreateHref}
+                      onClick={() => {
+                        saveSignupPreference(true, signupProductUpdatesOptIn);
+                        if (isKnownAuthProvider(authProvider)) {
+                          recordLastUsedLoginMethod(authProvider);
+                        }
+                      }}
+                    >
+                      Create account
+                    </a>
+                  </Button>
+                  <Button variant="outline" className="w-full" asChild>
+                    <a href={logoutHref}>Use a different account</a>
+                  </Button>
+                </>
+              )}
             </div>
           )}
 

--- a/web_src/src/pages/auth/signupRequiredPrompt.spec.ts
+++ b/web_src/src/pages/auth/signupRequiredPrompt.spec.ts
@@ -4,7 +4,9 @@ import {
   getLogoutHref,
   getSignupRequiredAccountBody,
   getSignupRequiredCreateHref,
+  isEmailAuthProvider,
   isKnownAuthProvider,
+  isSignupRequiredErrorBody,
   shouldShowSignupRequiredPrompt,
 } from "./signupRequiredPrompt";
 
@@ -19,6 +21,10 @@ describe("getSignupRequiredAccountBody", () => {
 
   it("uses generic copy when the provider is missing", () => {
     expect(getSignupRequiredAccountBody(null)).toBe("This account does not have a SuperPlane account.");
+  });
+
+  it("names the email account", () => {
+    expect(getSignupRequiredAccountBody("email")).toBe("This email does not have a SuperPlane account.");
   });
 });
 
@@ -35,6 +41,35 @@ describe("getSignupRequiredCreateHref", () => {
 
   it("sends unknown providers to signup", () => {
     expect(getSignupRequiredCreateHref(null, "?redirect=%2Finvite%2Fabc")).toBe("/signup?redirect=%2Finvite%2Fabc");
+  });
+
+  it("does not send email create to signup or Google", () => {
+    expect(getSignupRequiredCreateHref("email", "?redirect=%2Finvite%2Fabc")).toBe("");
+    expect(getSignupRequiredCreateHref("email", "")).not.toContain("/signup");
+    expect(getSignupRequiredCreateHref("email", "")).not.toContain("/auth/google");
+  });
+});
+
+describe("isSignupRequiredErrorBody", () => {
+  it("accepts the JSON error used by magic-code request", () => {
+    expect(isSignupRequiredErrorBody(`{"error":"signup_required"}`)).toBe(true);
+  });
+
+  it("accepts the legacy plain-text error", () => {
+    expect(isSignupRequiredErrorBody("signup must be started from the signup page")).toBe(true);
+  });
+
+  it("rejects other errors", () => {
+    expect(isSignupRequiredErrorBody("signup is currently disabled")).toBe(false);
+    expect(isSignupRequiredErrorBody("")).toBe(false);
+  });
+});
+
+describe("isEmailAuthProvider", () => {
+  it("accepts email only", () => {
+    expect(isEmailAuthProvider("email")).toBe(true);
+    expect(isEmailAuthProvider("google")).toBe(false);
+    expect(isEmailAuthProvider(null)).toBe(false);
   });
 });
 

--- a/web_src/src/pages/auth/signupRequiredPrompt.ts
+++ b/web_src/src/pages/auth/signupRequiredPrompt.ts
@@ -1,7 +1,12 @@
 export const SIGNUP_REQUIRED_AUTH_ERROR = "signup_required";
+const SIGNUP_REQUIRED_LEGACY_MESSAGE = "signup must be started from the signup page";
 
 export function isKnownAuthProvider(provider: string | null): provider is "google" | "github" {
   return provider === "google" || provider === "github";
+}
+
+export function isEmailAuthProvider(provider: string | null): boolean {
+  return provider === "email";
 }
 
 export function shouldShowSignupRequiredPrompt(authError: string | null, canSignup: boolean): boolean {
@@ -17,10 +22,18 @@ export function getSignupRequiredAccountBody(provider: string | null): string {
     return "This GitHub account does not have a SuperPlane account.";
   }
 
+  if (provider === "email") {
+    return "This email does not have a SuperPlane account.";
+  }
+
   return "This account does not have a SuperPlane account.";
 }
 
 export function getSignupRequiredCreateHref(provider: string | null, redirectQuery: string): string {
+  if (isEmailAuthProvider(provider)) {
+    return "";
+  }
+
   if (!isKnownAuthProvider(provider)) {
     return `/signup${redirectQuery}`;
   }
@@ -28,6 +41,20 @@ export function getSignupRequiredCreateHref(provider: string | null, redirectQue
   const params = new URLSearchParams(redirectQuery.startsWith("?") ? redirectQuery.slice(1) : redirectQuery);
   params.set("signup", "true");
   return `/auth/${provider}?${params.toString()}`;
+}
+
+export function isSignupRequiredErrorBody(body: string): boolean {
+  const text = body.trim();
+  if (text === SIGNUP_REQUIRED_LEGACY_MESSAGE) {
+    return true;
+  }
+
+  try {
+    const parsed = JSON.parse(text) as { error?: string };
+    return parsed.error === SIGNUP_REQUIRED_AUTH_ERROR;
+  } catch {
+    return false;
+  }
 }
 
 export function getLogoutHref(redirectQuery: string): string {


### PR DESCRIPTION
## Summary

Unknown email sign-in sent a code, then showed a raw policy error.
Google and GitHub also asked for provider consent a second time after Create account.
This change shows the existing create-account prompt first, then continues signup from that step.

## Test plan

- [ ] On `/login`, enter an unknown email and click Continue with email.
- [ ] Confirm the page shows No account found and does not send a code.
- [ ] Click Create account, enter the code, and confirm the account is created.
- [ ] On `/login`, click Continue with Google with no account, then Create account.
- [ ] Confirm Google does not ask for consent a second time.
- [ ] Repeat the Google path with GitHub.
- [ ] Confirm an existing email user still receives a code on the first Continue.


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["fix: Use Strict cookie for pending OAuth..."](https://github.com/superplanehq/superplane/commit/b7476d68a7c7d101688e8c07635be0949b0e52b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61358336)</sub>

<!-- /greptile_comment -->