### PR TITLE
fix: Open Setup Instead of Empty Workspace

### DIFF
--- a/test/e2e/factories_test.go
+++ b/test/e2e/factories_test.go
@@ -136,7 +136,8 @@ func (s *factorySteps) confirmDeleteFactory() {
 }
 
 func (s *factorySteps) assertRedirectedToFactoriesList() {
-	s.session.WaitForBrowserPath("/" + s.session.OrgSlug + "/workspaces")
+	// Deleting the last workspace opens setup for a new workspace.
+	s.session.AssertVisible(q.TestID("workspace-setup"))
 }
 
 func (s *factorySteps) assertFactoryNotVisibleInList(name string) {

--- a/test/e2e/organization_entry_test.go
+++ b/test/e2e/organization_entry_test.go
@@ -55,6 +55,8 @@ func TestOrganizationEntry(t *testing.T) {
 		})
 		require.NoError(t, waitErr)
 		session.AssertVisible(q.TestID("workspace-setup"))
+		session.AssertVisible(q.TestID("first-run-log-out"))
+		session.AssertHidden(q.TestID("first-run-organization-switch"))
 
 		organization, err := models.FindOrganizationByName("GitHub User")
 		require.NoError(t, err)
@@ -92,6 +94,8 @@ func TestOrganizationEntry(t *testing.T) {
 		})
 		require.NoError(t, waitErr)
 		session.AssertVisible(q.TestID("workspace-setup"))
+		session.AssertVisible(q.TestID("first-run-log-out"))
+		session.AssertVisible(q.TestID("first-run-organization-switch"))
 	})
 }
 

--- a/web_src/src/components/OrganizationSwitchMenu.spec.tsx
+++ b/web_src/src/components/OrganizationSwitchMenu.spec.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type * as ReactRouterDom from "react-router";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DropdownMenu, DropdownMenuContent } from "@/ui/dropdownMenu";
+
+import { OrganizationSwitchMenu } from "./OrganizationSwitchMenu";
+
+const navigateSpy = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof ReactRouterDom>("react-router");
+  return {
+    ...actual,
+    useNavigate: () => navigateSpy,
+  };
+});
+
+const organizationsState = vi.hoisted(() => ({
+  data: [
+    { id: "org-1", name: "Acme", slug: "acme" },
+    { id: "org-2", name: "Other Co", slug: "other-co" },
+  ],
+  isLoading: false,
+  isError: false,
+}));
+
+vi.mock("@/hooks/useAccountOrganizations", () => ({
+  useAccountOrganizations: () => organizationsState,
+}));
+
+function renderMenu(navigateToCurrentOrganization = false) {
+  return render(
+    <MemoryRouter>
+      <DropdownMenu open>
+        <DropdownMenuContent>
+          <OrganizationSwitchMenu
+            currentOrganizationRouteId="acme"
+            navigateToCurrentOrganization={navigateToCurrentOrganization}
+            testIdPrefix="menu"
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </MemoryRouter>,
+  );
+}
+
+describe("OrganizationSwitchMenu", () => {
+  beforeEach(() => {
+    navigateSpy.mockClear();
+  });
+
+  it("does not navigate when the selected organization is already current", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByTestId("menu-organization-option-org-1"));
+
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("navigates to the current organization when onboarding asks to leave setup", async () => {
+    const user = userEvent.setup();
+    renderMenu(true);
+
+    await user.click(screen.getByTestId("menu-organization-option-org-1"));
+
+    expect(navigateSpy).toHaveBeenCalledWith("/acme");
+  });
+
+  it("navigates to another organization", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByTestId("menu-organization-option-org-2"));
+
+    expect(navigateSpy).toHaveBeenCalledWith("/other-co");
+  });
+});

--- a/web_src/src/components/OrganizationSwitchMenu.tsx
+++ b/web_src/src/components/OrganizationSwitchMenu.tsx
@@ -10,6 +10,11 @@ interface OrganizationSwitchMenuProps {
   currentOrganizationRouteId: string;
   onNavigate?: () => void;
   testIdPrefix?: string;
+  /**
+   * Set from onboarding so choosing the current organization still leaves
+   * the wizard and opens that organization home.
+   */
+  navigateToCurrentOrganization?: boolean;
 }
 
 /** Shared organization choices for the Factories and legacy navigation menus. */
