### PR TITLE
feat: Show one icon per column automation

### DIFF
--- a/web_src/src/pages/factories/lib/columnAutomationActivity.spec.ts
+++ b/web_src/src/pages/factories/lib/columnAutomationActivity.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FactoriesWorkOrder } from "@/api-client";
+
+import { buildColumnAutomationActivity, emptyColumnAutomationActivity } from "./columnAutomationActivity";
+
+const NOW = new Date("2026-09-08T19:00:00.000Z");
+
+function isoHoursAgo(hours: number): string {
+  return new Date(NOW.getTime() - hours * 60 * 60 * 1000).toISOString();
+}
+
+function orderWithExecutions(
+  executions: Array<{
+    appId: string;
+    state?: "STATE_STARTED" | "STATE_FINISHED";
+    result?: "RESULT_PASSED" | "RESULT_FAILED" | "RESULT_CANCELLED";
+    at?: string;
+  }>,
+): FactoriesWorkOrder {
+  return {
+    id: "wo-activity",
+    lineDispatches: [
+      {
+        stepExecutions: executions.map((execution, index) => ({
+          id: `exec-${index}`,
+          state: execution.state ?? "STATE_FINISHED",
+          result: execution.result,
+          finishedAt: execution.at,
+          updatedAt: execution.at,
+          createdAt: execution.at,
+          run: { appId: execution.appId },
+        })),
+      },
+    ],
+  };
+}
+
+describe("buildColumnAutomationActivity", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns only the running count when the automation has no canvas", () => {
+    expect(
+      buildColumnAutomationActivity({
+        workOrders: [orderWithExecutions([{ appId: "app-1", result: "RESULT_PASSED", at: isoHoursAgo(1) }])],
+        runningCount: 2,
+      }),
+    ).toEqual(emptyColumnAutomationActivity(2));
+  });
+
+  it("uses the newest finished run for last-run status", () => {
+    const activity = buildColumnAutomationActivity({
+      canvasId: "app-implement",
+      runningCount: 1,
+      workOrders: [
+        orderWithExecutions([
+          { appId: "app-implement", result: "RESULT_PASSED", at: isoHoursAgo(3) },
+          { appId: "app-implement", result: "RESULT_FAILED", at: isoHoursAgo(0.5) },
+          { appId: "app-other", result: "RESULT_PASSED", at: isoHoursAgo(0.1) },
+          { appId: "app-implement", state: "STATE_STARTED" },
+        ]),
+      ],
+    });
+
+    expect(activity).toEqual({
+      lastRunStatus: "failed",
+      lastRunWhen: "30 minutes ago",
+      runningCount: 1,
+    });
+  });
+});

--- a/web_src/src/pages/factories/lib/columnAutomationActivity.ts
+++ b/web_src/src/pages/factories/lib/columnAutomationActivity.ts
@@ -1,0 +1,82 @@
+import type { FactoriesWorkOrder, FactoriesWorkOrderExecution } from "@/api-client";
+import { formatRelativeTime } from "@/lib/timezone";
+
+import { flattenWorkOrderExecutions, getExecutionStepTimestamp } from "./workOrderExecutions";
+
+export type ColumnAutomationLastRunStatus = "passed" | "failed";
+
+export type ColumnAutomationActivity = {
+  lastRunStatus?: ColumnAutomationLastRunStatus;
+  lastRunWhen?: string;
+  runningCount: number;
+};
+
+type FinishedOutcome = {
+  status: ColumnAutomationLastRunStatus;
+  at: number;
+  when: string;
+};
+
+export function emptyColumnAutomationActivity(runningCount = 0): ColumnAutomationActivity {
+  return { runningCount };
+}
+
+export function buildColumnAutomationActivity(input: {
+  canvasId?: string;
+  workOrders: FactoriesWorkOrder[];
+  runningCount: number;
+}): ColumnAutomationActivity {
+  const canvasId = input.canvasId?.trim();
+  if (!canvasId) {
+    return emptyColumnAutomationActivity(input.runningCount);
+  }
+
+  let lastRun: FinishedOutcome | undefined;
+  for (const execution of executionsForApp(canvasId, input.workOrders)) {
+    const outcome = finishedOutcome(execution);
+    if (!outcome) {
+      continue;
+    }
+    if (!lastRun || outcome.at > lastRun.at) {
+      lastRun = outcome;
+    }
+  }
+
+  return {
+    lastRunStatus: lastRun?.status,
+    lastRunWhen: lastRun?.when,
+    runningCount: input.runningCount,
+  };
+}
+
+function executionsForApp(canvasId: string, workOrders: FactoriesWorkOrder[]): FactoriesWorkOrderExecution[] {
+  return workOrders.flatMap((order) =>
+    flattenWorkOrderExecutions(order).filter((execution) => execution.run?.appId === canvasId),
+  );
+}
+
+function finishedOutcome(execution: FactoriesWorkOrderExecution): FinishedOutcome | undefined {
+  if (execution.state !== "STATE_FINISHED") {
+    return undefined;
+  }
+  const status = resultStatus(execution.result);
+  if (!status) {
+    return undefined;
+  }
+  const when = execution.finishedAt ?? getExecutionStepTimestamp(execution);
+  const at = Date.parse(when);
+  if (!Number.isFinite(at)) {
+    return undefined;
+  }
+  return { status, at, when: formatRelativeTime(when) };
+}
+
+function resultStatus(result: FactoriesWorkOrderExecution["result"]): ColumnAutomationLastRunStatus | undefined {
+  if (result === "RESULT_PASSED") {
+    return "passed";
+  }
+  if (result === "RESULT_FAILED") {
+    return "failed";
+  }
+  return undefined;
+}

--- a/web_src/src/pages/factories/lib/columnAutomations.spec.ts
+++ b/web_src/src/pages/factories/lib/columnAutomations.spec.ts
@@ -4,6 +4,7 @@ import type { FactoriesFactoryIntake, FactoriesFactoryPrFeedbackHandler, Factori
 
 import {
   applyColumnAutomationsOverlay,
+  automationOffersAgentEdit,
   buildColumnAutomations,
   catalogForColumn,
   columnAutomationOpenPath,
@@ -108,6 +109,15 @@ describe("columnTitleForKey", () => {
     expect(columnTitleForKey("backlog")).toBe("Backlog");
     expect(columnTitleForKey("phase-0", [IMPLEMENT_COLUMN])).toBe("Implement");
     expect(columnTitleForKey("phase-3", [IMPLEMENT_COLUMN])).toBe("Phase 4");
+  });
+});
+
+describe("automationOffersAgentEdit", () => {
+  it("offers agent edit for analysis and agent-step automations", () => {
+    expect(automationOffersAgentEdit({ kind: "analysis" })).toBe(true);
+    expect(automationOffersAgentEdit({ kind: "agent-step" })).toBe(true);
+    expect(automationOffersAgentEdit({ kind: "intake" })).toBe(false);
+    expect(automationOffersAgentEdit({ kind: "custom" })).toBe(false);
   });
 });
 

--- a/web_src/src/pages/factories/lib/columnAutomations.spec.ts
+++ b/web_src/src/pages/factories/lib/columnAutomations.spec.ts
@@ -173,6 +173,7 @@ describe("buildColumnAutomations", () => {
         action: "Run the Implement agent",
         runningCount: 1,
         canvasId: "app-refund-implementer",
+        activity: expect.objectContaining({ runningCount: 1 }),
       }),
     ]);
   });

--- a/web_src/src/pages/factories/lib/columnAutomations.ts
+++ b/web_src/src/pages/factories/lib/columnAutomations.ts
@@ -451,6 +451,10 @@ export function applyColumnAutomationsOverlay(
     .map((automation) => (disabled.has(automation.id) ? { ...automation, health: "disabled" } : automation));
 }
 
