### PR TITLE
feat: Add SuperPlane start-task models and reset

### DIFF
--- a/pkg/grpc/actions/factories/factory_app_templates.go
+++ b/pkg/grpc/actions/factories/factory_app_templates.go
@@ -334,13 +334,19 @@ func resolveFactoryTemplate(nodes []models.Node) (factoryAppTemplate, bool) {
 	return factoryAppTemplate{}, false
 }
 
-func deriveFactoryTemplateInput(tx *gorm.DB, canvas *models.Canvas, version *models.CanvasVersion, template factoryAppTemplate) factoryTemplateInput {
+func deriveFactoryTemplateInput(
+	tx *gorm.DB,
+	factory *models.Factory,
+	canvas *models.Canvas,
+	version *models.CanvasVersion,
+	template factoryAppTemplate,
+) factoryTemplateInput {
 	input := factoryTemplateInput{
 		appID:         canvas.ID.String(),
 		appName:       canvas.Name,
 		installParams: deriveFactoryInstallParams(version.Nodes),
 		integrations:  map[string]factoryTemplateIntegration{},
-		agent:         deriveFactoryAgent(version.Nodes),
+		agent:         resetFactoryTemplateAgent(tx, factory, version.Nodes),
 	}
 	for _, node := range version.Nodes {
 		integrationType := template.componentIntegrations[node.ComponentName()]
@@ -428,6 +434,30 @@ func deriveFactoryInstallParams(nodes []models.Node) map[string]string {
 		}
 	}
 	return params
+}
+
+func resetFactoryTemplateAgent(tx *gorm.DB, factory *models.Factory, nodes []models.Node) *factoryTemplateAgent {
+	if agent := hostedResetIntakeAgent(tx, factory); agent != nil {
+		return &factoryTemplateAgent{
+			component:        models.SuperPlaneRunnerComponent,
+			credentialSource: "hosted",
+		}
+	}
+	return deriveFactoryAgent(nodes)
+}
+
+func hostedResetIntakeAgent(tx *gorm.DB, factory *models.Factory) *intakeAgent {
+	if tx == nil || factory == nil {
+		return nil
+	}
+	return intakeAgentFromHostedProvider(tx, factory)
+}
+
+func resetFactoryIntakeAgent(tx *gorm.DB, factory *models.Factory, nodes []models.Node) *intakeAgent {
+	if agent := hostedResetIntakeAgent(tx, factory); agent != nil {
+		return agent
+	}
+	return intakeAgentFromCanvasNodes(nodes)
 }
 
 func deriveFactoryAgent(nodes []models.Node) *factoryTemplateAgent {
@@ -545,10 +575,15 @@ func materializeIntakeDefaults(
 	}, nil
 }
 
-func materializeBacklogDefaults(canvas *models.Canvas, version *models.CanvasVersion) (*materializedFactoryTemplate, error) {
+func materializeBacklogDefaults(
+	tx *gorm.DB,
+	factory *models.Factory,
+	canvas *models.Canvas,
+	version *models.CanvasVersion,
+) (*materializedFactoryTemplate, error) {
 	defaults := buildBacklogCanvas(backlogCanvasRequest{
 		Name:  canvas.Name,
-		Agent: intakeAgentFromCanvasNodes(version.Nodes),
+		Agent: resetFactoryIntakeAgent(tx, factory, version.Nodes),
 	})
 	defaults.Metadata.ID = canvas.ID.String()
 	for i := range defaults.Spec.Nodes {
@@ -591,6 +626,78 @@ func intakeAgentFromCanvasNodes(nodes []models.Node) *intakeAgent {
 	return nil
 }
 
+func materializePRFeedbackDefaults(
+	tx *gorm.DB,
+	factory *models.Factory,
+	canvas *models.Canvas,
+	version *models.CanvasVersion,
+	handler *models.FactoryPRFeedbackHandler,
+) (*materializedFactoryTemplate, error) {
+	spec := models.LiveCanvasSpec{Nodes: version.Nodes, Edges: version.Edges}
+	graph := resolvePRFeedbackGraph(spec)
+	settings := prFeedbackSettingsFromGraph(graph, spec)
+	request := prFeedbackBuildRequest{
+		Name:                   canvas.Name,
+		Repository:             settings.Repository,
+		Mention:                settings.Mention,
+		IgnoreBots:             settings.IgnoreBots,
+		AllowedBots:            settings.AllowedBots,
+		CheckNames:             settings.CheckNames,
+		MaximumAttempts:        prFeedbackResetMaximumAttempts(handler),
+		RunnerIntegrationNames: settings.RunnerIntegrationNames,
+		Binding:                resolvePRFeedbackBinding(tx, factory, settings.Repository),
+		Agent:                  resetFactoryIntakeAgent(tx, factory, version.Nodes),
+	}
+
+	templateID := prFeedbackDiscussionTemplateID
+	triggerID := prFeedbackCommentTriggerNodeID
+	defaults := buildDiscussionPRFeedbackCanvas(request)
+	if handler.Source == models.FactoryPRFeedbackHandlerSourcePullRequestChecks {
+		templateID = prFeedbackChecksTemplateID
+		triggerID = prFeedbackPullRequestTriggerNodeID
+		defaults = buildChecksPRFeedbackCanvas(request)
+	}
+
+	defaults.Metadata.ID = canvas.ID.String()
+	stampFactoryTemplateMetadata(defaults, triggerID, templateID)
+	encoded, err := goyaml.Marshal(defaults)
+	if err != nil {
+		return nil, fmt.Errorf("encode PR feedback defaults: %w", err)
+	}
+	return &materializedFactoryTemplate{
+		templateID: templateID,
+		canvasYAML: string(encoded),
+	}, nil
+}
+
+func prFeedbackResetMaximumAttempts(handler *models.FactoryPRFeedbackHandler) int {
+	if handler != nil && handler.MaximumAttempts != nil && *handler.MaximumAttempts > 0 {
+		return *handler.MaximumAttempts
+	}
+	return prFeedbackDefaultMaximumAttempts
+}
+
+func stampFactoryTemplateMetadata(canvas *yaml.Canvas, nodeID, templateID string) {
+	if canvas == nil || canvas.Spec == nil {
+		return
+	}
+	for i := range canvas.Spec.Nodes {
+		node := &canvas.Spec.Nodes[i]
+		if node.ID != nodeID {
+			continue
+		}
+		node.Metadata = maps.Clone(node.Metadata)
+		if node.Metadata == nil {
+			node.Metadata = map[string]any{}
+		}
+		node.Metadata[factoryTemplateMetadataKey] = map[string]any{
+			"id":      templateID,
+			"version": factoryTemplateVersion,
+		}
+		return
+	}
+}
+
 func findFactoryAppForDefaults(tx *gorm.DB, organizationID, factoryID, appID uuid.UUID) (*models.Canvas, *models.CanvasVersion, error) {
 	canvas, err := models.FindCanvasInTransaction(tx, organizationID, appID)
 	if err != nil {
@@ -604,4 +711,30 @@ func findFactoryAppForDefaults(tx *gorm.DB, organizationID, factoryID, appID uui
 		return nil, nil, err
 	}
 	return canvas, version, nil
+}
+
+func materializeNonIntakeFactoryAppDefaults(
+	tx *gorm.DB,
+	factory *models.Factory,
+	canvas *models.Canvas,
+	version *models.CanvasVersion,
+) (*materializedFactoryTemplate, error) {
+	handler, err := models.FindPRFeedbackHandlerByCanvasID(tx, canvas.ID)
+	if err != nil {
+		return nil, err
+	}
+	if handler != nil && handler.FactoryID == factory.ID {
+		return materializePRFeedbackDefaults(tx, factory, canvas, version, handler)
+	}
+	if onWorkOrderNodeIDFromSpec(models.LiveCanvasSpec{Nodes: version.Nodes, Edges: version.Edges}) != "" {
+		return materializeBacklogDefaults(tx, factory, canvas, version)
+	}
+	template, ok := resolveFactoryTemplate(version.Nodes)
+	if !ok {
+		return nil, invalidArgument("factory app has no bundled defaults")
+	}
+	return materializeFactoryTemplate(
+		template.id,
+		deriveFactoryTemplateInput(tx, factory, canvas, version, template),
+	)
 }

--- a/pkg/grpc/actions/factories/factory_app_templates_test.go
+++ b/pkg/grpc/actions/factories/factory_app_templates_test.go
@@ -256,7 +256,7 @@ func TestMaterializeBacklogDefaults(t *testing.T) {
 		Edges: current.Edges(),
 	}
 
-	result, err := materializeBacklogDefaults(canvas, version)
+	result, err := materializeBacklogDefaults(nil, nil, canvas, version)
 	require.NoError(t, err)
 	assert.Equal(t, "backlog", result.templateID)
 

--- a/pkg/grpc/actions/factories/factory_llm_models.go
+++ b/pkg/grpc/actions/factories/factory_llm_models.go
@@ -89,3 +89,15 @@ func serializeFactoryLLMModels(ids []string) []*pb.FactoryLLMModel {
 	}
 	return out
 }
+
+func serializeLineRunnerModels(ids []string) []*pb.FactoryLLMModel {
+	out := make([]*pb.FactoryLLMModel, 0, len(ids))
+	for _, id := range models.CompactModelIDs(ids) {
+		name := id
+		if parsed, err := models.ParseSelectableLLMModelKey(id); err == nil {
+			name = parsed.Label
+		}
+		out = append(out, &pb.FactoryLLMModel{Id: id, Name: name})
+	}
+	return out
+}

--- a/pkg/grpc/actions/factories/line_runner_models.go
+++ b/pkg/grpc/actions/factories/line_runner_models.go
@@ -38,7 +38,7 @@ func ListFactoryLineRunnerModels(
 	}
 
 	return &pb.ListFactoryLineRunnerModelsResponse{
-		Models: serializeFactoryLLMModels(ids),
+		Models: serializeLineRunnerModels(ids),
 	}, nil
 }
 
@@ -68,22 +68,9 @@ func listLineRunnerModels(tx *gorm.DB, orgID, factoryID uuid.UUID, lineName stri
 			return nil, err
 		}
 		for _, node := range []models.Node(version.Nodes) {
-			provider, ok := runnerComponentProvider(node.ComponentName())
-			if !ok {
-				continue
-			}
-			ids, err := models.ResolveSelectableLLMModels(
-				tx,
-				orgID,
-				&factoryID,
-				provider,
-				runnerFundingSource(node.Configuration),
-			)
+			ids, err := lineRunnerModelsForNode(tx, orgID, factoryID, node)
 			if err != nil {
 				return nil, err
-			}
-			if stored := storedRunnerModel(node.Configuration); stored != "" {
-				ids = append(ids, stored)
 			}
 			for _, id := range ids {
 				if _, dup := seen[id]; dup {
@@ -96,6 +83,49 @@ func listLineRunnerModels(tx *gorm.DB, orgID, factoryID uuid.UUID, lineName stri
 	}
 	sort.Strings(out)
 	return out, nil
+}
+
+func lineRunnerModelsForNode(tx *gorm.DB, orgID, factoryID uuid.UUID, node models.Node) ([]string, error) {
+	if node.ComponentName() == models.SuperPlaneRunnerComponent {
+		return hostedSelectableLineRunnerModels(tx, orgID, factoryID, storedRunnerModel(node.Configuration))
+	}
+
+	provider, ok := runnerComponentProvider(node.ComponentName())
+	if !ok {
+		return nil, nil
+	}
+	ids, err := models.ResolveSelectableLLMModels(
+		tx,
+		orgID,
+		&factoryID,
+		provider,
+		runnerFundingSource(node.Configuration),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if stored := storedRunnerModel(node.Configuration); stored != "" {
+		ids = append(ids, stored)
+	}
+	return ids, nil
+}
+
+func hostedSelectableLineRunnerModels(tx *gorm.DB, orgID, factoryID uuid.UUID, stored string) ([]string, error) {
+	selectable, err := models.ListSelectableLLMModels(tx, orgID, &factoryID)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(selectable)+1)
+	for _, model := range selectable {
+		if model.Source.ID != models.UsageFundingSourceHosted {
+			continue
+		}
+		ids = append(ids, model.Key)
+	}
+	if stored != "" {
+		ids = append(ids, stored)
+	}
+	return ids, nil
 }
 
 func runnerComponentProvider(component string) (string, bool) {

--- a/pkg/grpc/actions/factories/line_runner_models_test.go
+++ b/pkg/grpc/actions/factories/line_runner_models_test.go
@@ -114,6 +114,40 @@ func Test__ListLineRunnerModels__IncludesCanvasModelsWhenAllowlistEmpty(t *testi
 	assert.Equal(t, []string{"opus", "sonnet"}, ids)
 }
 
+func Test__ListLineRunnerModels__SuperPlaneLineUsesHostedSelectableKeys(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	seedHostedModels(t, db, models.UsageProviderAnthropic, "claude-sonnet-4-6")
+	seedHostedModels(t, db, models.UsageProviderOpenRouter, "x-ai/grok-4.6")
+
+	app := createLineAppWithRunner(t, r, factoryModel.ID, models.SuperPlaneRunnerComponent, "hosted", "")
+	_, err = factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
+		{Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: "start"},
+	})
+	require.NoError(t, err)
+
+	ids, err := listLineRunnerModels(db, r.Organization.ID, factoryModel.ID, "ship")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		models.FormatSelectableLLMModelKey(models.UsageFundingSourceHosted, models.UsageProviderAnthropic, "claude-sonnet-4-6"),
+		models.FormatSelectableLLMModelKey(models.UsageFundingSourceHosted, models.UsageProviderOpenRouter, "x-ai/grok-4.6"),
+	}, ids)
+}
+
+func Test__SerializeLineRunnerModels__NamesHostedSelectableKeys(t *testing.T) {
+	modelsProto := serializeLineRunnerModels([]string{
+		models.FormatSelectableLLMModelKey(models.UsageFundingSourceHosted, models.UsageProviderOpenRouter, "x-ai/grok-4.6"),
+		"opus",
+	})
+	require.Len(t, modelsProto, 2)
+	assert.Equal(t, "hosted::openrouter::x-ai/grok-4.6", modelsProto[0].GetId())
+	assert.Equal(t, "x-ai/grok-4.6", modelsProto[0].GetName())
+	assert.Equal(t, "opus", modelsProto[1].GetId())
+	assert.Equal(t, "opus", modelsProto[1].GetName())
+}
+
 func Test__ListLineRunnerModels__NoRunnerNodesReturnsEmpty(t *testing.T) {
 	r := support.Setup(t)
 	db := database.DB(t.Context())

--- a/pkg/grpc/actions/factories/materialize_factory_app.go
+++ b/pkg/grpc/actions/factories/materialize_factory_app.go
@@ -71,7 +71,8 @@ func MaterializeFactoryAppDefaults(
 	}
 
 	db := database.DB(ctx)
-	if _, err := models.FindFactory(db, orgID, factoryID); err != nil {
+	factory, err := models.FindFactory(db, orgID, factoryID)
+	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to materialize factory app defaults")
 	}
 	canvas, version, err := findFactoryAppForDefaults(db, orgID, factoryID, appID)
@@ -86,20 +87,8 @@ func MaterializeFactoryAppDefaults(
 		result, err = materializeIntakeDefaults(db, canvas, version, intake)
 	case intakeErr != nil && !errors.Is(intakeErr, models.ErrFactoryIntakeNotFound):
 		err = intakeErr
-	case onWorkOrderNodeIDFromSpec(models.LiveCanvasSpec{Nodes: version.Nodes, Edges: version.Edges}) != "":
-		result, err = materializeBacklogDefaults(canvas, version)
 	default:
-		template, ok := resolveFactoryTemplate(version.Nodes)
-		if !ok {
-			return nil, factoryErrorToStatus(
-				invalidArgument("factory app has no bundled defaults"),
-				"failed to materialize factory app defaults",
-			)
-		}
-		result, err = materializeFactoryTemplate(
-			template.id,
-			deriveFactoryTemplateInput(db, canvas, version, template),
-		)
+		result, err = materializeNonIntakeFactoryAppDefaults(db, factory, canvas, version)
 	}
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to materialize factory app defaults")

--- a/pkg/grpc/actions/factories/materialize_factory_app_test.go
+++ b/pkg/grpc/actions/factories/materialize_factory_app_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authentication"
@@ -14,6 +15,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/yaml"
 	"github.com/superplanehq/superplane/test/support"
 	"google.golang.org/grpc/codes"
+	"gorm.io/datatypes"
 
 	_ "github.com/superplanehq/superplane/pkg/registryimports"
 )
@@ -34,6 +36,15 @@ func Test__MaterializeFactoryAppDefaults(t *testing.T) {
 		t.Helper()
 		factory, err := models.CreateFactory(database.DB(t.Context()), r.Organization.ID, support.RandomName("factory"), "", "")
 		require.NoError(t, err)
+		return factory
+	}
+
+	newFactoryWithAppRepo := func(t *testing.T, repository string) *models.Factory {
+		t.Helper()
+		factory := newFactory(t)
+		require.NoError(t, factory.UpdateOnboarding(database.DB(t.Context()), models.FactoryOnboardingPatch{
+			AppRepository: &repository,
+		}))
 		return factory
 	}
 
@@ -111,5 +122,227 @@ func Test__MaterializeFactoryAppDefaults(t *testing.T) {
 		defaults, err := yaml.CanvasFromYAML([]byte(response.GetCanvasYaml()))
 		require.NoError(t, err)
 		assert.Equal(t, intake.GetIntake().GetCanvasId(), defaults.Metadata.ID)
+		assertNoRunnerNode(t, defaults)
 	})
+
+	t.Run("Plan with Claude BYOK resets to SuperPlane when the instance default is set", func(t *testing.T) {
+		factoryModel := newFactory(t)
+		canvas := createClaudePlanningCanvas(t, r, factoryModel.ID)
+		enableInstanceSuperPlaneDefault(t)
+
+		response, err := MaterializeFactoryAppDefaults(ctx, orgID, &pb.MaterializeFactoryAppDefaultsRequest{
+			FactoryId: factoryModel.ID.String(),
+			AppId:     canvas.ID.String(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "line-planning", response.GetTemplateId())
+
+		defaults, err := yaml.CanvasFromYAML([]byte(response.GetCanvasYaml()))
+		require.NoError(t, err)
+		assertSuperPlaneRunnerNode(t, findYAMLNode(t, defaults, "planner-agent-no-issue"))
+	})
+
+	t.Run("Plan keeps the Claude agent when the instance default is unset", func(t *testing.T) {
+		factoryModel := newFactory(t)
+		canvas := createClaudePlanningCanvas(t, r, factoryModel.ID)
+
+		response, err := MaterializeFactoryAppDefaults(ctx, orgID, &pb.MaterializeFactoryAppDefaultsRequest{
+			FactoryId: factoryModel.ID.String(),
+			AppId:     canvas.ID.String(),
+		})
+		require.NoError(t, err)
+
+		defaults, err := yaml.CanvasFromYAML([]byte(response.GetCanvasYaml()))
+		require.NoError(t, err)
+		agent := findYAMLNode(t, defaults, "planner-agent-no-issue")
+		assert.Equal(t, "runnerClaudeCode", agent.Component)
+		assert.Equal(t, "opus", agent.Configuration["model"])
+		assert.Equal(t, map[string]any{
+			"source":      "integration",
+			"integration": map[string]any{"name": "claude"},
+		}, agent.Configuration["credentials"])
+	})
+
+	t.Run("Backlog with Claude resets to SuperPlane when the instance default is set", func(t *testing.T) {
+		factoryModel := newFactory(t)
+		_, err := CreateFactoryIntake(ctx, deps, orgID, &pb.CreateFactoryIntakeRequest{
+			FactoryId: factoryModel.ID.String(),
+			Source:    pb.FactoryIntake_SOURCE_GITHUB_ISSUES,
+		})
+		require.NoError(t, err)
+		backlog := liveBacklogCanvas(t, factoryModel)
+		enableInstanceSuperPlaneDefault(t)
+
+		response, err := MaterializeFactoryAppDefaults(ctx, orgID, &pb.MaterializeFactoryAppDefaultsRequest{
+			FactoryId: factoryModel.ID.String(),
+			AppId:     backlog.ID.String(),
+		})
+		require.NoError(t, err)
+
+		defaults, err := yaml.CanvasFromYAML([]byte(response.GetCanvasYaml()))
+		require.NoError(t, err)
+		assertSuperPlaneRunnerNode(t, findYAMLNode(t, defaults, intakeAnalysisNodeID))
+	})
+
+	t.Run("Backlog keeps the Claude agent when the instance default is unset", func(t *testing.T) {
+		factoryModel := newFactory(t)
+		_, err := CreateFactoryIntake(ctx, deps, orgID, &pb.CreateFactoryIntakeRequest{
+			FactoryId: factoryModel.ID.String(),
+			Source:    pb.FactoryIntake_SOURCE_GITHUB_ISSUES,
+		})
+		require.NoError(t, err)
+		backlog := liveBacklogCanvas(t, factoryModel)
+
+		response, err := MaterializeFactoryAppDefaults(ctx, orgID, &pb.MaterializeFactoryAppDefaultsRequest{
+			FactoryId: factoryModel.ID.String(),
+			AppId:     backlog.ID.String(),
+		})
+		require.NoError(t, err)
+
+		defaults, err := yaml.CanvasFromYAML([]byte(response.GetCanvasYaml()))
+		require.NoError(t, err)
+		analysis := findYAMLNode(t, defaults, intakeAnalysisNodeID)
+		assert.Equal(t, "runnerClaudeCode", analysis.Component)
+		assert.Equal(t, "opus", analysis.Configuration["model"])
+	})
+
+	t.Run("a discussion PR feedback handler resets to its generated graph", func(t *testing.T) {
+		factoryModel := newFactoryWithAppRepo(t, "acme/ship")
+		handler, err := CreateFactoryPRFeedbackHandler(ctx, deps, orgID, &pb.CreateFactoryPRFeedbackHandlerRequest{
+			FactoryId: factoryModel.ID.String(),
+			Settings: &pb.FactoryPRFeedbackHandler_Settings{
+				Discussion: &pb.FactoryPRFeedbackHandler_DiscussionSettings{
+					Mention: "@shipbot",
+				},
+			},
+		})
+		require.NoError(t, err)
+		enableInstanceSuperPlaneDefault(t)
+
+		response, err := MaterializeFactoryAppDefaults(ctx, orgID, &pb.MaterializeFactoryAppDefaultsRequest{
+			FactoryId: factoryModel.ID.String(),
+			AppId:     handler.GetHandler().GetCanvasId(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, prFeedbackDiscussionTemplateID, response.GetTemplateId())
+		assert.Empty(t, response.GetConsoleYaml())
+
+		defaults, err := yaml.CanvasFromYAML([]byte(response.GetCanvasYaml()))
+		require.NoError(t, err)
+		trigger := findYAMLNode(t, defaults, prFeedbackCommentTriggerNodeID)
+		assert.Equal(t, "acme/ship", trigger.Configuration["repository"])
+		assert.Equal(t, "@shipbot", trigger.Configuration["contentFilter"])
+		assert.Equal(t, map[string]any{
+			"id":      prFeedbackDiscussionTemplateID,
+			"version": float64(factoryTemplateVersion),
+		}, trigger.Metadata[factoryTemplateMetadataKey])
+		assertSuperPlaneRunnerNode(t, findYAMLNode(t, defaults, prFeedbackRunnerNodeID))
+	})
+
+	t.Run("a checks PR feedback handler resets to its generated graph", func(t *testing.T) {
+		factoryModel := newFactoryWithAppRepo(t, "acme/ship")
+		handler, err := CreateFactoryPRFeedbackHandler(ctx, deps, orgID, &pb.CreateFactoryPRFeedbackHandlerRequest{
+			FactoryId: factoryModel.ID.String(),
+			Source:    pb.FactoryPRFeedbackHandler_SOURCE_PULL_REQUEST_CHECKS,
+		})
+		require.NoError(t, err)
+		enableInstanceSuperPlaneDefault(t)
+
+		response, err := MaterializeFactoryAppDefaults(ctx, orgID, &pb.MaterializeFactoryAppDefaultsRequest{
+			FactoryId: factoryModel.ID.String(),
+			AppId:     handler.GetHandler().GetCanvasId(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, prFeedbackChecksTemplateID, response.GetTemplateId())
+		assert.Empty(t, response.GetConsoleYaml())
+
+		defaults, err := yaml.CanvasFromYAML([]byte(response.GetCanvasYaml()))
+		require.NoError(t, err)
+		trigger := findYAMLNode(t, defaults, prFeedbackPullRequestTriggerNodeID)
+		assert.Equal(t, "acme/ship", trigger.Configuration["repository"])
+		assert.NotNil(t, findYAMLNode(t, defaults, prFeedbackWaitChecksNodeID))
+		assert.Equal(t, map[string]any{
+			"id":      prFeedbackChecksTemplateID,
+			"version": float64(factoryTemplateVersion),
+		}, trigger.Metadata[factoryTemplateMetadataKey])
+		assertSuperPlaneRunnerNode(t, findYAMLNode(t, defaults, prFeedbackRunnerNodeID))
+	})
+}
+
+func createClaudePlanningCanvas(t *testing.T, r *support.ResourceRegistry, factoryID uuid.UUID) *models.Canvas {
+	t.Helper()
+	canvas := support.CreateFactoryCanvas(t, r, factoryID, "Plan")
+	require.NoError(t, database.DB(t.Context()).Model(&models.CanvasVersion{}).
+		Where("id = ?", *canvas.LiveVersionID).
+		Update("nodes", datatypes.NewJSONSlice([]models.Node{
+			{
+				ID:   "onrun-create-plan",
+				Name: "On Run",
+				Type: models.NodeTypeTrigger,
+				Ref:  models.NodeRef{Trigger: &models.TriggerRef{Name: "onRun"}},
+			},
+			{
+				ID:   "planner-agent-no-issue",
+				Name: "Planner",
+				Type: models.NodeTypeComponent,
+				Ref:  models.NodeRef{Component: &models.ComponentRef{Name: "runnerClaudeCode"}},
+				Configuration: map[string]any{
+					"model": "opus",
+					"credentials": map[string]any{
+						"source":      "integration",
+						"integration": map[string]any{"name": "claude"},
+					},
+				},
+			},
+		})).Error)
+	return canvas
+}
+
+func enableInstanceSuperPlaneDefault(t *testing.T) {
+	t.Helper()
+	db := database.DB(t.Context())
+	previous, err := models.GetInstallationLLMSettings(db)
+	require.NoError(t, err)
+
+	_, err = models.UpsertHostedLLMProvider(db, models.HostedLLMProvider{
+		Provider:      models.UsageProviderOpenRouter,
+		Enabled:       true,
+		APIKey:        []byte("encrypted"),
+		AllowedModels: datatypes.JSONSlice[string]{"x-ai/grok-4.6"},
+	})
+	require.NoError(t, err)
+
+	provider := models.UsageProviderOpenRouter
+	model := "x-ai/grok-4.6"
+	_, err = models.UpdateInstallationLLMSettings(db, models.InstallationLLMSettings{
+		WelcomeGrantCents:     previous.WelcomeGrantCents,
+		MarkupBPS:             previous.MarkupBPS,
+		WarningThresholdBPS:   previous.WarningThresholdBPS,
+		DefaultHostedProvider: &provider,
+		DefaultHostedModel:    &model,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		conn := database.Conn()
+		_, err := models.UpdateInstallationLLMSettings(conn, *previous)
+		require.NoError(t, err)
+		_ = conn.Where("provider = ?", models.UsageProviderOpenRouter).Delete(&models.HostedLLMProvider{})
+	})
+}
+
+func assertSuperPlaneRunnerNode(t *testing.T, node *yaml.Node) {
+	t.Helper()
+	require.NotNil(t, node)
+	assert.Equal(t, models.SuperPlaneRunnerComponent, node.Component)
+	assert.Nil(t, node.Configuration["model"])
+	assert.Nil(t, node.Configuration["credentials"])
+}
+
+func assertNoRunnerNode(t *testing.T, canvas *yaml.Canvas) {
+	t.Helper()
+	for _, node := range canvas.Spec.Nodes {
+		assert.NotEqual(t, models.SuperPlaneRunnerComponent, node.Component)
+		assert.NotContains(t, []string{"runnerClaudeCode", "runnerCodex", "runnerOpenRouter"}, node.Component)
+	}
 }

--- a/pkg/grpc/actions/factories/pr_feedback_template.go
+++ b/pkg/grpc/actions/factories/pr_feedback_template.go
@@ -30,6 +30,9 @@ const (
 	prFeedbackDefaultMaximumAttempts = 3
 	prFeedbackMaximumAttemptsMin     = 1
 	prFeedbackMaximumAttemptsMax     = 10
+
+	prFeedbackDiscussionTemplateID = "pr-feedback:discussion"
+	prFeedbackChecksTemplateID     = "pr-feedback:checks"
 )
 
 var prFeedbackTriggerNodeIDs = []string{

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -2206,10 +2206,6 @@ func (b *NodeConfigurationBuilder) listDirectUpstreamExecutions() ([]models.Canv
 }
 
 func (b *NodeConfigurationBuilder) applyLineDispatchModel(resolved map[string]any) (map[string]any, error) {
-	if _, hasModel := resolved["model"]; !hasModel {
-		return resolved, nil
-	}
-
 	dispatch, err := b.lineDispatch()
 	if err != nil || dispatch == nil {
 		return resolved, err
@@ -2276,14 +2272,18 @@ func (b *NodeConfigurationBuilder) nodeAcceptsDispatchModel(
 		return false, err
 	}
 
-	provider, ok := runnerProviderForComponent(node.ComponentName())
-	if !ok {
-		return false, nil
-	}
-
 	workflow, err := models.FindCanvasWithoutOrgScopeInTransaction(b.tx, b.workflowID)
 	if err != nil {
 		return false, err
+	}
+
+	if node.ComponentName() == models.SuperPlaneRunnerComponent {
+		return superPlaneAcceptsDispatchModel(b.tx, workflow.OrganizationID, workflow.FactoryID, model)
+	}
+
+	provider, ok := runnerProviderForComponent(node.ComponentName())
+	if !ok {
+		return false, nil
 	}
 
 	return models.ModelIsSelectable(
@@ -2293,6 +2293,40 @@ func (b *NodeConfigurationBuilder) nodeAcceptsDispatchModel(
 		provider,
 		runnerFundingSourceFromConfig(resolved),
 		model,
+	)
+}
+
+func superPlaneAcceptsDispatchModel(
+	tx *gorm.DB,
+	orgID uuid.UUID,
+	factoryID *uuid.UUID,
+	model string,
+) (bool, error) {
+	if parsed, err := models.ParseSelectableLLMModelKey(model); err == nil {
+		if parsed.Source.ID != models.UsageFundingSourceHosted {
+			return false, nil
+		}
+		return models.ModelIsSelectable(
+			tx,
+			orgID,
+			factoryID,
+			parsed.Provider.ID,
+			models.UsageFundingSourceHosted,
+			parsed.Model.ID,
+		)
+	}
+
+	hosted, err := models.ParseHostedLLMModelKey(model)
+	if err != nil || !hosted.IsSet() {
+		return false, nil
+	}
+	return models.ModelIsSelectable(
+		tx,
+		orgID,
+		factoryID,
+		hosted.Provider,
+		models.UsageFundingSourceHosted,
+		hosted.Model,
 	)
 }
 

--- a/pkg/workers/contexts/node_configuration_builder_dispatch_model_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_dispatch_model_test.go
@@ -196,6 +196,133 @@ func Test__Build__DoesNotOverlaySiblingCanvasModel(t *testing.T) {
 	assert.Equal(t, "opus", resolved["model"])
 }
 
+func Test__Build__OverlaysLineDispatchModelOnSuperPlaneWithoutCanvasModel(t *testing.T) {
+	r := support.Setup(t)
+	db := database.Conn()
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	_, err = models.UpsertHostedLLMProvider(db, models.HostedLLMProvider{
+		Provider:      models.UsageProviderOpenRouter,
+		Enabled:       true,
+		APIKey:        []byte("encrypted"),
+		AllowedModels: datatypes.JSONSlice[string]{"x-ai/grok-4.6"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Where("provider = ?", models.UsageProviderOpenRouter).Delete(&models.HostedLLMProvider{})
+	})
+
+	canvas, rootEvent, run := setupRunnerAppExecution(t, r, factoryModel.ID, models.SuperPlaneRunnerComponent)
+	order, err := factoryModel.CreateWorkOrder(db, "Ship it", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	line, err := factoryModel.CreateLine(db, "ship", nil)
+	require.NoError(t, err)
+	dispatch := support.CreateFactoryLineDispatch(t, r.Organization.ID, factoryModel.ID, order.ID, line.ID, line.Name, nil)
+	override := models.FormatSelectableLLMModelKey(models.UsageFundingSourceHosted, models.UsageProviderOpenRouter, "x-ai/grok-4.6")
+	require.NoError(t, db.Model(dispatch).Update("model", override).Error)
+
+	now := time.Now()
+	require.NoError(t, db.Create(&models.FactoryWorkOrderExecution{
+		ID:             uuid.New(),
+		OrganizationID: r.Organization.ID,
+		FactoryID:      factoryModel.ID,
+		WorkOrderID:    order.ID,
+		LineID:         line.ID,
+		LineDispatchID: dispatch.ID,
+		StepIndex:      0,
+		StepName:       "agent",
+		RunID:          &run.ID,
+		Status:         models.FactoryWorkOrderExecutionStatusRunning,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}).Error)
+
+	builder := NewNodeConfigurationBuilder(db, canvas.ID).
+		WithNodeID("agent").
+		WithRootEvent(&rootEvent.ID)
+
+	resolved, err := builder.Build(map[string]any{
+		"machineType": "e1-large-amd64",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, override, resolved["model"])
+}
+
+func Test__Build__SkipsSuperPlaneOverrideWhenModelIsNotAllowlisted(t *testing.T) {
+	r := support.Setup(t)
+	db := database.Conn()
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	_, err = models.UpsertHostedLLMProvider(db, models.HostedLLMProvider{
+		Provider:      models.UsageProviderOpenRouter,
+		Enabled:       true,
+		APIKey:        []byte("encrypted"),
+		AllowedModels: datatypes.JSONSlice[string]{"x-ai/grok-4.6"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Where("provider = ?", models.UsageProviderOpenRouter).Delete(&models.HostedLLMProvider{})
+	})
+
+	canvas, rootEvent, run := setupRunnerAppExecution(t, r, factoryModel.ID, models.SuperPlaneRunnerComponent)
+	order, err := factoryModel.CreateWorkOrder(db, "Ship it", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	line, err := factoryModel.CreateLine(db, "ship", nil)
+	require.NoError(t, err)
+	dispatch := support.CreateFactoryLineDispatch(t, r.Organization.ID, factoryModel.ID, order.ID, line.ID, line.Name, nil)
+	require.NoError(t, db.Model(dispatch).Update("model", models.FormatSelectableLLMModelKey(
+		models.UsageFundingSourceHosted,
+		models.UsageProviderOpenRouter,
+		"openai/gpt-5",
+	)).Error)
+
+	now := time.Now()
+	require.NoError(t, db.Create(&models.FactoryWorkOrderExecution{
+		ID:             uuid.New(),
+		OrganizationID: r.Organization.ID,
+		FactoryID:      factoryModel.ID,
+		WorkOrderID:    order.ID,
+		LineID:         line.ID,
+		LineDispatchID: dispatch.ID,
+		StepIndex:      0,
+		StepName:       "agent",
+		RunID:          &run.ID,
+		Status:         models.FactoryWorkOrderExecutionStatusRunning,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}).Error)
+
+	builder := NewNodeConfigurationBuilder(db, canvas.ID).
+		WithNodeID("agent").
+		WithRootEvent(&rootEvent.ID)
+
+	resolved, err := builder.Build(map[string]any{})
+	require.NoError(t, err)
+	assert.NotContains(t, resolved, "model")
+}
+
+func Test__Build__KeepsSuperPlaneModelUnsetWhenDispatchIsAuto(t *testing.T) {
+	r := support.Setup(t)
+	db := database.Conn()
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+
+	canvas, rootEvent, run := setupRunnerAppExecution(t, r, factoryModel.ID, models.SuperPlaneRunnerComponent)
+	order, err := factoryModel.CreateWorkOrder(db, "Ship it", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	linkRunToWorkOrder(t, r, factoryModel, order.ID, run.ID)
+
+	builder := NewNodeConfigurationBuilder(db, canvas.ID).
+		WithNodeID("agent").
+		WithRootEvent(&rootEvent.ID)
+
+	resolved, err := builder.Build(map[string]any{
+		"machineType": "e1-large-amd64",
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, resolved, "model")
+}
+
 func setupRunnerAppExecution(
 	t *testing.T,
 	r *support.ResourceRegistry,

--- a/web_src/src/pages/factories/lib/factoryAppTemplate.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryAppTemplate.spec.ts
@@ -48,6 +48,14 @@ describe("hasFactoryAppDefaults", () => {
     expect(hasFactoryAppDefaults(canvasWith([{ id: "on-issue-labeled" }, { id: "create-work-order" }]))).toBe(true);
   });
 
+  it("recognizes generated PR feedback discussion canvases", () => {
+    expect(hasFactoryAppDefaults(canvasWith([{ id: "on-pr-comment" }, { id: "address-pr-feedback" }]))).toBe(true);
+  });
+
+  it("recognizes generated PR feedback checks canvases", () => {
+    expect(hasFactoryAppDefaults(canvasWith([{ id: "on-pull-request" }, { id: "wait-pr-checks" }]))).toBe(true);
+  });
+
   it("rejects custom canvases", () => {
     expect(hasFactoryAppDefaults(canvasWith([{ id: "custom" }]))).toBe(false);
   });

--- a/web_src/src/pages/factories/lib/factoryAppTemplate.ts
+++ b/web_src/src/pages/factories/lib/factoryAppTemplate.ts
@@ -38,6 +38,8 @@ export function hasFactoryAppDefaults(canvas: CanvasesCanvas | null | undefined)
   const nodeIds = new Set(nodes.map((node) => node.id));
   return (
     (nodeIds.has("trigger") && nodeIds.has("create-work-order")) ||
-    (nodeIds.has("on-issue-labeled") && nodeIds.has("create-work-order"))
+    (nodeIds.has("on-issue-labeled") && nodeIds.has("create-work-order")) ||
+    (nodeIds.has("on-pr-comment") && nodeIds.has("address-pr-feedback")) ||
+    (nodeIds.has("on-pull-request") && nodeIds.has("wait-pr-checks"))
   );
 }

--- a/web_src/src/pages/factories/pages/FactoryAppResetConfirmDialog.spec.tsx
+++ b/web_src/src/pages/factories/pages/FactoryAppResetConfirmDialog.spec.tsx
@@ -28,6 +28,12 @@ describe("FactoryAppResetConfirmDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("explains SuperPlane reset and that Save is still required", () => {
+    render(<FactoryAppResetConfirmDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} />);
+    expect(screen.getByTestId("factory-app-reset-defaults-dialog")).toHaveTextContent("Run SuperPlane Agent");
+    expect(screen.getByTestId("factory-app-reset-defaults-dialog")).toHaveTextContent("Save");
+  });
+
   it("renders nothing when closed", () => {
     render(<FactoryAppResetConfirmDialog open={false} onOpenChange={vi.fn()} onConfirm={vi.fn()} />);
     expect(screen.queryByTestId("factory-app-reset-defaults-dialog")).not.toBeInTheDocument();

--- a/web_src/src/pages/factories/pages/FactoryAppResetConfirmDialog.tsx
+++ b/web_src/src/pages/factories/pages/FactoryAppResetConfirmDialog.tsx
@@ -23,7 +23,8 @@ export function FactoryAppResetConfirmDialog({ open, onOpenChange, onConfirm }: 
           <AlertDialogTitle>Reset to factory defaults?</AlertDialogTitle>
           <AlertDialogDescription>
             This replaces your current draft with the bundled template for this app. It keeps your connected repository
-            and integrations. The change applies only after you click Save.
+            and integrations. When this instance has a SuperPlane default model, the draft uses Run SuperPlane Agent.
+            The change applies only after you click Save.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.spec.ts
@@ -66,4 +66,12 @@ describe("phaseWithRunnerModel", () => {
       ]).model,
     ).toBe("gpt-5");
   });
+
+  it("keeps a hosted SuperPlane start model", () => {
+    expect(
+      phaseWithRunnerModel({ model: "hosted::openrouter::x-ai/grok-4.6" }, [
+        { component: "runnerSuperPlane", configuration: {} },
+      ]).model,
+    ).toBe("hosted::openrouter::x-ai/grok-4.6");
+  });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/draftStartModel.ts
@@ -40,6 +40,7 @@ const RUNNER_PROVIDER: Record<string, string> = {
   runnerClaudeCode: "anthropic",
   runnerCodex: "openai",
   runnerOpenRouter: "openrouter",
+  runnerSuperPlane: "hosted",
 };
 
 export function runnerModelsFromCanvasNodes(nodes?: RunnerCanvasNode[]): string {
@@ -60,7 +61,7 @@ function runnerAcceptsStartModel(component: string | undefined, model: string): 
   if (!runner) {
     return false;
   }
-  if (runner === "openrouter") {
+  if (runner === "hosted" || runner === "openrouter") {
     return true;
   }
   const hint = startModelProvider(trimmed);


### PR DESCRIPTION
Hosted SuperPlane lines could not pick a model at start. Reset also copied the current BYOK agent, so SuperPlane factories could not convert Plan, Backlog, or PR feedback to Run SuperPlane Agent.

This change lists hosted models for SuperPlane lines, overlays the chosen model at dispatch, and uses the instance SuperPlane default when Reset to factory defaults runs.



<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/review-supe..."](https://github.com/superplanehq/superplane/commit/b2b4b9de5b3847ff35b6c3c72a7dd58025b54338) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61391709)</sub>

<!-- /greptile_comment -->