@@ -17,13 +22,15 @@ export function OrganizationSwitchMenu({
   currentOrganizationRouteId,
   onNavigate,
   testIdPrefix = "organization",
+  navigateToCurrentOrganization = false,
 }: OrganizationSwitchMenuProps) {
   const navigate = useNavigate();
   const organizationsQuery = useAccountOrganizations();
   const organizations = organizationsQuery.data ?? [];
 
   const goToOrganization = (organization: AccountOrganization) => {
-    if (!organizationMatchesRoute(organization, currentOrganizationRouteId)) {
+    const isCurrent = organizationMatchesRoute(organization, currentOrganizationRouteId);
+    if (!isCurrent || navigateToCurrentOrganization) {
       navigate(`/${organizationRouteId(organization)}`);
     }
     onNavigate?.();

--- a/web_src/src/pages/auth/RootOrganizationRedirect.spec.tsx
+++ b/web_src/src/pages/auth/RootOrganizationRedirect.spec.tsx
@@ -96,6 +96,16 @@ describe("RootOrganizationRedirect", () => {
     });
   });
 
+  it("sends an account with no organization to onboarding", async () => {
+    organizationsState.data = [];
+
+    renderRedirect();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/onboarding");
+    });
+  });
+
   it("falls back to the organization home page when there is nothing saved", async () => {
     renderRedirect();
 

--- a/web_src/src/pages/factories/FactoriesIndexPage.spec.tsx
+++ b/web_src/src/pages/factories/FactoriesIndexPage.spec.tsx
@@ -75,6 +75,15 @@ describe("FactoriesIndexPage", () => {
     );
   });
 
+  it("opens a finished workspace when another workspace is still in setup", () => {
+    listedFactories.splice(0, listedFactories.length, EMPTY_FACTORY, ACME_ONBOARDING_FACTORY);
+    renderIndex();
+
+    expect(screen.getByTestId("location-path")).toHaveTextContent(
+      factoryHomePath(FACTORIES_ORGANIZATION_ID, ACME_ONBOARDING_FACTORY.key!, ACME_ONBOARDING_LINE_ID),
+    );
+  });
+
   it("opens workspace setup when the organization has no workspace", () => {
     renderIndex();
 

--- a/web_src/src/pages/factories/FactoriesIndexPage.spec.tsx
+++ b/web_src/src/pages/factories/FactoriesIndexPage.spec.tsx
@@ -9,9 +9,10 @@ import {
   FACTORIES_ORGANIZATION_ID,
 } from "./__fixtures__/factoryPageResponses";
 import { FactoriesIndexPage } from "./FactoriesIndexPage";
-import { factoryHomePath } from "./lib/factoryPagePaths";
+import { factoryHomePath, newFactoryPath } from "./lib/factoryPagePaths";
 
 const listedFactories: Array<typeof ACME_ONBOARDING_FACTORY> = [];
+const permissionsState = vi.hoisted(() => ({ canCreate: true, isLoading: false }));
 
 vi.mock("@/hooks/useFactoryData", () => ({
   useFactories: () => ({ data: listedFactories, isLoading: false, error: null }),
@@ -22,7 +23,11 @@ vi.mock("@/contexts/useAccount", () => ({
 }));
 
 vi.mock("@/contexts/usePermissions", () => ({
-  usePermissions: () => ({ canAct: () => true, isLoading: false }),
+  usePermissions: () => ({
+    canAct: (resource: string, action: string) =>
+      resource === "factories" && action === "create" && permissionsState.canCreate,
+    isLoading: permissionsState.isLoading,
+  }),
 }));
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -38,6 +43,7 @@ function renderIndex() {
     <MemoryRouter initialEntries={[`/${FACTORIES_ORGANIZATION_ID}/workspaces`]}>
       <Routes>
         <Route path="/:organizationId/workspaces" element={<FactoriesIndexPage />} />
+        <Route path="/:organizationId/workspaces/new" element={<CurrentPath />} />
         <Route path="/:organizationId/workspaces/:factoryKey/*" element={<CurrentPath />} />
       </Routes>
     </MemoryRouter>,
@@ -47,6 +53,8 @@ function renderIndex() {
 describe("FactoriesIndexPage", () => {
   beforeEach(() => {
     listedFactories.length = 0;
+    permissionsState.canCreate = true;
+    permissionsState.isLoading = false;
   });
 
   it("opens the unique line when the workspace has one line", () => {
@@ -65,5 +73,20 @@ describe("FactoriesIndexPage", () => {
     expect(screen.getByTestId("location-path")).toHaveTextContent(
       factoryHomePath(FACTORIES_ORGANIZATION_ID, EMPTY_FACTORY.key!),
     );
+  });
+
+  it("opens workspace setup when the organization has no workspace", () => {
+    renderIndex();
+
+    expect(screen.getByTestId("location-path")).toHaveTextContent(newFactoryPath(FACTORIES_ORGANIZATION_ID));
+  });
+
+  it("asks an admin to finish setup when the user cannot create a workspace", () => {
+    permissionsState.canCreate = false;
+    renderIndex();
+
+    expect(screen.getByTestId("factories-empty-state")).toBeInTheDocument();
+    expect(screen.getByText("An organization admin must finish setup")).toBeInTheDocument();
+    expect(screen.queryByTestId("location-path")).not.toBeInTheDocument();
   });
 });

--- a/web_src/src/pages/factories/FactoriesIndexPage.tsx
+++ b/web_src/src/pages/factories/FactoriesIndexPage.tsx
@@ -1,15 +1,10 @@
-import { Heading } from "@/components/Heading/heading";
-import { Text } from "@/components/Text/text";
-import { PermissionTooltip } from "@/components/PermissionGate";
-import { Button } from "@/components/ui/button";
 import { useAccount } from "@/contexts/useAccount";
 import { usePermissions } from "@/contexts/usePermissions";
 import { useFactories } from "@/hooks/useFactoryData";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
 import { cn } from "@/lib/utils";
-import { Factory as FactoryIcon, Plus } from "lucide-react";
-import { Navigate, useNavigate, useParams } from "react-router";
+import { Navigate, useParams } from "react-router";
 import { factoryHomePath, firstFactoryLineId, newFactoryPath } from "./lib/factoryPagePaths";
 import { pickInitialFactory, readLastVisitedFactory } from "./lib/lastVisitedFactory";
 import { useFactoriesThemeClass } from "./lib/useFactoriesThemeClass";
@@ -25,7 +20,6 @@ export function FactoriesIndexPage() {
 }
 
 function FactoriesIndexPageContent({ organizationId }: { organizationId: string }) {
-  const navigate = useNavigate();
   const { account } = useAccount();
   const { canAct, isLoading: permissionsLoading } = usePermissions();
   const { data: factories = [], isLoading, error } = useFactories(organizationId);
@@ -64,36 +58,33 @@ function FactoriesIndexPageContent({ organizationId }: { organizationId: string 
     );
   }
 
-  const canCreate = canAct("factories", "create");
+  if (permissionsLoading) {
+    return (
+      <div
+        className={cn("flex min-h-screen w-full items-center justify-center bg-gray-50", appDarkModeClasses.surface)}
+      >
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading workspaces…</p>
+      </div>
+    );
+  }
+
+  if (canAct("factories", "create")) {
+    return <Navigate to={newFactoryPath(organizationId)} replace />;
+  }
 
   return (
     <div
-      className={cn("flex min-h-screen w-full items-center justify-center bg-gray-50 p-6", appDarkModeClasses.surface)}
+      className={cn(
+        "flex min-h-screen w-full items-center justify-center bg-background px-6",
+        appDarkModeClasses.surface,
+      )}
       data-testid="factories-empty-state"
     >
-      <div className="flex max-w-md flex-col items-center rounded-lg border border-dashed border-slate-300 bg-white px-8 py-12 text-center dark:border-gray-700 dark:bg-gray-900">
-        <FactoryIcon className="h-10 w-10 text-slate-400 dark:text-gray-500" aria-hidden />
-        <Heading level={2} className="mt-4 text-lg text-slate-900 dark:text-gray-100">
-          Create your first workspace
-        </Heading>
-        <Text className="mt-2 text-sm text-gray-500 dark:text-gray-400">
-          Workspaces group tasks, automations, and apps.
-        </Text>
-        <PermissionTooltip
-          allowed={canCreate || permissionsLoading}
-          message="You don't have permission to create workspaces."
-        >
-          <Button
-            type="button"
-            className="mt-6"
-            onClick={() => navigate(newFactoryPath(organizationId))}
-            disabled={!canCreate}
-            data-testid="factories-index-create-button"
-          >
-            <Plus className="h-4 w-4" aria-hidden />
-            Create workspace
-          </Button>
-        </PermissionTooltip>
+      <div className="max-w-md rounded-lg border border-border bg-card p-8 text-center">
+        <h1 className="text-[16px] font-semibold">An organization admin must finish setup</h1>
+        <p className="mt-2 text-[13px] text-muted-foreground">
+          Ask an organization admin to connect the integrations and configure this workspace.
+        </p>
       </div>
     </div>
   );

--- a/web_src/src/pages/factories/FactoriesIndexPage.tsx
+++ b/web_src/src/pages/factories/FactoriesIndexPage.tsx
@@ -6,7 +6,7 @@ import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
 import { cn } from "@/lib/utils";
 import { Navigate, useParams } from "react-router";
 import { factoryHomePath, firstFactoryLineId, newFactoryPath } from "./lib/factoryPagePaths";
-import { pickInitialFactory, readLastVisitedFactory } from "./lib/lastVisitedFactory";
+import { pickReadyFactory, readLastVisitedFactory } from "./lib/lastVisitedFactory";
 import { useFactoriesThemeClass } from "./lib/useFactoriesThemeClass";
 
 export function FactoriesIndexPage() {
@@ -50,7 +50,7 @@ function FactoriesIndexPageContent({ organizationId }: { organizationId: string 
   }
 
   const lastVisited = account?.id ? readLastVisitedFactory(account.id, organizationId) : null;
-  const targetFactory = pickInitialFactory(factories, lastVisited);
+  const targetFactory = pickReadyFactory(factories, lastVisited);
 
   if (targetFactory?.key) {
     return (

--- a/web_src/src/pages/factories/lib/lastVisitedFactory.spec.ts
+++ b/web_src/src/pages/factories/lib/lastVisitedFactory.spec.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { pickInitialFactory } from "./lastVisitedFactory";
+import { pickInitialFactory, pickReadyFactory } from "./lastVisitedFactory";
 
 const FACTORIES = [
   { id: "factory-1", key: "AA" },
   { id: "factory-2", key: "BB" },
+];
+
+const MIXED_FACTORIES = [
+  { id: "factory-setup", key: "SETUP", onboarding: {} },
+  { id: "factory-ready", key: "READY", onboarding: { completedAt: "2026-09-01T00:00:00.000Z" } },
 ];
 
 describe("pickInitialFactory", () => {
@@ -18,5 +23,15 @@ describe("pickInitialFactory", () => {
 
   it("returns null when there are no factories", () => {
     expect(pickInitialFactory([], "factory-1")).toBeNull();
+  });
+});
+
+describe("pickReadyFactory", () => {
+  it("skips an incomplete last-visited workspace when a ready one exists", () => {
+    expect(pickReadyFactory(MIXED_FACTORIES, "factory-setup")).toBe(MIXED_FACTORIES[1]);
+  });
+
+  it("keeps an incomplete workspace when it is the only one", () => {
+    expect(pickReadyFactory([MIXED_FACTORIES[0]], "factory-setup")).toBe(MIXED_FACTORIES[0]);
   });
 });

--- a/web_src/src/pages/factories/lib/lastVisitedFactory.ts
+++ b/web_src/src/pages/factories/lib/lastVisitedFactory.ts
@@ -75,6 +75,25 @@ export function pickInitialFactory<T extends { id?: string }>(
   return known[0];
 }
 
+function isWorkspaceReady(factory: { onboarding?: { completedAt?: string } }): boolean {
+  return Boolean(factory.onboarding?.completedAt);
+}
+
+/**
+ * Lands on a finished workspace when one exists. An incomplete last-visited
+ * workspace would send the user back into setup after they leave it.
+ */
+export function pickReadyFactory<T extends { id?: string; onboarding?: { completedAt?: string } }>(
+  factories: T[],
+  lastVisitedFactoryId: string | null,
+): T | null {
+  const ready = factories.filter(isWorkspaceReady);
+  if (ready.length > 0) {
+    return pickInitialFactory(ready, lastVisitedFactoryId);
+  }
+  return pickInitialFactory(factories, lastVisitedFactoryId);
+}
+
 export function recordLastVisitedFactory(accountId: string, organizationId: string, factoryId: string): void {
   if (!accountId || !organizationId || !factoryId || typeof window === "undefined") {
     return;

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
@@ -46,12 +46,7 @@ vi.mock("@/hooks/useBindGitHubInstallation", () => ({
   useBindGitHubInstallation: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
 }));
 
-const deleteFactoryMutateAsync = vi.fn().mockResolvedValue(undefined);
 const navigateSpy = vi.fn();
-
-vi.mock("@/hooks/useFactoryData", () => ({
-  useDeleteFactory: () => ({ mutateAsync: deleteFactoryMutateAsync, isPending: false }),
-}));
 
 let accountOrganizations: Array<{ id: string; name: string; slug?: string }>;
 
@@ -118,7 +113,6 @@ describe("FirstRunSetup", () => {
     factory = { id: "factory-1", onboarding: { vcsIntegrationId: "github-1" } };
     factories = [factory];
     accountOrganizations = [{ id: "org-1", name: "Acme" }];
-    deleteFactoryMutateAsync.mockClear();
     navigateSpy.mockClear();
   });
 
@@ -294,28 +288,17 @@ describe("FirstRunSetup", () => {
     expect(screen.getByTestId("first-run-agent")).toBeInTheDocument();
   });
 
-  it("shows the close control instead of Log out when another workspace exists", () => {
+  it("shows Log out and the organization switch when another workspace exists", () => {
     factories = [factory, { id: "factory-2" }];
 
     renderSetup(pageModel());
 
-    expect(screen.getByTestId("first-run-cancel")).toBeInTheDocument();
-    expect(screen.queryByTestId("first-run-log-out")).not.toBeInTheDocument();
+    expect(screen.getByTestId("first-run-log-out")).toBeInTheDocument();
+    expect(screen.getByTestId("first-run-organization-switch")).toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-cancel")).not.toBeInTheDocument();
   });
 
-  it("deletes the placeholder workspace and returns to the workspace index on cancel", async () => {
-    factories = [factory, { id: "factory-2" }];
-    const user = userEvent.setup();
-
-    renderSetup(pageModel());
-
-    await user.click(screen.getByTestId("first-run-cancel"));
-
-    expect(deleteFactoryMutateAsync).toHaveBeenCalledWith("factory-1");
-    await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith("/org-1/workspaces"));
-  });
-
-  it("shows the close control when another organization exists, even with no other workspace here", () => {
+  it("shows Log out and the organization switch when another organization exists", () => {
     factories = [factory];
     accountOrganizations = [
       { id: "org-1", name: "Acme" },
@@ -324,34 +307,30 @@ describe("FirstRunSetup", () => {
 
     renderSetup(pageModel());
 
-    expect(screen.getByTestId("first-run-cancel")).toBeInTheDocument();
-    expect(screen.queryByTestId("first-run-log-out")).not.toBeInTheDocument();
+    expect(screen.getByTestId("first-run-log-out")).toBeInTheDocument();
+    expect(screen.getByTestId("first-run-organization-switch")).toBeInTheDocument();
   });
 
-  it("navigates to another organization on cancel, not back into onboarding, when this org has no other workspace", async () => {
-    factories = [factory];
-    accountOrganizations = [
-      { id: "org-1", name: "Acme" },
-      { id: "org-2", name: "Other Co", slug: "other-co" },
-    ];
+  it("opens the current organization from the switch menu so the user can leave setup", async () => {
+    factories = [factory, { id: "factory-2" }];
     const user = userEvent.setup();
 
     renderSetup(pageModel());
 
-    await user.click(screen.getByTestId("first-run-cancel"));
+    await user.click(screen.getByTestId("first-run-organization-switch"));
+    await user.click(screen.getByTestId("first-run-organization-option-org-1"));
 
-    expect(deleteFactoryMutateAsync).toHaveBeenCalledWith("factory-1");
-    await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith("/other-co"));
-    expect(navigateSpy).not.toHaveBeenCalledWith("/org-1/workspaces");
+    expect(navigateSpy).toHaveBeenCalledWith("/org-1");
   });
 
-  it("keeps Log out and hides the close control with a single org and single (placeholder) workspace", () => {
+  it("keeps Log out and hides the organization switch with a single org and single workspace", () => {
     factories = [factory];
     accountOrganizations = [{ id: "org-1", name: "Acme" }];
 
     renderSetup(pageModel());
 
     expect(screen.getByTestId("first-run-log-out")).toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-organization-switch")).not.toBeInTheDocument();
     expect(screen.queryByTestId("first-run-cancel")).not.toBeInTheDocument();
   });
 });

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
@@ -1,9 +1,8 @@
 import { LoadingButton } from "@/components/ui/loading-button";
 import { useAccount } from "@/contexts/useAccount";
 import { useAccountOrganizations } from "@/hooks/useAccountOrganizations";
-import { useDeleteFactory } from "@/hooks/useFactoryData";
 import { useMe } from "@/hooks/useMe";
-import { organizationMatchesRoute, organizationRouteId } from "@/lib/accountOrganizations";
+import { organizationMatchesRoute } from "@/lib/accountOrganizations";
 import { getApiErrorMessage } from "@/lib/errors";
 import {
   hostedGitHubInstallRequested,
@@ -21,9 +20,8 @@ import {
 import { showErrorToast } from "@/lib/toast";
 import { posthog } from "@/posthog";
 import { useEffect, useRef, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router";
+import { useSearchParams } from "react-router";
 
-import { factoryListPath } from "../../lib/factoryPagePaths";
 import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
 import { AgentStep } from "./AgentStep";
 import { FirstRunChooseScreen } from "./first-run/FirstRunChooseScreen";
@@ -307,8 +305,6 @@ export function FirstRunSetup({ model }: { model: OnboardingPageModel }) {
   const { organizationId, factoryId, factories } = useFactoriesLayout();
   const flow = useFirstRunSetupFlow(model);
   const setup = model.setup;
-  const navigate = useNavigate();
-  const deleteFactory = useDeleteFactory(organizationId);
   const accountOrganizations = useAccountOrganizations();
 
   // The placeholder workspace under setup is itself in `factories`, so
@@ -320,28 +316,13 @@ export function FirstRunSetup({ model }: { model: OnboardingPageModel }) {
   const otherOrganizations = (accountOrganizations.data ?? []).filter(
     (organization) => !organizationMatchesRoute(organization, organizationId),
   );
-  const canExitSetup = hasOtherWorkspace || otherOrganizations.length > 0;
-
-  const cancelSetup = async () => {
-    // Guards against a double delete from a second click while the mutation
-    // is already in flight.
-    if (deleteFactory.isPending) return;
-    await deleteFactory.mutateAsync(factoryId);
-    // Cancelling out of the last workspace in this organization must not
-    // bounce the user back into onboarding for it, so it sends them to
-    // another organization instead of this one's (now onboarding) workspace list.
-    if (hasOtherWorkspace) {
-      navigate(factoryListPath(organizationId));
-    } else {
-      navigate(`/${organizationRouteId(otherOrganizations[0])}`);
-    }
-  };
+  const canSwitchOrganization = hasOtherWorkspace || otherOrganizations.length > 0;
 
   const chromeFor = (target: FirstRunScreen): FirstRunChrome => ({
     displayName: firstNameOf(account?.name),
     email: account?.email,
-    onLogOut: canExitSetup ? undefined : signOut,
-    onCancel: canExitSetup ? () => void cancelSetup() : undefined,
+    onLogOut: signOut,
+    organizationSwitch: canSwitchOrganization ? { currentOrganizationRouteId: organizationId } : undefined,
     stepIndex: STEP_INDEX_FOR_SCREEN[target],
     stepCount: flow.skipAgentScreen ? FIRST_RUN_STEP_COUNT - 1 : FIRST_RUN_STEP_COUNT,
   });

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunShell.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunShell.tsx
@@ -1,5 +1,7 @@
+import { OrganizationSwitchMenu } from "@/components/OrganizationSwitchMenu";
 import { cn } from "@/lib/utils";
-import { X } from "lucide-react";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/ui/dropdownMenu";
+import { ArrowRightLeft } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { useFactoriesThemeClass } from "../../../lib/useFactoriesThemeClass";
@@ -27,26 +29,37 @@ export function FirstRunShell({
   return (
     <div className="fixed inset-0 bg-background text-foreground" data-testid={testId}>
       <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between px-6 py-5">
-        {chrome?.onCancel ? (
+        <div className="pointer-events-auto flex items-center gap-3">
           <button
             type="button"
-            className="pointer-events-auto text-muted-foreground transition-colors hover:text-foreground"
-            onClick={chrome.onCancel}
-            aria-label={copy.close}
-            data-testid="first-run-cancel"
-          >
-            <X className="size-4" aria-hidden />
-          </button>
-        ) : (
-          <button
-            type="button"
-            className="pointer-events-auto text-[13px] text-muted-foreground transition-colors hover:text-foreground"
+            className="text-[13px] text-muted-foreground transition-colors hover:text-foreground"
             onClick={chrome?.onLogOut}
             data-testid="first-run-log-out"
           >
             {copy.logOut}
           </button>
-        )}
+          {chrome?.organizationSwitch ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="text-muted-foreground transition-colors hover:text-foreground"
+                  aria-label={copy.switchOrganization}
+                  data-testid="first-run-organization-switch"
+                >
+                  <ArrowRightLeft className="size-4" aria-hidden />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-64">
+                <OrganizationSwitchMenu
+                  currentOrganizationRouteId={chrome.organizationSwitch.currentOrganizationRouteId}
+                  navigateToCurrentOrganization
+                  testIdPrefix="first-run"
+                />
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
+        </div>
         {identity ? (
           <p className="text-right text-[13px] leading-5 text-muted-foreground" data-testid="first-run-signed-in">
             <span className="block">{copy.loggedInAs}</span>

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunShell.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunShell.tsx
@@ -1,4 +1,5 @@
 import { OrganizationSwitchMenu } from "@/components/OrganizationSwitchMenu";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/ui/dropdownMenu";
 import { ArrowRightLeft } from "lucide-react";
@@ -30,25 +31,29 @@ export function FirstRunShell({
     <div className="fixed inset-0 bg-background text-foreground" data-testid={testId}>
       <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between px-6 py-5">
         <div className="pointer-events-auto flex items-center gap-3">
-          <button
+          <Button
             type="button"
-            className="text-[13px] text-muted-foreground transition-colors hover:text-foreground"
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-foreground"
             onClick={chrome?.onLogOut}
             data-testid="first-run-log-out"
           >
             {copy.logOut}
-          </button>
+          </Button>
           {chrome?.organizationSwitch ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <button
+                <Button
                   type="button"
-                  className="text-muted-foreground transition-colors hover:text-foreground"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="text-muted-foreground hover:text-foreground"
                   aria-label={copy.switchOrganization}
                   data-testid="first-run-organization-switch"
                 >
                   <ArrowRightLeft className="size-4" aria-hidden />
-                </button>
+                </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="w-64">
                 <OrganizationSwitchMenu

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunCopy.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunCopy.ts
@@ -7,7 +7,7 @@ import {
 export const FIRST_RUN_COPY = {
   chrome: {
     logOut: "Log out",
-    close: "Cancel setup",
+    switchOrganization: "Switch organization",
     loggedInAs: "Logged in as",
     stepLabel: (step: number, total: number) => `Step ${step} of ${total}`,
   },

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunTypes.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunTypes.ts
@@ -5,12 +5,10 @@ export type FirstRunChrome = {
   displayName?: string;
   onLogOut?: () => void;
   /**
-   * Set when the user has somewhere to go on cancel: another workspace in
-   * this organization, or another organization entirely. The shell shows a
-   * close (X) control instead of "Log out", and it cancels setup rather than
-   * signing the user out. Mutually exclusive with `onLogOut`.
+   * Set when the user has another workspace or another organization to
+   * open. The shell shows the organization switch next to Log out.
    */
-  onCancel?: () => void;
+  organizationSwitch?: { currentOrganizationRouteId: string };
   stepIndex: number;
   /** Number of step dots. Set it when the flow skips a screen. */
   stepCount?: number;


### PR DESCRIPTION
## Summary

The empty workspace card opened a second setup path. This change removes that card.

An organization with no workspace now opens the same wizard. An account with no organization still opens `/onboarding`.

Setup always shows Log out. When the user has another organization or workspace, the switch control lets them leave the wizard.

## Test plan

- [ ] Sign in with no organization and confirm `/` opens `/onboarding`.
- [ ] Confirm the wizard shows Log out and does not show an exit control.
- [ ] Open an organization with no workspace and confirm setup opens.
- [ ] Start setup while another organization exists and open the switch control.
- [ ] Choose the current organization and confirm the wizard closes.
- [ ] Sign out from setup and confirm the session ends.

Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["fix: Land on a Ready Workspace After Set..."](https://github.com/superplanehq/superplane/commit/54dfd73d8ac4a89b897820e37c04446ecb591cb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61369811)</sub>

<!-- /greptile_comment -->