+export function automationOffersAgentEdit(automation: Pick<ColumnAutomation, "kind">): boolean {
+  return automation.kind === "agent-step" || automation.kind === "analysis";
+}
+
 export function catalogEntryToAutomation(
   entry: ColumnAutomationCatalogEntry,
   columnTitle: string,

--- a/web_src/src/pages/factories/lib/columnAutomations.ts
+++ b/web_src/src/pages/factories/lib/columnAutomations.ts
@@ -463,6 +463,8 @@ export const COLUMN_AUTOMATIONS_COPY = {
   needsRepairLabel: "Needs repair",
   disabledLabel: "Disabled",
   editLabel: "Edit automation",
+  editAgentLabel: "Edit Agent",
+  editAutomationMenuLabel: "Edit Automation",
   tabsLabel: "Automation sections",
   generalTab: "General",
   agentTab: "Agent",

--- a/web_src/src/pages/factories/lib/columnAutomations.ts
+++ b/web_src/src/pages/factories/lib/columnAutomations.ts
@@ -3,6 +3,11 @@ import githubIcon from "@/assets/icons/integrations/github.svg";
 
 import { LINE_INTAKE_SOURCES, lineIntakeSourceForApiSource } from "../pages/lineIntakeModel";
 import { PR_FEEDBACK_SOURCES, prFeedbackSourceId } from "../pages/prFeedbackSettingsModel";
+import {
+  buildColumnAutomationActivity,
+  emptyColumnAutomationActivity,
+  type ColumnAutomationActivity,
+} from "./columnAutomationActivity";
 import { factoryColumnAutomationViewPath, factoryIntakePath, factoryPRFeedbackPath } from "./factoryPagePaths";
 import { isActiveWorkOrderExecution } from "./workOrderExecutions";
 import { findBacklogAutomationApp, findClosureAutomationApp, type LinePhaseColumn } from "./linePhaseRuns";
@@ -32,6 +37,7 @@ export type ColumnAutomation = {
   runningCount: number;
   catalogId: string;
   canvasId?: string;
+  activity?: ColumnAutomationActivity;
 };
 
 export type ColumnAutomationCatalogEntry = {
@@ -201,19 +207,37 @@ export function columnAutomationsNeedRepair(automations: ColumnAutomation[]): bo
 }
 
 export function buildColumnAutomations(key: ColumnKey, input: ColumnAutomationsInput): ColumnAutomation[] {
+  const workOrders = input.workOrders ?? [];
+  const automations = automationsForColumn(key, input, workOrders);
+  return automations.map((automation) => attachAutomationActivity(automation, workOrders));
+}
+
+function automationsForColumn(
+  key: ColumnKey,
+  input: ColumnAutomationsInput,
+  workOrders: FactoriesWorkOrder[],
+): ColumnAutomation[] {
   if (key === "backlog") {
-    return [
-      ...intakeAutomations(input.intakes ?? [], input.workOrders ?? []),
-      ...analysisAutomation(input.apps ?? [], input.workOrders ?? []),
-    ];
+    return [...intakeAutomations(input.intakes ?? [], workOrders), ...analysisAutomation(input.apps ?? [], workOrders)];
   }
   if (key === "verify") {
-    return prFeedbackAutomations(input.prFeedbackHandlers ?? [], input.workOrders ?? []);
+    return prFeedbackAutomations(input.prFeedbackHandlers ?? [], workOrders);
   }
   if (key === "done") {
-    return closureAutomation(input.apps ?? [], input.workOrders ?? []);
+    return closureAutomation(input.apps ?? [], workOrders);
   }
-  return agentStepAutomation(key, input.columnTitle, input.columns ?? [], input.workOrders ?? []);
+  return agentStepAutomation(key, input.columnTitle, input.columns ?? [], workOrders);
+}
+
+function attachAutomationActivity(automation: ColumnAutomation, workOrders: FactoriesWorkOrder[]): ColumnAutomation {
+  return {
+    ...automation,
+    activity: buildColumnAutomationActivity({
+      canvasId: automation.canvasId,
+      workOrders,
+      runningCount: automation.runningCount,
+    }),
+  };
 }
 
 function intakeAutomations(intakes: FactoriesFactoryIntake[], workOrders: FactoriesWorkOrder[]): ColumnAutomation[] {
@@ -450,6 +474,7 @@ export function catalogEntryToAutomation(
     health: "healthy",
     runningCount: 0,
     catalogId: entry.id,
+    activity: emptyColumnAutomationActivity(0),
   };
 }
 
@@ -473,4 +498,7 @@ export const COLUMN_AUTOMATIONS_COPY = {
   viewEmpty: "This automation has no canvas yet.",
   viewError: "SuperPlane could not load the automation.",
   viewRetry: "Try again",
+  lastRunPassed: "Passed",
+  lastRunFailed: "Failed",
+  activityRunning: "running",
 } as const;

--- a/web_src/src/pages/factories/pages/BacklogColumn.tsx
+++ b/web_src/src/pages/factories/pages/BacklogColumn.tsx
@@ -41,15 +41,10 @@ export type BacklogColumnProps = {
   intakePanel?: BacklogIntakePanel;
   /** Opens the Add intake picker from the overflow menu. Hidden when unset. */
   onAddIntake?: () => void;
-  /** Column automations for the header indicator. Hidden when unset. */
+  /** Column automations for the header icons. Hidden when unset. */
   automations?: ColumnAutomation[];
-  /** Opens the Automations menu. Hidden when unset. */
-  onOpenAutomations?: () => void;
-  automationsOpen?: boolean;
-  onCloseAutomations?: () => void;
   onAddAutomation?: () => void;
   onAutomationRowAction?: (automation: ColumnAutomation, action: ColumnAutomationRowAction) => void;
-  automationsLockOpen?: boolean;
 };
 
 export type BacklogIntakePanel = {
@@ -84,12 +79,8 @@ export function BacklogColumn({
   intakePanel,
   onAddIntake,
   automations,
-  onOpenAutomations,
-  automationsOpen,
-  onCloseAutomations,
   onAddAutomation,
   onAutomationRowAction,
-  automationsLockOpen,
 }: BacklogColumnProps) {
   const surfaceClassName = lineBoardColumnLaneClassName(colorId);
   const atCapacity = size != null && orders.length >= size;
@@ -123,12 +114,8 @@ export function BacklogColumn({
             title={title}
             createPopover={createPopover}
             automations={automations}
-            automationsOpen={automationsOpen}
-            onOpenAutomations={onOpenAutomations}
-            onCloseAutomations={onCloseAutomations}
             onAddAutomation={onAddAutomation}
             onAutomationRowAction={onAutomationRowAction}
-            automationsLockOpen={automationsLockOpen}
             onOpenSettings={onOpenSettings}
             onAddIntake={onAddIntake}
             colorId={colorId}
@@ -162,12 +149,8 @@ function BacklogColumnHeaderActions({
   title,
   createPopover,
   automations,
-  automationsOpen,
-  onOpenAutomations,
-  onCloseAutomations,
   onAddAutomation,
   onAutomationRowAction,
-  automationsLockOpen,
   onOpenSettings,
   onAddIntake,
   colorId,
@@ -176,12 +159,8 @@ function BacklogColumnHeaderActions({
   BacklogColumnProps,
   | "title"
   | "automations"
-  | "automationsOpen"
-  | "onOpenAutomations"
-  | "onCloseAutomations"
   | "onAddAutomation"
   | "onAutomationRowAction"
-  | "automationsLockOpen"
   | "onOpenSettings"
   | "onAddIntake"
   | "colorId"
@@ -194,14 +173,8 @@ function BacklogColumnHeaderActions({
       <BacklogCreatePopover {...createPopover} />
       <ColumnAutomationsHeaderSlot
         title={title}
-        columnKey="backlog"
         automations={automations}
-        open={automationsOpen}
-        onOpen={onOpenAutomations}
-        onClose={onCloseAutomations}
-        onAdd={onAddAutomation}
         onRowAction={onAutomationRowAction}
-        lockOpen={automationsLockOpen}
         testId="lines-backlog-automations"
       />
       <ColumnLaneMenu
@@ -209,6 +182,7 @@ function BacklogColumnHeaderActions({
         testId="lines-backlog-menu"
         onEdit={onOpenSettings}
         onAddIntake={onAddIntake}
+        onAddAutomation={onAddAutomation}
         colorId={colorId}
         onColorChange={onColorChange}
       />

--- a/web_src/src/pages/factories/pages/BacklogColumn.tsx
+++ b/web_src/src/pages/factories/pages/BacklogColumn.tsx
@@ -170,13 +170,13 @@ function BacklogColumnHeaderActions({
 }) {
   return (
     <div className="flex shrink-0 items-center gap-0.5">
-      <BacklogCreatePopover {...createPopover} />
       <ColumnAutomationsHeaderSlot
         title={title}
         automations={automations}
         onRowAction={onAutomationRowAction}
         testId="lines-backlog-automations"
       />
+      <BacklogCreatePopover {...createPopover} />
       <ColumnLaneMenu
         title={title}
         testId="lines-backlog-menu"

--- a/web_src/src/pages/factories/pages/ColumnAutomationsIndicator.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsIndicator.tsx
@@ -1,95 +1,40 @@
-import { cn } from "@/lib/utils";
-import { Workflow } from "lucide-react";
+import type { ColumnAutomation } from "../lib/columnAutomations";
+import {
+  automationOffersAgentEdit,
+  ColumnAutomationsPopup,
+  type ColumnAutomationRowAction,
+} from "./ColumnAutomationsPopup";
 
-import { columnAutomationsNeedRepair, type ColumnAutomation, type ColumnKey } from "../lib/columnAutomations";
-import { ColumnAutomationsPopup, type ColumnAutomationRowAction } from "./ColumnAutomationsPopup";
-
-interface ColumnAutomationsIndicatorProps {
-  title: string;
-  count: number;
-  needsRepair: boolean;
-  testId: string;
-  open?: boolean;
-}
-
-/** Compact count in the column header. Opens the Automations menu. */
-export function ColumnAutomationsIndicator({
-  title,
-  count,
-  needsRepair,
-  testId,
-  open = false,
-}: ColumnAutomationsIndicatorProps) {
-  return (
-    <button
-      type="button"
-      aria-label={`${title} automations`}
-      title={`${title} automations`}
-      data-testid={testId}
-      className={cn(
-        "relative flex h-6 shrink-0 items-center gap-1 rounded-md px-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
-        open && "bg-accent text-foreground",
-      )}
-    >
-      <Workflow className="size-3.5" aria-hidden />
-      <span className="text-[11px] font-medium tabular-nums">{count}</span>
-      {needsRepair ? (
-        <span
-          className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-amber-500"
-          data-testid={`${testId}-needs-repair`}
-          aria-hidden
-        />
-      ) : null}
-    </button>
-  );
-}
-
+/** One header icon for each configured automation. */
 export function ColumnAutomationsHeaderSlot({
   title,
-  columnKey,
   automations,
-  open = false,
-  onOpen,
-  onClose,
-  onAdd,
   onRowAction,
-  lockOpen,
+  canEditAgent,
   testId,
 }: {
   title: string;
-  columnKey: ColumnKey;
   automations?: ColumnAutomation[];
-  open?: boolean;
-  onOpen?: () => void;
-  onClose?: () => void;
-  onAdd?: () => void;
   onRowAction?: (automation: ColumnAutomation, action: ColumnAutomationRowAction) => void;
-  lockOpen?: boolean;
+  /** When set, overrides the default agent-edit offer for every icon in this slot. */
+  canEditAgent?: boolean;
   testId: string;
 }) {
-  if (!onOpen || !onClose || !onAdd || !onRowAction || !automations) {
+  if (!onRowAction || !automations || automations.length === 0) {
     return null;
   }
   return (
-    <ColumnAutomationsPopup
-      columnTitle={title}
-      columnKey={columnKey}
-      automations={automations}
-      open={open}
-      lockOpen={lockOpen}
-      onOpen={onOpen}
-      onClose={onClose}
-      onAdd={onAdd}
-      onRowAction={onRowAction}
-      trigger={
-        <ColumnAutomationsIndicator
-          title={title}
-          count={automations.length}
-          needsRepair={columnAutomationsNeedRepair(automations)}
-          testId={testId}
-          open={open}
-        />
-      }
-    />
+    <div className="flex shrink-0 items-center" role="list" aria-label={`${title} automations`} data-testid={testId}>
+      {automations.map((automation) => (
+        <div key={automation.id} role="listitem">
+          <ColumnAutomationsPopup
+            automation={automation}
+            onAction={(action) => onRowAction(automation, action)}
+            showEditAgent={canEditAgent ?? automationOffersAgentEdit(automation)}
+            showEditAutomation={Boolean(automation.canvasId)}
+          />
+        </div>
+      ))}
+    </div>
   );
 }

--- a/web_src/src/pages/factories/pages/ColumnAutomationsIndicator.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsIndicator.tsx
@@ -1,10 +1,6 @@
 import { emptyColumnAutomationActivity } from "../lib/columnAutomationActivity";
-import type { ColumnAutomation } from "../lib/columnAutomations";
-import {
-  automationOffersAgentEdit,
-  ColumnAutomationsPopup,
-  type ColumnAutomationRowAction,
-} from "./ColumnAutomationsPopup";
+import { automationOffersAgentEdit, type ColumnAutomation } from "../lib/columnAutomations";
+import { ColumnAutomationsPopup, type ColumnAutomationRowAction } from "./ColumnAutomationsPopup";
 
 /** One header icon for each configured automation. */
 export function ColumnAutomationsHeaderSlot({

--- a/web_src/src/pages/factories/pages/ColumnAutomationsIndicator.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsIndicator.tsx
@@ -1,3 +1,4 @@
+import { emptyColumnAutomationActivity } from "../lib/columnAutomationActivity";
 import type { ColumnAutomation } from "../lib/columnAutomations";
 import {
   automationOffersAgentEdit,
@@ -29,6 +30,7 @@ export function ColumnAutomationsHeaderSlot({
         <div key={automation.id} role="listitem">
           <ColumnAutomationsPopup
             automation={automation}
+            activity={automation.activity ?? emptyColumnAutomationActivity(automation.runningCount)}
             onAction={(action) => onRowAction(automation, action)}
             showEditAgent={canEditAgent ?? automationOffersAgentEdit(automation)}
             showEditAutomation={Boolean(automation.canvasId)}

--- a/web_src/src/pages/factories/pages/ColumnAutomationsPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsPopup.spec.tsx
@@ -89,6 +89,24 @@ describe("ColumnAutomationsPopup", () => {
     expect(screen.getByTestId("column-automation-row-intake-github")).not.toHaveTextContent("running");
   });
 
+  it("shows last-run activity when it is supplied", () => {
+    renderPopup({
+      automation: { ...INTAKE, name: "Task analysis" },
+      activity: {
+        lastRunStatus: "passed",
+        lastRunWhen: "2 minutes ago",
+        runningCount: 2,
+      },
+    });
+
+    const activity = screen.getByTestId("column-automation-activity");
+    expect(activity).toHaveTextContent("Passed");
+    expect(activity).toHaveTextContent("2 minutes ago");
+    expect(activity).toHaveTextContent("2 running");
+    expect(activity.querySelector("svg.animate-spin")).not.toBeNull();
+    expect(screen.queryByTestId("column-automation-hourly-chart")).not.toBeInTheDocument();
+  });
+
   it("reports a click on the summary", async () => {
     const user = userEvent.setup();
     const onAction = vi.fn();

--- a/web_src/src/pages/factories/pages/ColumnAutomationsPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsPopup.spec.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { ColumnAutomation } from "../lib/columnAutomations";
+import { ColumnAutomationsHeaderSlot } from "./ColumnAutomationsIndicator";
 import { ColumnAutomationsPopup } from "./ColumnAutomationsPopup";
 
 const INTAKE: ColumnAutomation = {
@@ -18,6 +19,20 @@ const INTAKE: ColumnAutomation = {
   runningCount: 0,
   catalogId: "github-issues",
   canvasId: "app-github",
+};
+
+const AGENT: ColumnAutomation = {
+  id: "step-0-app-refund-implementer",
+  kind: "agent-step",
+  name: "Implement",
+  trigger: "On task in Implement",
+  action: "Run the Implement agent",
+  iconSrc: "",
+  iconAlt: "",
+  health: "healthy",
+  runningCount: 0,
+  catalogId: "agent-step",
+  canvasId: "app-refund-implementer",
 };
 
 const REPAIR: ColumnAutomation = {
@@ -41,65 +56,100 @@ const DISABLED: ColumnAutomation = {
 };
 
 function renderPopup(props: Partial<ComponentProps<typeof ColumnAutomationsPopup>> = {}) {
-  return render(
-    <ColumnAutomationsPopup
-      columnTitle="Backlog"
-      columnKey="backlog"
-      automations={[INTAKE]}
-      open
-      onOpen={vi.fn()}
-      onClose={vi.fn()}
-      onAdd={vi.fn()}
-      onRowAction={vi.fn()}
-      trigger={<button type="button">Open automations</button>}
-      {...props}
-    />,
-  );
+  return render(<ColumnAutomationsPopup automation={INTAKE} onAction={vi.fn()} defaultOpen {...props} />);
 }
 
 describe("ColumnAutomationsPopup", () => {
-  it("lists automations with a trigger-to-action sentence", () => {
-    renderPopup();
+  it("opens a summary from the automation icon", async () => {
+    const user = userEvent.setup();
+    render(<ColumnAutomationsPopup automation={INTAKE} onAction={vi.fn()} />);
 
-    expect(screen.getByRole("heading", { name: "Backlog automations" })).toBeInTheDocument();
+    expect(screen.queryByTestId("column-automations-popup")).not.toBeInTheDocument();
+    await user.click(screen.getByTestId("column-automation-icon-intake-github"));
+
+    expect(screen.getByTestId("column-automations-popup")).toBeInTheDocument();
     expect(screen.getByTestId("column-automation-row-intake-github")).toHaveTextContent(
       "On GitHub issue → Create a task in Backlog",
     );
-    expect(screen.getByTestId("column-automations-divider")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "GitHub issues menu" })).not.toBeInTheDocument();
-  });
-
-  it("shows the empty copy for a phase with no automations", () => {
-    renderPopup({ columnTitle: "Review", columnKey: "phase-1", automations: [] });
-
-    expect(screen.getByTestId("column-automations-empty")).toHaveTextContent(
-      "No automations. Tasks pass through Review without action.",
-    );
+    expect(screen.queryByTestId("column-automations-add")).not.toBeInTheDocument();
   });
 
   it("shows needs-repair and disabled badges", () => {
-    renderPopup({ automations: [REPAIR, DISABLED] });
-
+    renderPopup({ automation: REPAIR });
     expect(screen.getByTestId("column-automation-row-intake-sentry")).toHaveTextContent("Needs repair");
+    expect(screen.getByTestId("column-automation-icon-intake-sentry-needs-repair")).toBeInTheDocument();
+
+    renderPopup({ automation: DISABLED });
     expect(screen.getByTestId("column-automation-row-analysis-1")).toHaveTextContent("Disabled");
   });
 
   it("does not show a running count", () => {
-    renderPopup({ automations: [{ ...INTAKE, runningCount: 4 }] });
+    renderPopup({ automation: { ...INTAKE, runningCount: 4 } });
 
     expect(screen.getByTestId("column-automation-row-intake-github")).not.toHaveTextContent("running");
   });
 
-  it("reports row click and Add automation", async () => {
+  it("reports a click on the summary", async () => {
     const user = userEvent.setup();
-    const onAdd = vi.fn();
-    const onRowAction = vi.fn();
-    renderPopup({ onAdd, onRowAction });
+    const onAction = vi.fn();
+    renderPopup({ onAction });
 
     await user.click(screen.getByTestId("column-automation-row-intake-github"));
-    expect(onRowAction).toHaveBeenCalledWith(INTAKE, "settings");
+    expect(onAction).toHaveBeenCalledWith("settings");
+  });
 
-    await user.click(screen.getByTestId("column-automations-add"));
-    expect(onAdd).toHaveBeenCalledTimes(1);
+  it("offers Edit Agent ahead of Edit Automation when both are present", async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+    render(
+      <ColumnAutomationsPopup automation={AGENT} onAction={onAction} showEditAgent showEditAutomation defaultOpen />,
+    );
+
+    const editAgent = screen.getByTestId("column-automation-step-0-app-refund-implementer-edit-agent");
+    const editAutomation = screen.getByTestId("column-automation-step-0-app-refund-implementer-edit");
+    expect(editAgent).toHaveTextContent("Edit Agent");
+    expect(editAutomation).toHaveTextContent("Edit Automation");
+    expect(editAgent.compareDocumentPosition(editAutomation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    await user.click(editAgent);
+    expect(onAction).toHaveBeenCalledWith("edit-agent");
+  });
+
+  it("hides edit actions when they are not offered", () => {
+    renderPopup();
+
+    expect(screen.queryByTestId("column-automation-intake-github-edit-agent")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("column-automation-intake-github-edit")).not.toBeInTheDocument();
+  });
+});
+
+describe("ColumnAutomationsHeaderSlot", () => {
+  it("renders one icon for each automation", () => {
+    render(
+      <ColumnAutomationsHeaderSlot
+        title="Backlog"
+        automations={[INTAKE, DISABLED]}
+        onRowAction={vi.fn()}
+        testId="lines-backlog-automations"
+      />,
+    );
+
+    expect(screen.getByTestId("lines-backlog-automations")).toBeInTheDocument();
+    expect(screen.getByTestId("column-automation-icon-intake-github")).toHaveAttribute("aria-label", "GitHub issues");
+    expect(screen.getByTestId("column-automation-icon-analysis-1")).toHaveAttribute("aria-label", "Task analysis");
+    expect(screen.getByTestId("lines-backlog-automations")).not.toHaveTextContent("2");
+  });
+
+  it("hides the strip when the column has no automations", () => {
+    const { container } = render(
+      <ColumnAutomationsHeaderSlot
+        title="Review"
+        automations={[]}
+        onRowAction={vi.fn()}
+        testId="lines-phase-3-automations"
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/web_src/src/pages/factories/pages/ColumnAutomationsPopup.stories.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsPopup.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { ComponentStoryShell } from "../__fixtures__/ComponentStoryShell";
 import type { ColumnAutomation } from "../lib/columnAutomations";
+import { ColumnAutomationsHeaderSlot } from "./ColumnAutomationsIndicator";
 import { ColumnAutomationsPopup } from "./ColumnAutomationsPopup";
 
 const INTAKE: ColumnAutomation = {
@@ -53,22 +54,13 @@ const meta = {
   component: ColumnAutomationsPopup,
   parameters: { layout: "centered" },
   args: {
-    columnTitle: "Backlog",
-    columnKey: "backlog",
-    automations: [INTAKE, ANALYSIS],
-    open: true,
-    onClose: () => undefined,
-    onAdd: () => undefined,
-    onRowAction: () => undefined,
-    trigger: (
-      <button type="button" className="rounded-md border border-border px-2 py-1 text-sm">
-        Automations
-      </button>
-    ),
+    automation: INTAKE,
+    onAction: () => undefined,
+    defaultOpen: true,
   },
   decorators: [
     (Story) => (
-      <ComponentStoryShell className="relative min-h-[520px] bg-gray-50 p-6 dark:bg-gray-950">
+      <ComponentStoryShell className="relative min-h-[320px] bg-gray-50 p-6 dark:bg-gray-950">
         <Story />
       </ComponentStoryShell>
     ),
@@ -79,29 +71,44 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Populated: Story = {
-  name: "Populated",
+export const InfoOpen: Story = {
+  name: "Info open",
 };
 
-export const Empty: Story = {
-  name: "Empty phase",
+export const PhaseEditActions: Story = {
+  name: "Phase edit actions",
   args: {
-    columnTitle: "Review",
-    columnKey: "phase-1",
-    automations: [],
+    automation: ANALYSIS,
+    showEditAgent: true,
+    showEditAutomation: true,
   },
 };
 
 export const NeedsRepair: Story = {
   name: "Needs repair",
   args: {
-    automations: [REPAIR, ANALYSIS],
+    automation: REPAIR,
   },
 };
 
-export const DisabledRow: Story = {
-  name: "Disabled row",
+export const DisabledIcon: Story = {
+  name: "Disabled icon",
   args: {
-    automations: [INTAKE, DISABLED],
+    automation: DISABLED,
   },
+};
+
+export const HeaderIcons: Story = {
+  name: "Header icons",
+  args: {
+    defaultOpen: false,
+  },
+  render: () => (
+    <ColumnAutomationsHeaderSlot
+      title="Backlog"
+      automations={[INTAKE, ANALYSIS, REPAIR]}
+      onRowAction={() => undefined}
+      testId="story-column-automations"
+    />
+  ),
 };

--- a/web_src/src/pages/factories/pages/ColumnAutomationsPopup.stories.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsPopup.stories.tsx
@@ -3,7 +3,19 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ComponentStoryShell } from "../__fixtures__/ComponentStoryShell";
 import type { ColumnAutomation } from "../lib/columnAutomations";
 import { ColumnAutomationsHeaderSlot } from "./ColumnAutomationsIndicator";
-import { ColumnAutomationsPopup } from "./ColumnAutomationsPopup";
+import { ColumnAutomationsPopup, type ColumnAutomationActivity } from "./ColumnAutomationsPopup";
+
+const HEALTHY_ACTIVITY: ColumnAutomationActivity = {
+  lastRunStatus: "passed",
+  lastRunWhen: "2 minutes ago",
+  runningCount: 2,
+};
+
+const FAILED_ACTIVITY: ColumnAutomationActivity = {
+  lastRunStatus: "failed",
+  lastRunWhen: "18 minutes ago",
+  runningCount: 1,
+};
 
 const INTAKE: ColumnAutomation = {
   id: "intake-github",
@@ -81,6 +93,26 @@ export const PhaseEditActions: Story = {
     automation: ANALYSIS,
     showEditAgent: true,
     showEditAutomation: true,
+  },
+};
+
+export const WithActivity: Story = {
+  name: "With last-run activity",
+  args: {
+    automation: ANALYSIS,
+    showEditAgent: true,
+    showEditAutomation: true,
+    activity: HEALTHY_ACTIVITY,
+  },
+};
+
+export const WithFailedActivity: Story = {
+  name: "With failed last run",
+  args: {
+    automation: ANALYSIS,
+    showEditAgent: true,
+    showEditAutomation: true,
+    activity: FAILED_ACTIVITY,
   },
 };
 

--- a/web_src/src/pages/factories/pages/ColumnAutomationsPopup.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsPopup.tsx
@@ -207,7 +207,3 @@ function ColumnAutomationActivitySummary({ activity }: { activity: ColumnAutomat
     </span>
   );
 }
-
-export function automationOffersAgentEdit(automation: ColumnAutomation): boolean {
-  return automation.kind === "agent-step" || automation.kind === "analysis";
-}

--- a/web_src/src/pages/factories/pages/ColumnAutomationsPopup.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsPopup.tsx
@@ -1,176 +1,167 @@
 import { cn } from "@/lib/utils";
-import { Popover, PopoverAnchor, PopoverContent } from "@/ui/popover";
-import { Separator } from "@/ui/separator";
-import { Plus, Workflow } from "lucide-react";
-import { useEffect, useState, type ReactNode } from "react";
-
 import {
-  COLUMN_AUTOMATIONS_COPY,
-  columnAutomationsEmptyCopy,
-  type ColumnAutomation,
-  type ColumnKey,
-} from "../lib/columnAutomations";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/ui/dropdownMenu";
+import { Bot, Pencil, Sparkles, Workflow } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
-export type ColumnAutomationRowAction = "settings" | "edit" | "disable" | "enable" | "remove";
+import { COLUMN_AUTOMATIONS_COPY, type ColumnAutomation, type ColumnAutomationKind } from "../lib/columnAutomations";
 
-/** Same hover surface for an automation row and Add automation. */
-const AUTOMATION_ITEM_CLASS =
-  "flex w-full cursor-pointer items-start gap-3 rounded-md px-2.5 py-2.5 text-left hover:bg-accent";
+export type ColumnAutomationRowAction = "settings" | "edit" | "edit-agent" | "disable" | "enable" | "remove";
+
+const KIND_FALLBACK_ICON: Partial<Record<ColumnAutomationKind, LucideIcon>> = {
+  analysis: Sparkles,
+  "agent-step": Bot,
+  custom: Workflow,
+};
 
 interface ColumnAutomationsPopupProps {
-  columnTitle: string;
-  columnKey: ColumnKey;
-  automations: ColumnAutomation[];
-  onClose: () => void;
-  onAdd: () => void;
-  onRowAction: (automation: ColumnAutomation, action: ColumnAutomationRowAction) => void;
-  open?: boolean;
-  onOpen?: () => void;
-  /** Keep the menu open while another dialog (Add automation) is up. */
-  lockOpen?: boolean;
-  trigger?: ReactNode;
+  automation: ColumnAutomation;
+  onAction: (action: ColumnAutomationRowAction) => void;
+  showEditAgent?: boolean;
+  showEditAutomation?: boolean;
+  /** Open the menu on first render. Used by stories. */
+  defaultOpen?: boolean;
 }
 
-/** Large column menu, same chrome as the Backlog create dropdown. */
+/** Header icon. Click opens a menu with the automation summary and edit actions. */
 export function ColumnAutomationsPopup({
-  columnTitle,
-  columnKey,
-  automations,
-  onClose,
-  onAdd,
-  onRowAction,
-  open = true,
-  onOpen,
-  lockOpen = false,
-  trigger,
+  automation,
+  onAction,
+  showEditAgent = false,
+  showEditAutomation = false,
+  defaultOpen = false,
 }: ColumnAutomationsPopupProps) {
-  const title = `${columnTitle} automations`;
-  const [menuOpen, setMenuOpen] = useState(open);
-
-  useEffect(() => {
-    setMenuOpen(open);
-  }, [open]);
+  const needsRepair = automation.health === "needs-repair";
+  const disabled = automation.health === "disabled";
+  const hasEditActions = showEditAgent || showEditAutomation;
 
   return (
-    <Popover
-      open={menuOpen}
-      onOpenChange={(next) => {
-        if (!next && lockOpen) {
-          return;
-        }
-        setMenuOpen(next);
-        if (next) {
-          onOpen?.();
-          return;
-        }
-        onClose();
-      }}
-    >
-      {trigger ? (
-        <PopoverAnchor asChild>
-          <span
-            className="inline-flex"
-            onClick={() => {
-              setMenuOpen(true);
-              onOpen?.();
-            }}
-          >
-            {trigger}
-          </span>
-        </PopoverAnchor>
-      ) : null}
-      <PopoverContent
-        side="bottom"
-        align="end"
-        sideOffset={6}
-        className="w-96 p-2"
-        data-testid="column-automations-popup"
-      >
-        <h2 className="px-2.5 pb-1.5 pt-1 text-sm font-medium tracking-[-0.01em]">{title}</h2>
-        {automations.length === 0 ? (
-          <p className="px-2.5 py-4 text-[13px] text-muted-foreground" data-testid="column-automations-empty">
-            {columnAutomationsEmptyCopy(columnTitle, columnKey)}
-          </p>
-        ) : (
-          <ul className="flex flex-col" data-testid="column-automations-list">
-            {automations.map((automation) => (
-              <ColumnAutomationRow
-                key={automation.id}
-                automation={automation}
-                onAction={(action) => onRowAction(automation, action)}
-              />
-            ))}
-          </ul>
-        )}
-        <Separator className="my-1" data-testid="column-automations-divider" />
+    <DropdownMenu defaultOpen={defaultOpen}>
+      <DropdownMenuTrigger asChild>
         <button
           type="button"
-          onClick={onAdd}
-          data-testid="column-automations-add"
-          className={cn(AUTOMATION_ITEM_CLASS, "mt-0.5")}
+          aria-label={automation.name}
+          title={automation.name}
+          data-testid={`column-automation-icon-${automation.id}`}
+          className={cn(
+            "relative flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+            disabled && "opacity-70",
+          )}
         >
-          <Plus className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
-          <span className="min-w-0">
-            <span className="block text-sm font-medium">{COLUMN_AUTOMATIONS_COPY.addLabel}</span>
-            <span className="mt-0.5 block text-[13px] text-muted-foreground">{COLUMN_AUTOMATIONS_COPY.addHint}</span>
-          </span>
+          <ColumnAutomationGlyph automation={automation} className="size-3.5" />
+          {needsRepair ? (
+            <span
+              className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-amber-500"
+              data-testid={`column-automation-icon-${automation.id}-needs-repair`}
+              aria-hidden
+            />
+          ) : null}
         </button>
-      </PopoverContent>
-    </Popover>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-56 w-80 p-0" data-testid="column-automations-popup">
+        <div className="p-1">
+          <ColumnAutomationInfo automation={automation} onOpenSettings={() => onAction("settings")} />
+        </div>
+        {hasEditActions ? (
+          <>
+            <DropdownMenuSeparator className="my-0" />
+            <div className="p-1">
+              {showEditAgent ? (
+                <DropdownMenuItem
+                  onSelect={() => onAction("edit-agent")}
+                  data-testid={`column-automation-${automation.id}-edit-agent`}
+                >
+                  <Bot className="h-3.5 w-3.5" aria-hidden />
+                  {COLUMN_AUTOMATIONS_COPY.editAgentLabel}
+                </DropdownMenuItem>
+              ) : null}
+              {showEditAutomation ? (
+                <DropdownMenuItem
+                  onSelect={() => onAction("edit")}
+                  data-testid={`column-automation-${automation.id}-edit`}
+                >
+                  <Pencil className="h-3.5 w-3.5" aria-hidden />
+                  {COLUMN_AUTOMATIONS_COPY.editAutomationMenuLabel}
+                </DropdownMenuItem>
+              ) : null}
+            </div>
+          </>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
-function ColumnAutomationRow({
+export function ColumnAutomationGlyph({
   automation,
-  onAction,
+  className,
+}: {
+  automation: Pick<ColumnAutomation, "iconSrc" | "iconAlt" | "kind">;
+  className?: string;
+}) {
+  if (automation.iconSrc) {
+    return (
+      <img
+        src={automation.iconSrc}
+        alt=""
+        className={cn(
+          "shrink-0 object-contain",
+          className,
+          automation.iconAlt === "GitHub" && "dark:brightness-0 dark:invert",
+        )}
+      />
+    );
+  }
+  const Icon = KIND_FALLBACK_ICON[automation.kind] ?? Workflow;
+  return <Icon className={cn("shrink-0 text-muted-foreground", className)} aria-hidden />;
+}
+
+function ColumnAutomationInfo({
+  automation,
+  onOpenSettings,
 }: {
   automation: ColumnAutomation;
-  onAction: (action: ColumnAutomationRowAction) => void;
+  onOpenSettings: () => void;
 }) {
   const disabled = automation.health === "disabled";
   const needsRepair = automation.health === "needs-repair";
 
   return (
-    <li>
-      <button
-        type="button"
-        data-testid={`column-automation-row-${automation.id}`}
-        onClick={() => onAction("settings")}
-        className={cn(AUTOMATION_ITEM_CLASS, disabled && "opacity-70")}
-      >
-        {automation.iconSrc ? (
-          <img
-            src={automation.iconSrc}
-            alt=""
-            className={cn(
-              "mt-0.5 size-4 shrink-0 object-contain",
-              automation.iconAlt === "GitHub" && "dark:brightness-0 dark:invert",
-            )}
-          />
-        ) : (
-          <Workflow className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
-        )}
-        <span className="min-w-0">
-          <span className="block text-sm font-medium">{automation.name}</span>
-          <span className="mt-0.5 block text-[13px] text-muted-foreground">
-            {automation.trigger} → {automation.action}
-          </span>
-          {needsRepair || disabled ? (
-            <span className="mt-1 flex flex-wrap items-center gap-1.5">
-              {needsRepair ? (
-                <span className="text-[11px] font-medium text-amber-700 dark:text-amber-400">
-                  {COLUMN_AUTOMATIONS_COPY.needsRepairLabel}
-                </span>
-              ) : null}
-              {disabled ? (
-                <span className="text-[11px] font-medium text-muted-foreground">
-                  {COLUMN_AUTOMATIONS_COPY.disabledLabel}
-                </span>
-              ) : null}
-            </span>
-          ) : null}
+    <DropdownMenuItem
+      data-testid={`column-automation-row-${automation.id}`}
+      onSelect={onOpenSettings}
+      className={cn("items-start gap-3 py-2.5", disabled && "opacity-70")}
+    >
+      <ColumnAutomationGlyph automation={automation} className="mt-0.5 size-4" />
+      <span className="min-w-0">
+        <span className="block text-sm font-medium">{automation.name}</span>
+        <span className="mt-0.5 block text-[13px] text-muted-foreground">
+          {automation.trigger} → {automation.action}
         </span>
-      </button>
-    </li>
+        {needsRepair || disabled ? (
+          <span className="mt-1 flex flex-wrap items-center gap-1.5">
+            {needsRepair ? (
+              <span className="text-[11px] font-medium text-amber-700 dark:text-amber-400">
+                {COLUMN_AUTOMATIONS_COPY.needsRepairLabel}
+              </span>
+            ) : null}
+            {disabled ? (
+              <span className="text-[11px] font-medium text-muted-foreground">
+                {COLUMN_AUTOMATIONS_COPY.disabledLabel}
+              </span>
+            ) : null}
+          </span>
+        ) : null}
+      </span>
+    </DropdownMenuItem>
   );
+}
+
+export function automationOffersAgentEdit(automation: ColumnAutomation): boolean {
+  return automation.kind === "agent-step" || automation.kind === "analysis";
 }

--- a/web_src/src/pages/factories/pages/ColumnAutomationsPopup.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsPopup.tsx
@@ -6,10 +6,13 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdownMenu";
-import { Bot, Pencil, Sparkles, Workflow } from "lucide-react";
+import { Bot, LoaderCircle, Pencil, Sparkles, Workflow } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
+import { type ColumnAutomationActivity, type ColumnAutomationLastRunStatus } from "../lib/columnAutomationActivity";
 import { COLUMN_AUTOMATIONS_COPY, type ColumnAutomation, type ColumnAutomationKind } from "../lib/columnAutomations";
+
+export type { ColumnAutomationActivity, ColumnAutomationLastRunStatus };
 
 export type ColumnAutomationRowAction = "settings" | "edit" | "edit-agent" | "disable" | "enable" | "remove";
 
@@ -24,6 +27,7 @@ interface ColumnAutomationsPopupProps {
   onAction: (action: ColumnAutomationRowAction) => void;
   showEditAgent?: boolean;
   showEditAutomation?: boolean;
+  activity?: ColumnAutomationActivity;
   /** Open the menu on first render. Used by stories. */
   defaultOpen?: boolean;
 }
@@ -34,6 +38,7 @@ export function ColumnAutomationsPopup({
   onAction,
   showEditAgent = false,
   showEditAutomation = false,
+  activity,
   defaultOpen = false,
 }: ColumnAutomationsPopupProps) {
   const needsRepair = automation.health === "needs-repair";
@@ -63,9 +68,13 @@ export function ColumnAutomationsPopup({
           ) : null}
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="min-w-56 w-80 p-0" data-testid="column-automations-popup">
+      <DropdownMenuContent align="end" className="min-w-56 p-0" data-testid="column-automations-popup">
         <div className="p-1">
-          <ColumnAutomationInfo automation={automation} onOpenSettings={() => onAction("settings")} />
+          <ColumnAutomationInfo
+            automation={automation}
+            activity={activity}
+            onOpenSettings={() => onAction("settings")}
+          />
         </div>
         {hasEditActions ? (
           <>
@@ -123,9 +132,11 @@ export function ColumnAutomationGlyph({
 
 function ColumnAutomationInfo({
   automation,
+  activity,
   onOpenSettings,
 }: {
   automation: ColumnAutomation;
+  activity?: ColumnAutomationActivity;
   onOpenSettings: () => void;
 }) {
   const disabled = automation.health === "disabled";
@@ -138,11 +149,12 @@ function ColumnAutomationInfo({
       className={cn("items-start gap-3 py-2.5", disabled && "opacity-70")}
     >
       <ColumnAutomationGlyph automation={automation} className="mt-0.5 size-4" />
-      <span className="min-w-0">
+      <span className="min-w-0 flex-1">
         <span className="block text-sm font-medium">{automation.name}</span>
         <span className="mt-0.5 block text-[13px] text-muted-foreground">
           {automation.trigger} → {automation.action}
         </span>
+        {activity ? <ColumnAutomationActivitySummary activity={activity} /> : null}
         {needsRepair || disabled ? (
           <span className="mt-1 flex flex-wrap items-center gap-1.5">
             {needsRepair ? (
@@ -159,6 +171,40 @@ function ColumnAutomationInfo({
         ) : null}
       </span>
     </DropdownMenuItem>
+  );
+}
+
+function ColumnAutomationActivitySummary({ activity }: { activity: ColumnAutomationActivity }) {
+  const running = activity.runningCount ?? 0;
+  const lastRunLabel =
+    activity.lastRunStatus === "passed"
+      ? COLUMN_AUTOMATIONS_COPY.lastRunPassed
+      : activity.lastRunStatus === "failed"
+        ? COLUMN_AUTOMATIONS_COPY.lastRunFailed
+        : undefined;
+
+  return (
+    <span className="mt-1.5 flex flex-col gap-0.5" data-testid="column-automation-activity">
+      {lastRunLabel && activity.lastRunWhen ? (
+        <span
+          className={cn(
+            "text-[11px] font-medium",
+            activity.lastRunStatus === "passed"
+              ? "text-emerald-700 dark:text-emerald-400"
+              : "text-red-700 dark:text-red-400",
+          )}
+        >
+          {lastRunLabel}
+          <span className="font-normal text-muted-foreground"> · {activity.lastRunWhen}</span>
+        </span>
+      ) : null}
+      <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+        {running > 0 ? (
+          <LoaderCircle className="size-3 shrink-0 animate-spin text-[color:var(--status-running-dot)]" aria-hidden />
+        ) : null}
+        {running} {COLUMN_AUTOMATIONS_COPY.activityRunning}
+      </span>
+    </span>
   );
 }
 

--- a/web_src/src/pages/factories/pages/ColumnLaneMenu.spec.tsx
+++ b/web_src/src/pages/factories/pages/ColumnLaneMenu.spec.tsx
@@ -68,36 +68,6 @@ describe("ColumnLaneMenu", () => {
     expect(onEdit).toHaveBeenCalledTimes(1);
   });
 
-  it("offers a separate Edit Agent action", async () => {
-    const onEditAgent = vi.fn();
-    const user = userEvent.setup();
-
-    render(
-      <MemoryRouter>
-        <ColumnLaneMenu
-          title="Plan"
-          testId="lines-phase-menu-0"
-          editHref="/canvas-edit"
-          editLabel="Edit Automation"
-          onEditAgent={onEditAgent}
-          colorId={null}
-          onColorChange={vi.fn()}
-        />
-      </MemoryRouter>,
-    );
-
-    await user.click(screen.getByTestId("lines-phase-menu-0"));
-    const editAgent = screen.getByTestId("lines-phase-menu-0-edit-agent");
-    const editAutomation = screen.getByTestId("lines-phase-menu-0-edit");
-    expect(editAgent).toHaveTextContent("Edit Agent");
-    expect(editAutomation).toHaveTextContent("Edit Automation");
-    // Editing the agent is the common task, so it leads the menu.
-    expect(editAgent.compareDocumentPosition(editAutomation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    await user.click(editAgent);
-
-    expect(onEditAgent).toHaveBeenCalledTimes(1);
-  });
-
   it("uses the supplied Edit label for canvas columns", async () => {
     const user = userEvent.setup();
 
@@ -127,8 +97,6 @@ describe("ColumnLaneMenu", () => {
         <ColumnLaneMenu
           title="Implement"
           testId="lines-phase-menu-1"
-          editHref="/canvas-edit"
-          editLabel="Edit Automation"
           onSetParallelism={onSetParallelism}
           parallelism={10}
           colorId={null}
@@ -181,6 +149,52 @@ describe("ColumnLaneMenu", () => {
 
     await user.click(addIntake);
     expect(onAddIntake).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers Add automation ahead of the other actions when supplied", async () => {
+    const onAddAutomation = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ColumnLaneMenu
+          title="Backlog"
+          testId="lines-backlog-menu"
+          onEdit={vi.fn()}
+          onAddAutomation={onAddAutomation}
+          colorId={null}
+          onColorChange={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId("lines-backlog-menu"));
+    const addAutomation = screen.getByTestId("lines-backlog-menu-add-automation");
+    expect(addAutomation).toHaveTextContent("Add automation");
+    const edit = screen.getByTestId("lines-backlog-menu-edit");
+    expect(addAutomation.compareDocumentPosition(edit) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    await user.click(addAutomation);
+    expect(onAddAutomation).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides Add automation when it is not supplied", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ColumnLaneMenu
+          title="Backlog"
+          testId="lines-backlog-menu"
+          onEdit={vi.fn()}
+          colorId={null}
+          onColorChange={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId("lines-backlog-menu"));
+    expect(screen.queryByTestId("lines-backlog-menu-add-automation")).not.toBeInTheDocument();
   });
 
   it("hides Add intake when it is not supplied", async () => {

--- a/web_src/src/pages/factories/pages/ColumnLaneMenu.tsx
+++ b/web_src/src/pages/factories/pages/ColumnLaneMenu.tsx
@@ -1,4 +1,4 @@
-import { Bot, Check, MoreHorizontal, Pencil, Plus, SlidersHorizontal, XIcon } from "lucide-react";
+import { Check, MoreHorizontal, Pencil, Plus, SlidersHorizontal, XIcon } from "lucide-react";
 import { useNavigate } from "react-router";
 
 import { cn } from "@/lib/utils";
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/ui/dropdownMenu";
 
+import { COLUMN_AUTOMATIONS_COPY } from "../lib/columnAutomations";
 import { DEFAULT_LINE_STEP_PARALLELISM, setParallelismLabel } from "../lib/factoryLineFormShared";
 import { LINE_BOARD_COLUMN_COLORS, type LineBoardColumnColorId } from "./lineBoardColumnColors";
 
@@ -23,13 +24,13 @@ interface ColumnLaneMenuProps {
   onEdit?: () => void;
   /** Menu item copy. Defaults to Edit. */
   editLabel?: string;
-  /** Opens the inline agent editor. */
-  onEditAgent?: () => void;
   /** Opens the parallelism modal for canvas-backed phases. */
   onSetParallelism?: () => void;
   parallelism?: number;
   /** Opens the Add intake picker. Leads the menu when set. */
   onAddIntake?: () => void;
+  /** Opens the Add automation picker. */
+  onAddAutomation?: () => void;
   colorId: LineBoardColumnColorId | null;
   onColorChange: (colorId: LineBoardColumnColorId | null) => void;
 }
@@ -43,16 +44,16 @@ export function ColumnLaneMenu({
   editHref,
   onEdit,
   editLabel = "Edit",
-  onEditAgent,
   onSetParallelism,
   parallelism = DEFAULT_LINE_STEP_PARALLELISM,
   onAddIntake,
+  onAddAutomation,
   colorId,
   onColorChange,
 }: ColumnLaneMenuProps) {
   const navigate = useNavigate();
   const canEdit = Boolean(onEdit || editHref);
-  const hasActions = canEdit || Boolean(onEditAgent || onSetParallelism || onAddIntake);
+  const hasActions = canEdit || Boolean(onSetParallelism || onAddIntake || onAddAutomation);
 
   const handleEdit = () => {
     if (onEdit) {
@@ -84,10 +85,10 @@ export function ColumnLaneMenu({
               editLabel={editLabel}
               canEdit={canEdit}
               onEdit={handleEdit}
-              onEditAgent={onEditAgent}
               onSetParallelism={onSetParallelism}
               parallelism={parallelism}
               onAddIntake={onAddIntake}
+              onAddAutomation={onAddAutomation}
             />
             <DropdownMenuSeparator className="my-0" />
           </>
@@ -103,32 +104,32 @@ function ColumnLaneMenuActions({
   editLabel,
   canEdit,
   onEdit,
-  onEditAgent,
   onSetParallelism,
   parallelism,
   onAddIntake,
+  onAddAutomation,
 }: {
   testId: string;
   editLabel: string;
   canEdit: boolean;
   onEdit: () => void;
-  onEditAgent?: () => void;
   onSetParallelism?: () => void;
   parallelism: number;
   onAddIntake?: () => void;
+  onAddAutomation?: () => void;
 }) {
   return (
     <div className="p-1">
+      {onAddAutomation ? (
+        <DropdownMenuItem onSelect={onAddAutomation} data-testid={`${testId}-add-automation`}>
+          <Plus className="h-3.5 w-3.5" aria-hidden />
+          {COLUMN_AUTOMATIONS_COPY.addLabel}
+        </DropdownMenuItem>
+      ) : null}
       {onAddIntake ? (
         <DropdownMenuItem onSelect={onAddIntake} data-testid={`${testId}-add-intake`}>
           <Plus className="h-3.5 w-3.5" aria-hidden />
           Add intake
-        </DropdownMenuItem>
-      ) : null}
-      {onEditAgent ? (
-        <DropdownMenuItem onSelect={onEditAgent} data-testid={`${testId}-edit-agent`}>
-          <Bot className="h-3.5 w-3.5" aria-hidden />
-          Edit Agent
         </DropdownMenuItem>
       ) : null}
       {canEdit ? (

--- a/web_src/src/pages/factories/pages/Lines.stories.tsx
+++ b/web_src/src/pages/factories/pages/Lines.stories.tsx
@@ -239,7 +239,7 @@ export const LineBoardAddAutomationPicker: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Open the Backlog drawer and press Add automation. Taken catalog entries stay disabled.",
+        story: "Open the column menu and press Add automation. Taken catalog entries stay disabled.",
       },
     },
   },

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -411,10 +411,12 @@ describe("LinesPage board", () => {
     expect(within(backlog).queryByTestId(`line-intake-source-${GITHUB_ISSUES_INTAKE_ID}`)).not.toBeInTheDocument();
     expect(screen.queryByTestId("lines-verify-listener-handler-discussion")).not.toBeInTheDocument();
     expect(screen.queryByTestId("lines-verify-add-pr-feedback")).not.toBeInTheDocument();
-    expect(screen.getByTestId("lines-backlog-automations")).toHaveTextContent("3");
-    expect(screen.getByTestId("lines-phase-0-automations")).toBeInTheDocument();
-    expect(screen.getByTestId("lines-verify-automations")).toHaveTextContent("1");
-    expect(screen.getByTestId("lines-done-automations")).toBeInTheDocument();
+    expect(screen.getByTestId(`column-automation-icon-${GITHUB_ISSUES_INTAKE_ID}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`column-automation-icon-${SENTRY_INTAKE_ID}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`column-automation-icon-${PAGERDUTY_INTAKE_ID}`)).toBeInTheDocument();
+    expect(screen.getByTestId("column-automation-icon-step-0-app-refund-implementer")).toBeInTheDocument();
+    expect(screen.getByTestId("column-automation-icon-handler-discussion")).toBeInTheDocument();
+    expect(screen.queryByTestId("lines-done-automations")).not.toBeInTheDocument();
   });
 
   it("opens the backlog automations menu from the indicator", async () => {
@@ -423,15 +425,15 @@ describe("LinesPage board", () => {
     const user = userEvent.setup();
     renderLinesBoard();
 
-    await user.click(screen.getByTestId("lines-backlog-automations"));
+    await user.click(screen.getByTestId(`column-automation-icon-${GITHUB_ISSUES_INTAKE_ID}`));
 
-    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
-      `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?automations=backlog`,
-    );
-    expect(screen.getByRole("heading", { name: "Backlog automations" })).toBeInTheDocument();
+    expect(screen.getByTestId("column-automations-popup")).toBeInTheDocument();
     expect(screen.getByTestId(`column-automation-row-${GITHUB_ISSUES_INTAKE_ID}`)).toHaveTextContent(
       "On GitHub issue → Create a task in Backlog",
     );
+
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByTestId("column-automation-icon-analysis-app-refund-backlog"));
     expect(screen.getByTestId("column-automation-row-analysis-app-refund-backlog")).toHaveTextContent(
       "On task in Backlog → Score the task",
     );
@@ -440,8 +442,9 @@ describe("LinesPage board", () => {
   it("opens intake settings on the first tab when an automation row is clicked", async () => {
     useFactoryIntakes.mockReturnValue({ data: [GITHUB_ISSUES_INTAKE] });
     const user = userEvent.setup();
-    renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?automations=backlog`);
+    renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`);
 
+    await user.click(screen.getByTestId(`column-automation-icon-${GITHUB_ISSUES_INTAKE_ID}`));
     await user.click(screen.getByTestId(`column-automation-row-${GITHUB_ISSUES_INTAKE_ID}`));
 
     expect(screen.getByTestId("lines-test-location")).toHaveTextContent(`intake=1&intakeId=${GITHUB_ISSUES_INTAKE_ID}`);
@@ -453,8 +456,9 @@ describe("LinesPage board", () => {
   it("opens an existing phase automation in the board view popup", async () => {
     useFactoryApps.mockReturnValue({ data: [{ id: "app-refund-implementer", name: "Implement" }] });
     const user = userEvent.setup();
-    renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?automations=phase-0`);
+    renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`);
 
+    await user.click(screen.getByTestId("column-automation-icon-step-0-app-refund-implementer"));
     await user.click(screen.getByTestId("column-automation-row-step-0-app-refund-implementer"));
 
     const location = screen.getByTestId("lines-test-location");
@@ -483,8 +487,9 @@ describe("LinesPage board", () => {
   it("opens an existing analysis automation in the board view popup", async () => {
     useFactoryApps.mockReturnValue({ data: [{ id: "app-refund-backlog", name: "Ingest" }] });
     const user = userEvent.setup();
-    renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?automations=backlog`);
+    renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`);
 
+    await user.click(screen.getByTestId("column-automation-icon-analysis-app-refund-backlog"));
     await user.click(screen.getByTestId("column-automation-row-analysis-app-refund-backlog"));
 
     expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
@@ -494,30 +499,48 @@ describe("LinesPage board", () => {
     expect(screen.getByTestId("lines-test-location")).not.toHaveTextContent("configure=1");
   });
 
-  it("opens the phase automations menu from the indicator", async () => {
+  it("opens the phase automation summary from the header icon", async () => {
     const user = userEvent.setup();
     renderLinesBoard();
 
-    await user.click(screen.getByTestId("lines-phase-0-automations"));
+    await user.click(screen.getByTestId("column-automation-icon-step-0-app-refund-implementer"));
 
-    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
-      `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?automations=phase-0`,
-    );
     expect(screen.getByTestId("column-automations-popup")).toBeInTheDocument();
-    expect(screen.getByTestId("column-automations-add")).toBeInTheDocument();
+    expect(screen.getByTestId("column-automation-row-step-0-app-refund-implementer")).toHaveTextContent(
+      "On task in Phase 1 → Run the Phase 1 agent",
+    );
+    expect(screen.queryByTestId("column-automations-add")).not.toBeInTheDocument();
   });
 
-  it("opens the verify and done automations menus from the indicators", async () => {
+  it("opens Add automation from the column menu", async () => {
     const user = userEvent.setup();
     renderLinesBoard();
 
-    await user.click(screen.getByTestId("lines-verify-automations"));
-    expect(screen.getByTestId("lines-test-location")).toHaveTextContent("automations=verify");
-    expect(screen.getByRole("heading", { name: "Verify automations" })).toBeInTheDocument();
+    await user.click(screen.getByTestId("lines-phase-menu-0"));
+    await user.click(screen.getByTestId("lines-phase-menu-0-add-automation"));
 
-    await user.click(screen.getByTestId("lines-done-automations"));
-    expect(screen.getByTestId("lines-test-location")).toHaveTextContent("automations=done");
-    expect(screen.getByRole("heading", { name: "Done automations" })).toBeInTheDocument();
+    expect(screen.getByTestId("add-column-automation-picker")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Add automation" })).toBeInTheDocument();
+  });
+
+  it("opens the verify and done automation summaries from the header icons", async () => {
+    useFactoryPRFeedbackHandlers.mockReturnValue({
+      data: [{ id: "handler-discussion", source: "SOURCE_PULL_REQUEST_DISCUSSION", healthy: true }],
+    });
+    useFactoryApps.mockReturnValue({ data: [{ id: "app-pr-closure", name: "PR Closure" }] });
+    const user = userEvent.setup();
+    renderLinesBoard();
+
+    await user.click(screen.getByTestId("column-automation-icon-handler-discussion"));
+    expect(screen.getByTestId("column-automation-row-handler-discussion")).toHaveTextContent(
+      "On pull request comment → Address the feedback",
+    );
+
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByTestId("column-automation-icon-closure-app-pr-closure"));
+    expect(screen.getByTestId("column-automation-row-closure-app-pr-closure")).toHaveTextContent(
+      "On pull request merged or closed → Complete the task",
+    );
   });
 
   it("names each Verify listener from its source", async () => {
@@ -818,10 +841,14 @@ describe("LinesPage board editing", () => {
     const user = userEvent.setup();
     renderLinesBoard();
 
-    await user.click(screen.getByTestId("lines-phase-menu-0"));
-    expect(screen.getByTestId("lines-phase-menu-0-edit")).toHaveTextContent("Edit Automation");
-    expect(screen.getByTestId("lines-phase-menu-0-edit-agent")).toHaveTextContent("Edit Agent");
-    await user.click(screen.getByTestId("lines-phase-menu-0-edit"));
+    await user.click(screen.getByTestId("column-automation-icon-step-0-app-refund-implementer"));
+    expect(screen.getByTestId("column-automation-step-0-app-refund-implementer-edit")).toHaveTextContent(
+      "Edit Automation",
+    );
+    expect(screen.getByTestId("column-automation-step-0-app-refund-implementer-edit-agent")).toHaveTextContent(
+      "Edit Agent",
+    );
+    await user.click(screen.getByTestId("column-automation-step-0-app-refund-implementer-edit"));
 
     expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
       factoryAppConfigurePath("org-1", PRIMARY_FACTORY_KEY, "app-refund-implementer", {
@@ -835,8 +862,8 @@ describe("LinesPage board editing", () => {
     const user = userEvent.setup();
     renderLinesBoard();
 
-    await user.click(screen.getByTestId("lines-phase-menu-0"));
-    await user.click(screen.getByTestId("lines-phase-menu-0-edit-agent"));
+    await user.click(screen.getByTestId("column-automation-icon-step-0-app-refund-implementer"));
+    await user.click(screen.getByTestId("column-automation-step-0-app-refund-implementer-edit-agent"));
 
     expect(screen.getByRole("heading", { level: 2, name: "Implement From Task Description" })).toBeInTheDocument();
     expect(screen.getByTestId("planning-review-nav-steps")).toHaveAttribute("aria-current", "page");
@@ -852,17 +879,19 @@ describe("LinesPage board editing", () => {
     const user = userEvent.setup();
     renderLinesBoard();
 
-    await user.click(screen.getByTestId("lines-phase-menu-0"));
-    expect(screen.getByTestId("lines-phase-menu-0-edit")).toHaveTextContent("Edit Automation");
-    expect(screen.queryByTestId("lines-phase-menu-0-edit-agent")).not.toBeInTheDocument();
+    await user.click(screen.getByTestId("column-automation-icon-step-0-app-refund-implementer"));
+    expect(screen.getByTestId("column-automation-step-0-app-refund-implementer-edit")).toHaveTextContent(
+      "Edit Automation",
+    );
+    expect(screen.queryByTestId("column-automation-step-0-app-refund-implementer-edit-agent")).not.toBeInTheDocument();
   });
 
   it("stages and commits the canvas agent on Save Agent", async () => {
     const user = userEvent.setup();
     renderLinesBoard();
 
-    await user.click(screen.getByTestId("lines-phase-menu-0"));
-    await user.click(screen.getByTestId("lines-phase-menu-0-edit-agent"));
+    await user.click(screen.getByTestId("column-automation-icon-step-0-app-refund-implementer"));
+    await user.click(screen.getByTestId("column-automation-step-0-app-refund-implementer-edit-agent"));
     await user.click(screen.getByTestId("planning-review-step-toggle-0"));
     const stepName = screen.getByTestId("planning-review-step-name-0");
     await user.clear(stepName);

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -431,6 +431,8 @@ describe("LinesPage board", () => {
     expect(screen.getByTestId(`column-automation-row-${GITHUB_ISSUES_INTAKE_ID}`)).toHaveTextContent(
       "On GitHub issue → Create a task in Backlog",
     );
+    expect(screen.queryByTestId("column-automation-hourly-chart")).not.toBeInTheDocument();
+    expect(screen.getByTestId("column-automation-activity")).toHaveTextContent("0 running");
 
     await user.keyboard("{Escape}");
     await user.click(screen.getByTestId("column-automation-icon-analysis-app-refund-backlog"));
@@ -499,6 +501,17 @@ describe("LinesPage board", () => {
     expect(screen.getByTestId("lines-test-location")).not.toHaveTextContent("configure=1");
   });
 
+  it("shows last-run activity on a phase automation from work-order executions", async () => {
+    useFactoryWorkOrders.mockReturnValue({ data: [BOARD_IMPLEMENT_FAILED_ORDER] });
+    const user = userEvent.setup();
+    renderLinesBoard();
+
+    await user.click(screen.getByTestId("column-automation-icon-step-0-app-refund-implementer"));
+
+    expect(screen.getByTestId("column-automation-activity")).toHaveTextContent("Failed");
+    expect(screen.queryByTestId("column-automation-hourly-chart")).not.toBeInTheDocument();
+  });
+
   it("opens the phase automation summary from the header icon", async () => {
     const user = userEvent.setup();
     renderLinesBoard();
@@ -509,6 +522,8 @@ describe("LinesPage board", () => {
     expect(screen.getByTestId("column-automation-row-step-0-app-refund-implementer")).toHaveTextContent(
       "On task in Phase 1 → Run the Phase 1 agent",
     );
+    expect(screen.queryByTestId("column-automation-hourly-chart")).not.toBeInTheDocument();
+    expect(screen.getByTestId("column-automation-activity")).toHaveTextContent("0 running");
     expect(screen.queryByTestId("column-automations-add")).not.toBeInTheDocument();
   });
 
@@ -535,12 +550,16 @@ describe("LinesPage board", () => {
     expect(screen.getByTestId("column-automation-row-handler-discussion")).toHaveTextContent(
       "On pull request comment → Address the feedback",
     );
+    expect(screen.getByTestId("column-automation-activity")).toHaveTextContent("0 running");
+    expect(screen.queryByTestId("column-automation-hourly-chart")).not.toBeInTheDocument();
 
     await user.keyboard("{Escape}");
     await user.click(screen.getByTestId("column-automation-icon-closure-app-pr-closure"));
     expect(screen.getByTestId("column-automation-row-closure-app-pr-closure")).toHaveTextContent(
       "On pull request merged or closed → Complete the task",
     );
+    expect(screen.getByTestId("column-automation-activity")).toHaveTextContent("0 running");
+    expect(screen.queryByTestId("column-automation-hourly-chart")).not.toBeInTheDocument();
   });
 
   it("names each Verify listener from its source", async () => {

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -419,6 +419,19 @@ describe("LinesPage board", () => {
     expect(screen.queryByTestId("lines-done-automations")).not.toBeInTheDocument();
   });
 
+  it("puts backlog automations before the create plus and column menu", () => {
+    useFactoryIntakes.mockReturnValue({ data: [GITHUB_ISSUES_INTAKE] });
+    renderLinesBoard();
+
+    const backlog = screen.getByTestId("lines-backlog-column");
+    const automations = within(backlog).getByTestId("lines-backlog-automations");
+    const create = within(backlog).getByTestId("lines-backlog-create");
+    const menu = within(backlog).getByTestId("lines-backlog-menu");
+
+    expect(automations.compareDocumentPosition(create) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(create.compareDocumentPosition(menu) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it("opens the backlog automations menu from the indicator", async () => {
     useFactoryIntakes.mockReturnValue({ data: [GITHUB_ISSUES_INTAKE] });
     useFactoryApps.mockReturnValue({ data: [{ id: "app-refund-backlog", name: "Ingest" }] });
@@ -594,8 +607,9 @@ describe("LinesPage board", () => {
     expect(screen.queryByTestId("lines-verify-listener-pr-feedback")).not.toBeInTheDocument();
     const verify = screen.getByTestId("lines-verify-column");
     const add = within(verify).getByTestId("lines-verify-add-pr-feedback");
+    const menu = within(verify).getByTestId("lines-verify-menu");
     expect(add.closest("[data-testid='lines-verify-listeners']")).toBeNull();
-    expect(within(add.parentElement as HTMLElement).getByTestId("lines-verify-menu")).toBeInTheDocument();
+    expect(add.compareDocumentPosition(menu) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     await user.click(add);
     expect(screen.getByTestId("add-pr-feedback-picker")).toBeInTheDocument();
     expect(screen.getByTestId("add-pr-feedback-template-checks")).toHaveTextContent("Pull request checks");

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -102,10 +102,8 @@ import {
   factoryAppConfigurePath,
   factoryAppRunPath,
   factoryHomePath,
-  factoryColumnAutomationsPath,
   factoryIntakePath,
   factoryPRFeedbackPath,
-  columnAutomationsKeyFromSearch,
   columnAutomationViewCanvasIdFromSearch,
   firstFactoryLineId,
   workOrderDetailPath,
@@ -129,7 +127,6 @@ import {
   columnAutomationOpenPath,
   catalogEntryToAutomation,
   catalogForColumn,
-  isColumnKey,
   takenCatalogIds,
   type ColumnAutomation,
   type ColumnAutomationCatalogEntry,
@@ -205,8 +202,6 @@ export function LinesPage() {
   const { search, state: locationState } = useLocation();
   const navigate = useNavigate();
   const showColumnAutomations = useFactoryPreviewFlag("columnAutomations");
-  const automationsColumnKeyRaw = columnAutomationsKeyFromSearch(search);
-  const automationsColumnKey = isColumnKey(automationsColumnKeyRaw) ? automationsColumnKeyRaw : null;
   const intakeOpen = isIntakeSearchOpen(search);
   const intakeId = intakeIdFromSearch(search);
   const intakeSettingsTab = intakeSettingsTabFromSearch(search);
@@ -504,7 +499,6 @@ export function LinesPage() {
             factoryIntakes={factoryIntakes}
             prFeedbackHandlers={prFeedbackHandlers}
             showColumnAutomations={showColumnAutomations}
-            automationsColumnKey={automationsColumnKey}
             onAddCatalogAutomation={(entry) => {
               if (entry.kind === "intake") {
                 const template = ADD_INTAKE_TEMPLATES.find((item) => item.id === entry.id);
@@ -645,7 +639,6 @@ function LineDetail({
   factoryIntakes,
   prFeedbackHandlers,
   showColumnAutomations,
-  automationsColumnKey,
   onAddCatalogAutomation,
   workOrderCardContext,
   peekOrder,
@@ -668,7 +661,6 @@ function LineDetail({
   factoryIntakes: FactoriesFactoryIntake[];
   prFeedbackHandlers: FactoriesFactoryPrFeedbackHandler[];
   showColumnAutomations: boolean;
-  automationsColumnKey: ColumnKey | null;
   onAddCatalogAutomation: (entry: ColumnAutomationCatalogEntry) => boolean;
   workOrderCardContext: WorkOrderCardContext;
   peekOrder?: FactoriesWorkOrder | null;
@@ -689,7 +681,7 @@ function LineDetail({
   const { factory } = useFactoriesLayout();
   const agentSession = useCreateWithAgentSession(workspacePlanningRepository(factory), organizationId, factoryId);
   const navigate = useNavigate();
-  const [addAutomationOpen, setAddAutomationOpen] = useState(false);
+  const [addAutomationKey, setAddAutomationKey] = useState<ColumnKey | null>(null);
   const [overlay, setOverlay] = useState<{
     extra: Record<string, ColumnAutomation[]>;
     disabledIds: string[];
@@ -711,34 +703,27 @@ function LineDetail({
     [apps, board, factoryIntakes, overlay, prFeedbackHandlers, workOrders],
   );
 
-  const openAutomations = (key: ColumnKey) => {
-    if (!line.id) {
-      return;
-    }
-    navigate(factoryColumnAutomationsPath(organizationId, factoryKey, line.id, key));
-  };
-
-  const closeAutomations = () => {
-    if (!line.id) {
-      return;
-    }
-    navigate(factoryHomePath(organizationId, factoryKey, line.id));
-  };
-
-  const openColumnTitle = automationsColumnKey
-    ? automationsColumnKey === "backlog"
+  const addColumnTitle = addAutomationKey
+    ? addAutomationKey === "backlog"
       ? "Backlog"
-      : automationsColumnKey === "verify"
+      : addAutomationKey === "verify"
         ? "Verify"
-        : automationsColumnKey === "done"
+        : addAutomationKey === "done"
           ? "Done"
-          : (board.find((column) => `phase-${column.stepIndex}` === automationsColumnKey)?.stepName ?? "Column")
+          : (board.find((column) => `phase-${column.stepIndex}` === addAutomationKey)?.stepName ?? "Column")
     : "";
-  const openAutomationsList = automationsColumnKey ? automationsFor(automationsColumnKey, openColumnTitle) : [];
-  const openCatalog = automationsColumnKey ? catalogForColumn(automationsColumnKey) : [];
+  const addAutomationsList = addAutomationKey ? automationsFor(addAutomationKey, addColumnTitle) : [];
+  const addCatalog = addAutomationKey ? catalogForColumn(addAutomationKey) : [];
 
   const handleRowAction = (automation: ColumnAutomation, action: ColumnAutomationRowAction) => {
     if (action === "settings") {
+      const href = columnAutomationOpenPath(automation, { organizationId, factoryKey, lineId: line.id });
+      if (href) {
+        navigate(href);
+      }
+      return;
+    }
+    if (action === "edit-agent") {
       const href = columnAutomationOpenPath(automation, { organizationId, factoryKey, lineId: line.id });
       if (href) {
         navigate(href);
@@ -768,16 +753,17 @@ function LineDetail({
   };
 
   const handleAddCatalog = (entry: ColumnAutomationCatalogEntry) => {
-    setAddAutomationOpen(false);
-    if (onAddCatalogAutomation(entry) || !automationsColumnKey) {
+    const key = addAutomationKey;
+    setAddAutomationKey(null);
+    if (onAddCatalogAutomation(entry) || !key) {
       return;
     }
-    const added = catalogEntryToAutomation(entry, openColumnTitle, `local-${entry.id}-${Date.now()}`);
+    const added = catalogEntryToAutomation(entry, addColumnTitle, `local-${entry.id}-${Date.now()}`);
     setOverlay((current) => ({
       ...current,
       extra: {
         ...current.extra,
-        [automationsColumnKey]: [...(current.extra[automationsColumnKey] ?? []), added],
+        [key]: [...(current.extra[key] ?? []), added],
       },
     }));
   };
@@ -786,11 +772,11 @@ function LineDetail({
     <div className="flex min-h-0 flex-1 flex-col" data-testid="lines-detail">
       {showColumnAutomations ? (
         <AddColumnAutomationPicker
-          open={addAutomationOpen}
-          onClose={() => setAddAutomationOpen(false)}
+          open={addAutomationKey !== null}
+          onClose={() => setAddAutomationKey(null)}
           onSelect={handleAddCatalog}
-          catalog={openCatalog}
-          takenIds={takenCatalogIds(openAutomationsList, openCatalog)}
+          catalog={addCatalog}
+          takenIds={takenCatalogIds(addAutomationsList, addCatalog)}
         />
       ) : null}
       {steps.length === 0 && backlogOrders.length === 0 && doneOrders.length === 0 ? (
@@ -818,12 +804,8 @@ function LineDetail({
           analyzingOrderIds={backlogAnalysis.analyzingOrderIds}
           showColumnAutomations={showColumnAutomations}
           automationsFor={automationsFor}
-          automationsOpenKey={automationsColumnKey}
-          onOpenAutomations={openAutomations}
-          onCloseAutomations={closeAutomations}
-          onAddAutomation={() => setAddAutomationOpen(true)}
+          onAddAutomation={setAddAutomationKey}
           onAutomationRowAction={handleRowAction}
-          automationsLockOpen={addAutomationOpen}
         />
       )}
       {peekOrderId && peekOrder ? (
@@ -1102,12 +1084,8 @@ function PhaseBoard({
   analyzingOrderIds,
   showColumnAutomations,
   automationsFor,
-  automationsOpenKey,
-  onOpenAutomations,
-  onCloseAutomations,
   onAddAutomation,
   onAutomationRowAction,
-  automationsLockOpen,
 }: {
   organizationId: string;
   factoryId: string;
@@ -1130,12 +1108,8 @@ function PhaseBoard({
   analyzingOrderIds: ReadonlySet<string>;
   showColumnAutomations: boolean;
   automationsFor: (key: ColumnKey, columnTitle: string) => ColumnAutomation[];
-  automationsOpenKey: ColumnKey | null;
-  onOpenAutomations: (key: ColumnKey) => void;
-  onCloseAutomations: () => void;
-  onAddAutomation: () => void;
+  onAddAutomation: (key: ColumnKey) => void;
   onAutomationRowAction: (automation: ColumnAutomation, action: ColumnAutomationRowAction) => void;
-  automationsLockOpen: boolean;
 }) {
   const [columnColors, setColumnColors] = useState<Record<string, LineBoardColumnColorId | null>>(() =>
     normalizeColumnColors(line.columnColors),
@@ -1251,12 +1225,8 @@ function PhaseBoard({
           intakePanel={intakePanel}
           onAddIntake={onAddIntake}
           automations={showColumnAutomations ? automationsFor("backlog", columnTitles.backlog ?? "Backlog") : undefined}
-          onOpenAutomations={showColumnAutomations ? () => onOpenAutomations("backlog") : undefined}
-          automationsOpen={automationsOpenKey === "backlog"}
-          onCloseAutomations={onCloseAutomations}
-          onAddAutomation={onAddAutomation}
+          onAddAutomation={showColumnAutomations ? () => onAddAutomation("backlog") : undefined}
           onAutomationRowAction={onAutomationRowAction}
-          automationsLockOpen={automationsLockOpen}
         />
       </div>
       {columns.map((column, index) => {
@@ -1288,12 +1258,8 @@ function PhaseBoard({
                   ? automationsFor(columnKey as ColumnKey, columnTitles[columnKey] ?? column.stepName)
                   : undefined
               }
-              onOpenAutomations={showColumnAutomations ? () => onOpenAutomations(columnKey as ColumnKey) : undefined}
-              automationsOpen={automationsOpenKey === columnKey}
-              onCloseAutomations={onCloseAutomations}
-              onAddAutomation={onAddAutomation}
+              onAddAutomation={showColumnAutomations ? () => onAddAutomation(columnKey as ColumnKey) : undefined}
               onAutomationRowAction={onAutomationRowAction}
-              automationsLockOpen={automationsLockOpen}
             />
           </div>
         );
@@ -1312,12 +1278,8 @@ function PhaseBoard({
           workOrderCardContext={workOrderCardContext}
           onOpenWorkOrder={onOpenWorkOrder}
           automations={showColumnAutomations ? automationsFor("verify", columnTitles.verify ?? "Verify") : undefined}
-          onOpenAutomations={showColumnAutomations ? () => onOpenAutomations("verify") : undefined}
-          automationsOpen={automationsOpenKey === "verify"}
-          onCloseAutomations={onCloseAutomations}
-          onAddAutomation={onAddAutomation}
+          onAddAutomation={showColumnAutomations ? () => onAddAutomation("verify") : undefined}
           onAutomationRowAction={onAutomationRowAction}
-          automationsLockOpen={automationsLockOpen}
         />
       </div>
       <div className={cn("relative flex min-h-0 self-stretch", workOrderKanbanLaneSizeClassName)}>
@@ -1332,12 +1294,8 @@ function PhaseBoard({
           workOrderCardContext={workOrderCardContext}
           onOpenWorkOrder={onOpenWorkOrder}
           automations={showColumnAutomations ? automationsFor("done", columnTitles.done ?? "Done") : undefined}
-          onOpenAutomations={showColumnAutomations ? () => onOpenAutomations("done") : undefined}
-          automationsOpen={automationsOpenKey === "done"}
-          onCloseAutomations={onCloseAutomations}
-          onAddAutomation={onAddAutomation}
+          onAddAutomation={showColumnAutomations ? () => onAddAutomation("done") : undefined}
           onAutomationRowAction={onAutomationRowAction}
-          automationsLockOpen={automationsLockOpen}
         />
       </div>
     </WorkOrderKanbanBoard>
@@ -1356,12 +1314,8 @@ function VerifyColumn({
   workOrderCardContext,
   onOpenWorkOrder,
   automations,
-  onOpenAutomations,
-  automationsOpen,
-  onCloseAutomations,
   onAddAutomation,
   onAutomationRowAction,
-  automationsLockOpen,
 }: {
   orders: FactoriesWorkOrder[];
   title: string;
@@ -1374,12 +1328,8 @@ function VerifyColumn({
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string, order?: FactoriesWorkOrder) => void;
   automations?: ColumnAutomation[];
-  onOpenAutomations?: () => void;
-  automationsOpen?: boolean;
-  onCloseAutomations?: () => void;
   onAddAutomation?: () => void;
   onAutomationRowAction?: (automation: ColumnAutomation, action: ColumnAutomationRowAction) => void;
-  automationsLockOpen?: boolean;
 }) {
   const surfaceClassName = lineBoardColumnLaneClassName(colorId);
 
@@ -1411,17 +1361,17 @@ function VerifyColumn({
           ) : null}
           <ColumnAutomationsHeaderSlot
             title={title}
-            columnKey="verify"
             automations={automations}
-            open={automationsOpen}
-            onOpen={onOpenAutomations}
-            onClose={onCloseAutomations}
-            onAdd={onAddAutomation}
             onRowAction={onAutomationRowAction}
-            lockOpen={automationsLockOpen}
             testId="lines-verify-automations"
           />
-          <ColumnLaneMenu title={title} testId="lines-verify-menu" colorId={colorId} onColorChange={onColorChange} />
+          <ColumnLaneMenu
+            title={title}
+            testId="lines-verify-menu"
+            onAddAutomation={onAddAutomation}
+            colorId={colorId}
+            onColorChange={onColorChange}
+          />
         </div>
       }
       banner={<LaneListenerList listeners={listeners} testId="lines-verify-listeners" />}
@@ -1452,12 +1402,8 @@ function DoneColumn({
   workOrderCardContext,
   onOpenWorkOrder,
   automations,
-  onOpenAutomations,
-  automationsOpen,
-  onCloseAutomations,
   onAddAutomation,
   onAutomationRowAction,
-  automationsLockOpen,
 }: {
   orders: FactoriesWorkOrder[];
   title: string;
@@ -1468,12 +1414,8 @@ function DoneColumn({
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string, order?: FactoriesWorkOrder) => void;
   automations?: ColumnAutomation[];
-  onOpenAutomations?: () => void;
-  automationsOpen?: boolean;
-  onCloseAutomations?: () => void;
   onAddAutomation?: () => void;
   onAutomationRowAction?: (automation: ColumnAutomation, action: ColumnAutomationRowAction) => void;
-  automationsLockOpen?: boolean;
 }) {
   const surfaceClassName = lineBoardColumnLaneClassName(colorId);
 
@@ -1493,17 +1435,17 @@ function DoneColumn({
         <div className="flex shrink-0 items-center gap-0.5">
           <ColumnAutomationsHeaderSlot
             title={title}
-            columnKey="done"
             automations={automations}
-            open={automationsOpen}
-            onOpen={onOpenAutomations}
-            onClose={onCloseAutomations}
-            onAdd={onAddAutomation}
             onRowAction={onAutomationRowAction}
-            lockOpen={automationsLockOpen}
             testId="lines-done-automations"
           />
-          <ColumnLaneMenu title={title} testId="lines-done-menu" colorId={colorId} onColorChange={onColorChange} />
+          <ColumnLaneMenu
+            title={title}
+            testId="lines-done-menu"
+            onAddAutomation={onAddAutomation}
+            colorId={colorId}
+            onColorChange={onColorChange}
+          />
         </div>
       }
       testId="lines-done-column"
@@ -1574,12 +1516,8 @@ function PhaseColumn({
   workOrderCardContext,
   onOpenWorkOrder,
   automations,
-  onOpenAutomations,
-  automationsOpen,
-  onCloseAutomations,
   onAddAutomation,
   onAutomationRowAction,
-  automationsLockOpen,
 }: {
   organizationId: string;
   factoryKey: string;
@@ -1595,12 +1533,8 @@ function PhaseColumn({
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string, order?: FactoriesWorkOrder) => void;
   automations?: ColumnAutomation[];
-  onOpenAutomations?: () => void;
-  automationsOpen?: boolean;
-  onCloseAutomations?: () => void;
   onAddAutomation?: () => void;
   onAutomationRowAction?: (automation: ColumnAutomation, action: ColumnAutomationRowAction) => void;
-  automationsLockOpen?: boolean;
 }) {
   const scrollRef = useRef<HTMLUListElement>(null);
   const [visibleCount, setVisibleCount] = useState(LINE_PHASE_RUNS_PAGE_SIZE);
@@ -1649,24 +1583,23 @@ function PhaseColumn({
           <div className="flex shrink-0 items-center gap-0.5">
             <ColumnAutomationsHeaderSlot
               title={title}
-              columnKey={`phase-${column.stepIndex}`}
               automations={automations}
-              open={automationsOpen}
-              onOpen={onOpenAutomations}
-              onClose={onCloseAutomations}
-              onAdd={onAddAutomation}
-              onRowAction={onAutomationRowAction}
-              lockOpen={automationsLockOpen}
+              canEditAgent={Boolean(agentEditor.agentNode)}
+              onRowAction={(automation, action) => {
+                if (action === "edit-agent") {
+                  agentEditor.openEditor();
+                  return;
+                }
+                onAutomationRowAction?.(automation, action);
+              }}
               testId={`lines-phase-${column.stepIndex}-automations`}
             />
             <ColumnLaneMenu
               title={title}
               testId={`lines-phase-menu-${column.stepIndex}`}
-              editHref={configureHref}
-              editLabel={configureHref ? "Edit Automation" : undefined}
-              onEditAgent={agentEditor.openEditor}
               onSetParallelism={configureHref ? () => setParallelismOpen(true) : undefined}
               parallelism={parallelism}
+              onAddAutomation={onAddAutomation}
               colorId={colorId}
               onColorChange={onColorChange}
             />

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -1587,7 +1587,7 @@ function PhaseColumn({
               canEditAgent={Boolean(agentEditor.agentNode)}
               onRowAction={(automation, action) => {
                 if (action === "edit-agent") {
-                  agentEditor.openEditor();
+                  agentEditor.openEditor?.();
                   return;
                 }
                 onAutomationRowAction?.(automation, action);

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -1347,6 +1347,12 @@ function VerifyColumn({
       className={surfaceClassName ? undefined : "bg-muted"}
       actions={
         <div className="flex shrink-0 items-center gap-0.5">
+          <ColumnAutomationsHeaderSlot
+            title={title}
+            automations={automations}
+            onRowAction={onAutomationRowAction}
+            testId="lines-verify-automations"
+          />
           {onAdd ? (
             <button
               type="button"
@@ -1359,12 +1365,6 @@ function VerifyColumn({
               <Plus className="size-3.5" aria-hidden />
             </button>
           ) : null}
-          <ColumnAutomationsHeaderSlot
-            title={title}
-            automations={automations}
-            onRowAction={onAutomationRowAction}
-            testId="lines-verify-automations"
-          />
           <ColumnLaneMenu
             title={title}
             testId="lines-verify-menu"

--- a/web_src/src/pages/factories/pages/PlanningReviewPopup.stories.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewPopup.stories.tsx
@@ -8,8 +8,8 @@ import { RunOverlayBoardBackdrop } from "./work-order-popup-redesign/popupShared
 const AUTOMATION_HREF = "/organizations/demo-org/factories/refunds/apps/app-refund-planner?configure=1";
 
 /**
- * Simple editing mode for one phase agent. Column menu action Edit Agent
- * opens this popup.
+ * Simple editing mode for one phase agent. The automation icon action
+ * Edit Agent opens this popup.
  */
 const meta = {
   title: "Factories/Pages/Planning Review",

--- a/web_src/src/pages/factories/pages/factoryPreviewFlagsContext.ts
+++ b/web_src/src/pages/factories/pages/factoryPreviewFlagsContext.ts
@@ -9,7 +9,7 @@ export interface FactoryPreviewFlags {
   /** Show Add intake in the Intake drawer. */
   addIntakeControl: boolean;
   /**
-   * Per-column Automations menu. On by default.
+   * Per-column automation icons in the header. On by default.
    * Set false to keep lane listener banners (legacy Storybook).
    */
   columnAutomations?: boolean;


### PR DESCRIPTION
## Summary

The column header showed one count for all automations. Operators could not see which automations were on the column.

Each automation now has its own header icon. Click the icon to see last-run status and the running count.

The create plus sits next to the column menu. Add automation stays in that menu.

## Test plan

- [ ] Open a line board that has backlog and phase automations.
- [ ] Confirm each automation has its own header icon.
- [ ] Click an icon and confirm last-run status and the running count.
- [ ] Confirm the create plus sits next to the three-dots menu.
- [ ] Open Add automation from the column menu.
- [ ] Open Edit Agent and Edit Automation from the popup when they apply.


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61713374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/superplane/-/pull-requests/superplanehq/superplane/7280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a></h2>

The PR is not yet safe to merge because automation icons can still display last-run activity from a different line or phase that reuses the same app.

<!-- /greptile_comment -->