### PR TITLE
fix: Use canonical SuperPlane workspace templates

### DIFF
--- a/pkg/grpc/actions/canvases/changesets/builder.go
+++ b/pkg/grpc/actions/canvases/changesets/builder.go
@@ -106,7 +106,9 @@ func (b *ChangesetBuilder) computeUpdateNodeChanges() ([]*Change, error) {
 
 	//
 	// If a node exists in both the current and the proposed,
-	// but it's not the exactly same node, we need an UPDATE_NODE operation for it.
+	// but it's not the exactly same node, we need an UPDATE_NODE operation
+	// for it. An implementation change cannot UPDATE in place: the publisher
+	// tears the old block down, so we emit DELETE_NODE then ADD_NODE.
 	//
 	for _, node := range b.proposedNodes {
 		currentNode, ok := b.currentNodes[node.ID]
@@ -115,6 +117,22 @@ func (b *ChangesetBuilder) computeUpdateNodeChanges() ([]*Change, error) {
 		}
 
 		if reflect.DeepEqual(currentNode, node) {
+			continue
+		}
+
+		if nodeImplementationChanged(currentNode, node) {
+			added, err := changeNodeRefForAdd(node)
+			if err != nil {
+				return nil, err
+			}
+
+			changes = append(changes, &Change{
+				Type: ChangeTypeDeleteNode,
+				Node: &ChangeNode{ID: node.ID},
+			}, &Change{
+				Type: ChangeTypeAddNode,
+				Node: added,
+			})
 			continue
 		}
 

--- a/pkg/grpc/actions/canvases/changesets/builder_test.go
+++ b/pkg/grpc/actions/canvases/changesets/builder_test.go
@@ -122,6 +122,49 @@ func Test__ChangesetBuilder(t *testing.T) {
 		steps.assertHasConnect("node-a", "node-c", "default")
 	})
 
+	t.Run("implementation change deletes and adds the same node", func(t *testing.T) {
+		steps := &ChangesetBuilderSteps{t: t}
+		steps.whenBuilding(
+			[]models.Node{
+				{
+					ID:   "planner-agent-no-issue",
+					Name: "Plan",
+					Type: models.NodeTypeComponent,
+					Ref: models.NodeRef{
+						Component: &models.ComponentRef{Name: "runnerClaudeCode"},
+					},
+					Configuration: map[string]any{"model": "sonnet"},
+				},
+			},
+			nil,
+			[]models.Node{
+				{
+					ID:   "planner-agent-no-issue",
+					Name: "Plan",
+					Type: models.NodeTypeComponent,
+					Ref: models.NodeRef{
+						Component: &models.ComponentRef{Name: "runnerSuperPlane"},
+					},
+					Configuration: map[string]any{"machineType": "e1-large-amd64"},
+				},
+			},
+			nil,
+		)
+
+		steps.assertNoError()
+		steps.assertOperationCount(2)
+		steps.assertHasDeleteNode("planner-agent-no-issue")
+		steps.assertHasAddNode(
+			"planner-agent-no-issue",
+			"Plan",
+			"runnerSuperPlane",
+			map[string]any{"machineType": "e1-large-amd64"},
+		)
+		require.Nil(t, steps.findNodeOperation(ChangeTypeUpdateNode, "planner-agent-no-issue"))
+		require.Equal(t, ChangeTypeDeleteNode, steps.changeset.Changes[0].Type)
+		require.Equal(t, ChangeTypeAddNode, steps.changeset.Changes[1].Type)
+	})
+
 	t.Run("invalid configuration for added node returns error", func(t *testing.T) {
 		steps := &ChangesetBuilderSteps{t: t}
 		steps.whenBuilding(

--- a/pkg/grpc/actions/canvases/changesets/canvas_publisher.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_publisher.go
@@ -310,8 +310,8 @@ func (p *CanvasPublisher) restoreDeletedNode(
 	existing.Name = replacement.Name
 	existing.Type = replacement.Type
 	existing.Ref = replacement.Ref
-	existing.Configuration = replacement.Configuration
-	existing.Metadata = replacement.Metadata
+	existing.Configuration = datatypes.NewJSONType(withoutAppSubscriptionID(replacement.Configuration.Data()))
+	existing.Metadata = datatypes.NewJSONType(withoutAppSubscriptionID(replacement.Metadata.Data()))
 	existing.Position = replacement.Position
 	existing.IsCollapsed = replacement.IsCollapsed
 	existing.AppInstallationID = appInstallationID
@@ -322,6 +322,8 @@ func (p *CanvasPublisher) restoreDeletedNode(
 	existing.ConcurrencyMax = replacement.ConcurrencyMax
 	existing.DeletedAt = gorm.DeletedAt{}
 	existing.UpdatedAt = &now
+	node.Configuration = withoutAppSubscriptionID(node.Configuration)
+	node.Metadata = withoutAppSubscriptionID(node.Metadata)
 
 	if err := p.tx.Unscoped().Save(&existing).Error; err != nil {
 		return err
@@ -663,4 +665,21 @@ func (p *CanvasPublisher) ensureNewNodeID(node models.Node) string {
 	node.ID = newNodeID
 	p.finalNodes[newNodeID] = node
 	return newNodeID
+}
+
+const appSubscriptionIDKey = "appSubscriptionID"
+
+func withoutAppSubscriptionID(values map[string]any) map[string]any {
+	if values == nil {
+		return nil
+	}
+
+	cleaned := make(map[string]any, len(values))
+	for key, value := range values {
+		if key == appSubscriptionIDKey {
+			continue
+		}
+		cleaned[key] = value
+	}
+	return cleaned
 }

--- a/pkg/grpc/actions/canvases/changesets/canvas_publisher.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_publisher.go
@@ -279,6 +279,14 @@ func (p *CanvasPublisher) addNode(ctx context.Context, change *Change) error {
 		newNode.StateReason = nil
 	}
 
+	deletedNode, err := models.FindUnscopedCanvasNode(p.tx, p.live.WorkflowID, nodeID)
+	if err == nil && deletedNode.DeletedAt.Valid {
+		return p.restoreDeletedNode(node, *deletedNode, appInstallationID, newNode)
+	}
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+
 	//
 	// Insert first so Setup() (and sibling lookups during a later Setup) can
 	// find the workflow_node row. Setup itself is deferred until every AddNode
@@ -289,19 +297,50 @@ func (p *CanvasPublisher) addNode(ctx context.Context, change *Change) error {
 		return err
 	}
 
-	p.allNodes[newNode.NodeID] = newNode
+	return p.rememberAddedNode(node, newNode)
+}
 
-	//
-	// If node is already in error state, no need to run Setup() for it.
-	//
-	if newNode.State == models.CanvasNodeStateError {
-		node.Metadata = newNode.Metadata.Data()
+func (p *CanvasPublisher) restoreDeletedNode(
+	node models.Node,
+	existing models.CanvasNode,
+	appInstallationID *uuid.UUID,
+	replacement models.CanvasNode,
+) error {
+	now := time.Now()
+	existing.Name = replacement.Name
+	existing.Type = replacement.Type
+	existing.Ref = replacement.Ref
+	existing.Configuration = replacement.Configuration
+	existing.Metadata = replacement.Metadata
+	existing.Position = replacement.Position
+	existing.IsCollapsed = replacement.IsCollapsed
+	existing.AppInstallationID = appInstallationID
+	existing.WebhookID = nil
+	existing.State = replacement.State
+	existing.StateReason = replacement.StateReason
+	existing.ConcurrencyKey = replacement.ConcurrencyKey
+	existing.ConcurrencyMax = replacement.ConcurrencyMax
+	existing.DeletedAt = gorm.DeletedAt{}
+	existing.UpdatedAt = &now
+
+	if err := p.tx.Unscoped().Save(&existing).Error; err != nil {
+		return err
+	}
+
+	return p.rememberAddedNode(node, existing)
+}
+
+func (p *CanvasPublisher) rememberAddedNode(node models.Node, canvasNode models.CanvasNode) error {
+	p.allNodes[canvasNode.NodeID] = canvasNode
+
+	if canvasNode.State == models.CanvasNodeStateError {
+		node.Metadata = canvasNode.Metadata.Data()
 		p.finalNodes[node.ID] = node
 		return nil
 	}
 
 	p.pendingSetups = append(p.pendingSetups, pendingNodeSetup{
-		canvasNode: newNode,
+		canvasNode: canvasNode,
 		draftID:    node.ID,
 	})
 	p.finalNodes[node.ID] = node

--- a/pkg/grpc/actions/canvases/changesets/canvas_publisher_test.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_publisher_test.go
@@ -672,7 +672,7 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 		require.Equal(t, existingError, *updatedVersionNode.ErrorMessage)
 	})
 
-	t.Run("update node rejects component changes", func(t *testing.T) {
+	t.Run("publish replaces a runner implementation and keeps the node id", func(t *testing.T) {
 		r := support.Setup(t)
 
 		now := time.Now()
@@ -727,25 +727,26 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 		require.NoError(t, err)
 
 		err = publisher.Publish(context.Background())
-		require.ErrorContains(t, err, "cannot change node node-a implementation; delete the node and add a new one instead")
+		require.NoError(t, err)
 
 		activeNodes, err := models.FindCanvasNodes(canvas.ID)
 		require.NoError(t, err)
 		activeNode := findCanvasNode(t, activeNodes, "node-a")
 		require.Equal(t, models.NodeTypeComponent, activeNode.Type)
-		require.Equal(t, "runnerBash", activeNode.Ref.Data().Component.Name)
-		require.NotNil(t, activeNode.WebhookID)
-		require.Equal(t, staleWebhookID, *activeNode.WebhookID)
+		require.Equal(t, "runnerPython", activeNode.Ref.Data().Component.Name)
 		require.Equal(t, models.CanvasNodeStateReady, activeNode.State)
+		if activeNode.WebhookID != nil {
+			require.NotEqual(t, staleWebhookID, *activeNode.WebhookID)
+		}
 
 		staleWebhookNodes, err := models.FindWebhookNodesInTransaction(database.Conn(), staleWebhookID)
 		require.NoError(t, err)
-		require.Len(t, staleWebhookNodes, 1)
+		require.Empty(t, staleWebhookNodes)
 
 		var staleWebhook models.Webhook
 		err = database.Conn().Unscoped().First(&staleWebhook, staleWebhookID).Error
 		require.NoError(t, err)
-		require.False(t, staleWebhook.DeletedAt.Valid)
+		require.True(t, staleWebhook.DeletedAt.Valid)
 	})
 
 	t.Run("update node allows assigning the first implementation to a placeholder component", func(t *testing.T) {
@@ -802,7 +803,7 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 		require.Nil(t, activeNode.StateReason)
 	})
 
-	t.Run("update node rejects widget changes", func(t *testing.T) {
+	t.Run("publish replaces a component with a widget and keeps the node id", func(t *testing.T) {
 		r := support.Setup(t)
 
 		canvas, _ := support.CreateCanvas(
@@ -833,13 +834,17 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 		require.NoError(t, err)
 
 		err = publisher.Publish(context.Background())
-		require.ErrorContains(t, err, "cannot change node node-a implementation; delete the node and add a new one instead")
+		require.NoError(t, err)
 
 		activeNodes, err := models.FindCanvasNodes(canvas.ID)
 		require.NoError(t, err)
-		activeNode := findCanvasNode(t, activeNodes, "node-a")
-		require.Equal(t, models.NodeTypeComponent, activeNode.Type)
-		require.Equal(t, "noop", activeNode.Ref.Data().Component.Name)
+		require.Empty(t, activeNodes)
+
+		publishedVersion, err := models.FindCanvasVersionInTransaction(database.Conn(), canvas.ID, draft.ID)
+		require.NoError(t, err)
+		updatedVersionNode := findVersionNode(t, publishedVersion.Nodes, "node-a")
+		require.Equal(t, models.NodeTypeWidget, updatedVersionNode.Type)
+		require.Equal(t, "group", updatedVersionNode.Ref.Widget.Name)
 	})
 
 	t.Run("update widget ignores deleted component tombstone", func(t *testing.T) {
@@ -903,7 +908,7 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 		require.Equal(t, "group", updatedVersionNode.Ref.Widget.Name)
 	})
 
-	t.Run("update node rejects widget implementation changes", func(t *testing.T) {
+	t.Run("publish replaces a widget implementation and keeps the node id", func(t *testing.T) {
 		r := support.Setup(t)
 
 		canvas, _ := support.CreateCanvas(
@@ -944,12 +949,13 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 		require.NoError(t, err)
 
 		err = publisher.Publish(context.Background())
-		require.ErrorContains(t, err, "cannot change node node-a implementation; delete the node and add a new one instead")
+		require.NoError(t, err)
 
-		publishedVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), canvas.ID)
+		publishedVersion, err := models.FindCanvasVersionInTransaction(database.Conn(), canvas.ID, draft.ID)
 		require.NoError(t, err)
 		updatedVersionNode := findVersionNode(t, publishedVersion.Nodes, "node-a")
-		require.Equal(t, "group", updatedVersionNode.Ref.Widget.Name)
+		require.Equal(t, "annotation", updatedVersionNode.Ref.Widget.Name)
+		require.Equal(t, "Widget After", updatedVersionNode.Name)
 	})
 
 	t.Run("add node with conflicting id rewrites id in db and published version", func(t *testing.T) {

--- a/pkg/grpc/actions/canvases/changesets/canvas_publisher_test.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_publisher_test.go
@@ -749,6 +749,62 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 		require.True(t, staleWebhook.DeletedAt.Valid)
 	})
 
+	t.Run("publish restore strips stale app subscription id from node metadata", func(t *testing.T) {
+		r := support.Setup(t)
+
+		staleSubscriptionID := uuid.New().String()
+		existingNode := componentCanvasNode("node-a", "Node A", "runnerBash", runnerConfiguration())
+		existingNode.Metadata = datatypes.NewJSONType(map[string]any{
+			"appSubscriptionID": staleSubscriptionID,
+			"keepMe":            "yes",
+		})
+
+		canvas, _ := support.CreateCanvas(
+			t,
+			r.Organization.ID,
+			r.User,
+			[]models.CanvasNode{existingNode},
+			nil,
+		)
+
+		draftNode := componentNode("node-a", "Node A", "runnerPython", runnerConfiguration())
+		draftNode.Metadata = map[string]any{
+			"appSubscriptionID": staleSubscriptionID,
+			"keepMe":            "yes",
+		}
+
+		draft, err := models.CreateCommitVersionWithSpecInTransaction(
+			database.Conn(),
+			canvas.ID,
+			r.User,
+			"Test commit",
+			[]models.Node{draftNode},
+			nil,
+		)
+		require.NoError(t, err)
+
+		liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), canvas.ID)
+		require.NoError(t, err)
+		publisher, err := NewCanvasPublisher(database.Conn(), canvas, draft, liveVersion, canvasPublisherOptions(r))
+		require.NoError(t, err)
+
+		err = publisher.Publish(context.Background())
+		require.NoError(t, err)
+
+		activeNodes, err := models.FindCanvasNodes(canvas.ID)
+		require.NoError(t, err)
+		activeNode := findCanvasNode(t, activeNodes, "node-a")
+		require.Equal(t, "runnerPython", activeNode.Ref.Data().Component.Name)
+		require.NotContains(t, activeNode.Metadata.Data(), "appSubscriptionID")
+		require.Equal(t, "yes", activeNode.Metadata.Data()["keepMe"])
+
+		publishedVersion, err := models.FindCanvasVersionInTransaction(database.Conn(), canvas.ID, draft.ID)
+		require.NoError(t, err)
+		updatedVersionNode := findVersionNode(t, publishedVersion.Nodes, "node-a")
+		require.NotContains(t, updatedVersionNode.Metadata, "appSubscriptionID")
+		require.Equal(t, "yes", updatedVersionNode.Metadata["keepMe"])
+	})
+
 	t.Run("update node allows assigning the first implementation to a placeholder component", func(t *testing.T) {
 		r := support.Setup(t)
 

--- a/pkg/grpc/actions/factories/intake_agent.go
+++ b/pkg/grpc/actions/factories/intake_agent.go
@@ -78,12 +78,17 @@ func defaultIntakeAgentModel(component string) string {
 	return intakeAgentSpecs[index].model
 }
 
-// resolveIntakeAgent picks the workspace agent. Credit without an installation
-// uses Run SuperPlane Agent.
+// resolveIntakeAgent picks the workspace agent. A SuperPlane harness from
+// setup uses Run SuperPlane Agent and ignores organization BYOK keys.
+// Older workspaces with no harness still fall back to those installations.
 func resolveIntakeAgent(tx *gorm.DB, factory *models.Factory) *intakeAgent {
 	config := factory.OnboardingConfigValue()
 	if agent := intakeAgentFromSetup(tx, factory, config.AgentIntegrationID); agent != nil {
 		return agent
+	}
+
+	if config.AgentHarness == models.FactoryOnboardingAgentHarnessSuperPlane {
+		return intakeAgentFromHostedProvider(tx, factory)
 	}
 
 	if agent := intakeAgentFromInstallations(tx, factory); agent != nil {

--- a/pkg/grpc/actions/factories/intake_agent_test.go
+++ b/pkg/grpc/actions/factories/intake_agent_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
 )
 
 func Test__ResolveIntakeAgent(t *testing.T) {
@@ -103,27 +104,28 @@ func Test__ResolveIntakeAgent(t *testing.T) {
 		assert.Equal(t, integrationName(t, organization.ID, claudeID), integrationRefName(t, agent))
 	})
 
+	t.Run("a SuperPlane harness ignores organization installations", func(t *testing.T) {
+		organization := support.CreateOrganization(t, r, r.User)
+		factory := newFactoryIn(t, organization.ID)
+		createReadyOnboardingIntegration(t, organization.ID, "claude")
+		enableHostedSuperPlaneAgent(t, db)
+
+		harness := models.FactoryOnboardingAgentHarnessSuperPlane
+		require.NoError(t, factory.UpdateOnboarding(db, models.FactoryOnboardingPatch{
+			AgentHarness: &harness,
+		}))
+
+		agent := resolveIntakeAgent(db, factory)
+		require.NotNil(t, agent)
+		assert.Equal(t, models.SuperPlaneRunnerComponent, agent.Component)
+		assert.Empty(t, agent.Credentials)
+		assert.Empty(t, agent.Model)
+	})
+
 	t.Run("an organization without an installation runs on the SuperPlane agent", func(t *testing.T) {
 		organization := support.CreateOrganization(t, r, r.User)
 		factory := newFactoryIn(t, organization.ID)
-		clearHostedLLMProviders(t, db)
-		_, err := models.UpsertHostedLLMProvider(db, models.HostedLLMProvider{
-			Provider:      models.UsageProviderAnthropic,
-			Enabled:       true,
-			APIKey:        []byte("test-hosted-key"),
-			AllowedModels: datatypes.JSONSlice[string]{"claude-haiku-4-6", "claude-opus-4-6", "claude-sonnet-4-6"},
-		})
-		require.NoError(t, err)
-		provider := models.UsageProviderAnthropic
-		model := "claude-sonnet-4-6"
-		_, err = models.UpdateInstallationLLMSettings(db, models.InstallationLLMSettings{
-			WelcomeGrantCents:     models.DefaultWelcomeGrantCents,
-			MarkupBPS:             models.DefaultMarkupBPS,
-			WarningThresholdBPS:   models.DefaultWarningThresholdBPS,
-			DefaultHostedProvider: &provider,
-			DefaultHostedModel:    &model,
-		})
-		require.NoError(t, err)
+		enableHostedSuperPlaneAgent(t, db)
 
 		agent := resolveIntakeAgent(db, factory)
 		require.NotNil(t, agent)
@@ -204,6 +206,29 @@ func Test__IntakeAgentModel(t *testing.T) {
 		agent := &intakeAgent{Component: "runnerBash"}
 		assert.Empty(t, agent.model())
 	})
+}
+
+func enableHostedSuperPlaneAgent(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	clearHostedLLMProviders(t, db)
+	_, err := models.UpsertHostedLLMProvider(db, models.HostedLLMProvider{
+		Provider:      models.UsageProviderAnthropic,
+		Enabled:       true,
+		APIKey:        []byte("test-hosted-key"),
+		AllowedModels: datatypes.JSONSlice[string]{"claude-haiku-4-6", "claude-opus-4-6", "claude-sonnet-4-6"},
+	})
+	require.NoError(t, err)
+	provider := models.UsageProviderAnthropic
+	model := "claude-sonnet-4-6"
+	_, err = models.UpdateInstallationLLMSettings(db, models.InstallationLLMSettings{
+		WelcomeGrantCents:     models.DefaultWelcomeGrantCents,
+		MarkupBPS:             models.DefaultMarkupBPS,
+		WarningThresholdBPS:   models.DefaultWarningThresholdBPS,
+		DefaultHostedProvider: &provider,
+		DefaultHostedModel:    &model,
+	})
+	require.NoError(t, err)
 }
 
 func integrationName(t *testing.T, organizationID uuid.UUID, integrationID string) string {

--- a/web_src/src/hooks/useCanvasStagingResync.ts
+++ b/web_src/src/hooks/useCanvasStagingResync.ts
@@ -20,11 +20,13 @@ interface UseCanvasStagingResyncOptions {
   setStagingResetNonce: Dispatch<SetStateAction<number>>;
 }
 
-type ResyncStagedOptions = {
+export type ResyncStagedOptions = {
   /** Bumps stagingResetNonce so file/console baselines reset. Avoid when entering edit from agent staging — it remounts CanvasPage and can loop auto-open. */
   bumpResetNonce?: boolean;
   /** When true, reuse a warm stagedCanvasSpec cache instead of forcing a refetch. */
   preferCachedStagedSpec?: boolean;
+  /** When aborted, skip applying the fetched spec to editor state and query cache. */
+  signal?: AbortSignal;
 };
 
 // Re-applies the staged (uncommitted) spec into React editor state after a remote
@@ -86,10 +88,19 @@ export function useCanvasStagingResync(options: UseCanvasStagingResyncOptions) {
         return;
       }
 
-      const inFlight = resyncStagedInFlightRef.current.get(versionId);
-      if (inFlight) {
-        await inFlight;
-        return;
+      const signal = options?.signal;
+      const shouldApply = () => signal == null || !signal.aborted;
+      // Signaled callers (Configure enter timeout) must not occupy the
+      // in-flight slot: abort skips apply, and a coalesced waiter would
+      // otherwise return without applying its own result.
+      const coalesceInFlight = signal == null;
+
+      if (coalesceInFlight) {
+        const inFlight = resyncStagedInFlightRef.current.get(versionId);
+        if (inFlight) {
+          await inFlight;
+          return;
+        }
       }
 
       const bumpResetNonce = options?.bumpResetNonce ?? true;
@@ -121,6 +132,9 @@ export function useCanvasStagingResync(options: UseCanvasStagingResyncOptions) {
           cachedStaged.metadata?.id === versionId &&
           cachedStagedQueryState?.isInvalidated !== true
         ) {
+          if (!shouldApply()) {
+            return;
+          }
           applyStagedSpec(versionId, cachedStaged.spec);
           return;
         }
@@ -134,6 +148,10 @@ export function useCanvasStagingResync(options: UseCanvasStagingResyncOptions) {
         const stagedVersion = await fetchStagedCanvasVersionWithSpec(canvasId, versionShell);
         const stagedSpec = stagedVersion?.spec ?? null;
 
+        if (!shouldApply()) {
+          return;
+        }
+
         // Apply editor state before updating the staged query cache so draft sync
         // effects cannot briefly overwrite resynced content with a stale snapshot.
         applyStagedSpec(versionId, stagedSpec);
@@ -145,11 +163,15 @@ export function useCanvasStagingResync(options: UseCanvasStagingResyncOptions) {
         }
       })();
 
-      resyncStagedInFlightRef.current.set(versionId, resyncPromise);
+      if (coalesceInFlight) {
+        resyncStagedInFlightRef.current.set(versionId, resyncPromise);
+      }
       try {
         await resyncPromise;
       } finally {
-        resyncStagedInFlightRef.current.delete(versionId);
+        if (coalesceInFlight) {
+          resyncStagedInFlightRef.current.delete(versionId);
+        }
       }
     },
     [

--- a/web_src/src/hooks/useCanvasStagingResync.ts
+++ b/web_src/src/hooks/useCanvasStagingResync.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { fetchStagedCanvasVersionWithSpec } from "@/pages/app/lib/repository-spec-files";
@@ -28,6 +28,82 @@ export type ResyncStagedOptions = {
   /** When aborted, skip applying the fetched spec to editor state and query cache. */
   signal?: AbortSignal;
 };
+
+function shouldApplyStagedResync(signal?: AbortSignal): boolean {
+  return signal == null || !signal.aborted;
+}
+
+type RunStagedEditorResyncParams = {
+  canvasId: string;
+  versionId: string;
+  bumpResetNonce: boolean;
+  preferCachedStagedSpec: boolean;
+  signal?: AbortSignal;
+  queryClient: QueryClient;
+  activeCanvasVersionIdRef: MutableRefObject<string>;
+  draftCanvasSpecsRef: MutableRefObject<Map<string, CanvasSpec>>;
+  consoleMutationGenerationRef: MutableRefObject<number>;
+  applyStagedSpec: (versionId: string, spec: CanvasSpec) => void;
+  setStagingResetNonce: Dispatch<SetStateAction<number>>;
+};
+
+async function runStagedEditorResync({
+  canvasId,
+  versionId,
+  bumpResetNonce,
+  preferCachedStagedSpec,
+  signal,
+  queryClient,
+  activeCanvasVersionIdRef,
+  draftCanvasSpecsRef,
+  consoleMutationGenerationRef,
+  applyStagedSpec,
+  setStagingResetNonce,
+}: RunStagedEditorResyncParams): Promise<void> {
+  if (activeCanvasVersionIdRef.current !== versionId) {
+    draftCanvasSpecsRef.current.delete(versionId);
+    return;
+  }
+
+  const versionShell = queryClient.getQueryData<CanvasesCanvasVersion>(canvasKeys.versionDetail(canvasId, versionId)) ??
+    queryClient.getQueryData<CanvasesCanvasVersion>(canvasKeys.versionDescribe(canvasId, versionId)) ?? {
+      metadata: { id: versionId },
+    };
+
+  const stagedCanvasSpecKey = canvasKeys.stagedCanvasSpec(canvasId);
+  const cachedStaged = preferCachedStagedSpec
+    ? queryClient.getQueryData<CanvasesCanvasVersion>(stagedCanvasSpecKey)
+    : undefined;
+  const cachedStagedQueryState = preferCachedStagedSpec ? queryClient.getQueryState(stagedCanvasSpecKey) : undefined;
+
+  if (cachedStaged?.spec && cachedStaged.metadata?.id === versionId && cachedStagedQueryState?.isInvalidated !== true) {
+    if (shouldApplyStagedResync(signal)) {
+      applyStagedSpec(versionId, cachedStaged.spec);
+    }
+    return;
+  }
+
+  consoleMutationGenerationRef.current += 1;
+  await queryClient.cancelQueries({ queryKey: stagedCanvasSpecKey });
+  queryClient.invalidateQueries({ queryKey: canvasKeys.canvasStaging(canvasId) });
+  queryClient.invalidateQueries({ queryKey: canvasKeys.stagedConsole(canvasId) });
+  queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFiles(canvasId) });
+
+  const stagedVersion = await fetchStagedCanvasVersionWithSpec(canvasId, versionShell);
+  if (!shouldApplyStagedResync(signal)) {
+    return;
+  }
+
+  // Apply editor state before updating the staged query cache so draft sync
+  // effects cannot briefly overwrite resynced content with a stale snapshot.
+  applyStagedSpec(versionId, stagedVersion?.spec ?? null);
+  await queryClient.cancelQueries({ queryKey: stagedCanvasSpecKey });
+  queryClient.setQueryData(stagedCanvasSpecKey, stagedVersion ?? null);
+
+  if (bumpResetNonce) {
+    setStagingResetNonce((nonce) => nonce + 1);
+  }
+}
 
 // Re-applies the staged (uncommitted) spec into React editor state after a remote
 // staging_updated event. The graph reads local state, not React Query, so query
@@ -89,7 +165,6 @@ export function useCanvasStagingResync(options: UseCanvasStagingResyncOptions) {
       }
 
       const signal = options?.signal;
-      const shouldApply = () => signal == null || !signal.aborted;
       // Signaled callers (Configure enter timeout) must not occupy the
       // in-flight slot: abort skips apply, and a coalesced waiter would
       // otherwise return without applying its own result.
@@ -103,65 +178,19 @@ export function useCanvasStagingResync(options: UseCanvasStagingResyncOptions) {
         }
       }
 
-      const bumpResetNonce = options?.bumpResetNonce ?? true;
-      const preferCachedStagedSpec = options?.preferCachedStagedSpec ?? false;
-
-      const resyncPromise = (async () => {
-        if (activeCanvasVersionIdRef.current !== versionId) {
-          draftCanvasSpecsRef.current.delete(versionId);
-          return;
-        }
-
-        const versionShell = queryClient.getQueryData<CanvasesCanvasVersion>(
-          canvasKeys.versionDetail(canvasId, versionId),
-        ) ??
-          queryClient.getQueryData<CanvasesCanvasVersion>(canvasKeys.versionDescribe(canvasId, versionId)) ?? {
-            metadata: { id: versionId },
-          };
-
-        const stagedCanvasSpecKey = canvasKeys.stagedCanvasSpec(canvasId);
-        const cachedStaged = preferCachedStagedSpec
-          ? queryClient.getQueryData<CanvasesCanvasVersion>(stagedCanvasSpecKey)
-          : undefined;
-        const cachedStagedQueryState = preferCachedStagedSpec
-          ? queryClient.getQueryState(stagedCanvasSpecKey)
-          : undefined;
-
-        if (
-          cachedStaged?.spec &&
-          cachedStaged.metadata?.id === versionId &&
-          cachedStagedQueryState?.isInvalidated !== true
-        ) {
-          if (!shouldApply()) {
-            return;
-          }
-          applyStagedSpec(versionId, cachedStaged.spec);
-          return;
-        }
-
-        consoleMutationGenerationRef.current += 1;
-        await queryClient.cancelQueries({ queryKey: stagedCanvasSpecKey });
-        queryClient.invalidateQueries({ queryKey: canvasKeys.canvasStaging(canvasId) });
-        queryClient.invalidateQueries({ queryKey: canvasKeys.stagedConsole(canvasId) });
-        queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFiles(canvasId) });
-
-        const stagedVersion = await fetchStagedCanvasVersionWithSpec(canvasId, versionShell);
-        const stagedSpec = stagedVersion?.spec ?? null;
-
-        if (!shouldApply()) {
-          return;
-        }
-
-        // Apply editor state before updating the staged query cache so draft sync
-        // effects cannot briefly overwrite resynced content with a stale snapshot.
-        applyStagedSpec(versionId, stagedSpec);
-        await queryClient.cancelQueries({ queryKey: stagedCanvasSpecKey });
-        queryClient.setQueryData(stagedCanvasSpecKey, stagedVersion ?? null);
-
-        if (bumpResetNonce) {
-          setStagingResetNonce((nonce) => nonce + 1);
-        }
-      })();
+      const resyncPromise = runStagedEditorResync({
+        canvasId,
+        versionId,
+        bumpResetNonce: options?.bumpResetNonce ?? true,
+        preferCachedStagedSpec: options?.preferCachedStagedSpec ?? false,
+        signal,
+        queryClient,
+        activeCanvasVersionIdRef,
+        draftCanvasSpecsRef,
+        consoleMutationGenerationRef,
+        applyStagedSpec,
+        setStagingResetNonce,
+      });
 
       if (coalesceInFlight) {
         resyncStagedInFlightRef.current.set(versionId, resyncPromise);

--- a/web_src/src/pages/app/factoryConfigureEnterSession.ts
+++ b/web_src/src/pages/app/factoryConfigureEnterSession.ts
@@ -29,6 +29,28 @@ type StartFactoryConfigureEnterOptions = {
   deps: FactoryConfigureEnterDeps;
 };
 
+/** Give the staged-spec fetch a short window, then open Configure on the seed. */
+export const FACTORY_CONFIGURE_ENTER_RESYNC_TIMEOUT_MS = 2000;
+
+async function awaitStagedResync(
+  resync: FactoryConfigureEnterDeps["resyncStagedEditorState"],
+  versionId: string,
+): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      resync(versionId, { bumpResetNonce: false }),
+      new Promise<void>((resolve) => {
+        timeoutId = setTimeout(resolve, FACTORY_CONFIGURE_ENTER_RESYNC_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
 /** Seed draft + await staged resync for one Configure visit. Returns cancel cleanup. */
 export function startFactoryConfigureEnter({
   visitId,
@@ -69,10 +91,11 @@ export function startFactoryConfigureEnter({
   setDraft(immediateSpec);
 
   // Await staged resync before enabling edit so a late applyStagedSpec cannot
-  // wipe edits typed against the immediate seed.
+  // wipe edits typed against the immediate seed. A hung repository-file fetch
+  // must not leave "Loading canvas..." forever: time-box it and keep the seed.
   void (async () => {
     try {
-      await resync(configureVersionId, { bumpResetNonce: false });
+      await awaitStagedResync(resync, configureVersionId);
     } catch {
       // Keep the immediate live/committed spec so Configure stays usable.
     }

--- a/web_src/src/pages/app/factoryConfigureEnterSession.ts
+++ b/web_src/src/pages/app/factoryConfigureEnterSession.ts
@@ -1,6 +1,8 @@
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 
+import type { ResyncStagedOptions } from "@/hooks/useCanvasStagingResync";
+
 export type FactoryConfigureEnterDeps = {
   activateCanvasVersionForEditing: (
     versionId: string,
@@ -9,10 +11,7 @@ export type FactoryConfigureEnterDeps = {
   ) => void;
   draftCanvasSpecsRef: MutableRefObject<Map<string, CanvasesCanvas["spec"] | null>>;
   previewingCurrentVersionRef: MutableRefObject<boolean>;
-  resyncStagedEditorState: (
-    versionId: string,
-    options?: { bumpResetNonce?: boolean; preferCachedStagedSpec?: boolean },
-  ) => Promise<void>;
+  resyncStagedEditorState: (versionId: string, options?: ResyncStagedOptions) => Promise<void>;
   setDraftCanvasSpec: Dispatch<SetStateAction<CanvasesCanvas["spec"] | null>>;
   setEditSessionActive: Dispatch<SetStateAction<boolean>>;
   setLastSavedWorkflowSnapshot: (workflow: CanvasesCanvas | null) => void;
@@ -35,15 +34,22 @@ export const FACTORY_CONFIGURE_ENTER_RESYNC_TIMEOUT_MS = 2000;
 async function awaitStagedResync(
   resync: FactoryConfigureEnterDeps["resyncStagedEditorState"],
   versionId: string,
+  abort: AbortController,
 ): Promise<void> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
-    await Promise.race([
-      resync(versionId, { bumpResetNonce: false }),
-      new Promise<void>((resolve) => {
-        timeoutId = setTimeout(resolve, FACTORY_CONFIGURE_ENTER_RESYNC_TIMEOUT_MS);
+    const winner = await Promise.race([
+      resync(versionId, { bumpResetNonce: false, signal: abort.signal }).then(
+        () => "resync" as const,
+        () => "resync" as const,
+      ),
+      new Promise<"timeout">((resolve) => {
+        timeoutId = setTimeout(() => resolve("timeout"), FACTORY_CONFIGURE_ENTER_RESYNC_TIMEOUT_MS);
       }),
     ]);
+    if (winner === "timeout") {
+      abort.abort();
+    }
   } finally {
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId);
@@ -75,6 +81,7 @@ export function startFactoryConfigureEnter({
   };
 
   let cancelled = false;
+  const resyncAbort = new AbortController();
   const {
     activateCanvasVersionForEditing: activate,
     draftCanvasSpecsRef: specsRef,
@@ -92,10 +99,11 @@ export function startFactoryConfigureEnter({
 
   // Await staged resync before enabling edit so a late applyStagedSpec cannot
   // wipe edits typed against the immediate seed. A hung repository-file fetch
-  // must not leave "Loading canvas..." forever: time-box it and keep the seed.
+  // must not leave "Loading canvas..." forever: time-box it, abort the apply,
+  // and keep the seed.
   void (async () => {
     try {
-      await awaitStagedResync(resync, configureVersionId);
+      await awaitStagedResync(resync, configureVersionId, resyncAbort);
     } catch {
       // Keep the immediate live/committed spec so Configure stays usable.
     }
@@ -114,6 +122,7 @@ export function startFactoryConfigureEnter({
 
   return () => {
     cancelled = true;
+    resyncAbort.abort();
     // Strict Mode remount: allow retry only when edit never enabled for visit.
     if (editEnabledVisitIdRef.current !== visitId && inFlightVisitIdRef.current === visitId) {
       inFlightVisitIdRef.current = null;

--- a/web_src/src/pages/app/mappers/index.spec.ts
+++ b/web_src/src/pages/app/mappers/index.spec.ts
@@ -174,6 +174,10 @@ describe("getExecutionDetails", () => {
         isCollapsed: false,
         configuration: {
           machineType: "e1-large-amd64",
+          steps: [
+            { name: "Clone repo", type: "bash" },
+            { name: "Implement", type: "prompt" },
+          ],
         },
         metadata: {},
       },
@@ -192,6 +196,7 @@ describe("getExecutionDetails", () => {
     });
 
     expect(props.customField).toBeDefined();
+    expect(props.factoryBody).toBeDefined();
     expect(getStateMap("runnerCodex")).toBe(RUNNER_STATE_REGISTRY.stateMap);
   });
 
@@ -205,6 +210,10 @@ describe("getExecutionDetails", () => {
         isCollapsed: false,
         configuration: {
           machineType: "e1-large-amd64",
+          steps: [
+            { name: "Clone repo", type: "bash" },
+            { name: "Implement", type: "prompt" },
+          ],
         },
         metadata: {},
       },
@@ -223,6 +232,43 @@ describe("getExecutionDetails", () => {
     });
 
     expect(props.customField).toBeDefined();
+    expect(props.factoryBody).toBeDefined();
     expect(getStateMap("runnerSuperPlane")).toBe(RUNNER_STATE_REGISTRY.stateMap);
+  });
+
+  it("resolves runnerOpenRouter mapper and state registry", () => {
+    const mapper = getComponentBaseMapper("runnerOpenRouter");
+    const props = mapper.props({
+      node: {
+        id: "node-openrouter-1",
+        name: "Run OpenRouter Agent",
+        componentName: "runnerOpenRouter",
+        isCollapsed: false,
+        configuration: {
+          machineType: "e1-large-amd64",
+          steps: [
+            { name: "Clone repo", type: "bash" },
+            { name: "Implement", type: "prompt" },
+          ],
+        },
+        metadata: {},
+      },
+      nodes: [],
+      componentDefinition: {
+        name: "runnerOpenRouter",
+        label: "Run OpenRouter Agent",
+        description: "Runs an OpenRouter-backed coding agent on a fleet runner",
+        icon: "code",
+        color: "#6366F1",
+      },
+      lastExecutions: [],
+      currentUser: undefined,
+      actions: { invokeNodeExecutionHook: async () => {} },
+      canvasMode: "live",
+    });
+
+    expect(props.customField).toBeDefined();
+    expect(props.factoryBody).toBeDefined();
+    expect(getStateMap("runnerOpenRouter")).toBe(RUNNER_STATE_REGISTRY.stateMap);
   });
 });

--- a/web_src/src/pages/app/mappers/index.ts
+++ b/web_src/src/pages/app/mappers/index.ts
@@ -275,7 +275,7 @@ import {
 import { filterMapper, FILTER_STATE_REGISTRY } from "./filter";
 import { forEachMapper, FOR_EACH_STATE_REGISTRY } from "./forEach";
 import { sshMapper, SSH_STATE_REGISTRY } from "./ssh";
-import { claudeCodeMapper, runnerMapper, RUNNER_STATE_REGISTRY } from "./runner";
+import { agentHarnessMapper, runnerMapper, RUNNER_STATE_REGISTRY } from "./runner";
 import { waitCustomFieldRenderer, waitMapper, WAIT_STATE_REGISTRY } from "./wait";
 import { approvalMapper, APPROVAL_STATE_REGISTRY } from "./approval";
 import { loopMapper, LOOP_STATE_REGISTRY } from "./loop";
@@ -318,10 +318,10 @@ const componentBaseMappers: Record<string, ComponentBaseMapper> = {
   runnerJS: runnerMapper,
   runnerBash: runnerMapper,
   runnerPython: runnerMapper,
-  runnerSuperPlane: runnerMapper,
-  runnerClaudeCode: claudeCodeMapper,
-  runnerCodex: runnerMapper,
-  runnerOpenRouter: runnerMapper,
+  runnerSuperPlane: agentHarnessMapper,
+  runnerClaudeCode: agentHarnessMapper,
+  runnerCodex: agentHarnessMapper,
+  runnerOpenRouter: agentHarnessMapper,
   timeGate: timeGateMapper,
   filter: filterMapper,
   forEach: forEachMapper,

--- a/web_src/src/pages/app/mappers/runner.tsx
+++ b/web_src/src/pages/app/mappers/runner.tsx
@@ -217,7 +217,7 @@ export const runnerMapper: ComponentBaseMapper = {
   },
 };
 
-export const claudeCodeMapper: ComponentBaseMapper = {
+export const agentHarnessMapper: ComponentBaseMapper = {
   ...runnerMapper,
   props(context: ComponentBaseContext): ComponentBaseProps {
     const props = runnerMapper.props(context);

--- a/web_src/src/pages/app/useFactoryConfigureEnter.spec.ts
+++ b/web_src/src/pages/app/useFactoryConfigureEnter.spec.ts
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { FACTORY_CONFIGURE_ENTER_RESYNC_TIMEOUT_MS } from "./factoryConfigureEnterSession";
 import { useFactoryConfigureEnter } from "./useFactoryConfigureEnter";
 
 function baseOptions(overrides: Partial<Parameters<typeof useFactoryConfigureEnter>[0]> = {}) {
@@ -25,6 +26,9 @@ function baseOptions(overrides: Partial<Parameters<typeof useFactoryConfigureEnt
 }
 
 describe("useFactoryConfigureEnter", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
   it("does not re-enter Configure when activateCanvasVersionForEditing identity changes before edit is enabled", async () => {
     const activateCanvasVersionForEditing = vi.fn();
     const resyncStagedEditorState = vi.fn(() => new Promise<void>(() => {}));
@@ -195,5 +199,28 @@ describe("useFactoryConfigureEnter", () => {
     await waitFor(() => {
       expect(activateCanvasVersionForEditing).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it("enables edit when staged resync does not finish in time", async () => {
+    vi.useFakeTimers();
+    const setEditSessionActive = vi.fn();
+    const resyncStagedEditorState = vi.fn(() => new Promise<void>(() => {}));
+
+    renderHook(() =>
+      useFactoryConfigureEnter(
+        baseOptions({
+          setEditSessionActive,
+          resyncStagedEditorState,
+        }),
+      ),
+    );
+
+    expect(setEditSessionActive).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(FACTORY_CONFIGURE_ENTER_RESYNC_TIMEOUT_MS);
+    });
+
+    expect(setEditSessionActive).toHaveBeenCalledWith(true);
   });
 });

--- a/web_src/src/pages/app/useFactoryConfigureEnter.spec.ts
+++ b/web_src/src/pages/app/useFactoryConfigureEnter.spec.ts
@@ -223,4 +223,60 @@ describe("useFactoryConfigureEnter", () => {
 
     expect(setEditSessionActive).toHaveBeenCalledWith(true);
   });
+
+  it("does not apply a late staged resync after the enter timeout", async () => {
+    vi.useFakeTimers();
+    const setEditSessionActive = vi.fn();
+    const setDraftCanvasSpec = vi.fn();
+    const lateSpec = { nodes: [{ id: "late" }], edges: [] };
+
+    const resyncStagedEditorState = vi.fn((_versionId: string, options?: { signal?: AbortSignal }) => {
+      return new Promise<void>((resolve) => {
+        const finish = () => {
+          if (!options?.signal?.aborted) {
+            setDraftCanvasSpec(lateSpec);
+          }
+          resolve();
+        };
+        const timeoutId = window.setTimeout(finish, 5000);
+        options?.signal?.addEventListener("abort", () => {
+          window.clearTimeout(timeoutId);
+          finish();
+        });
+      });
+    });
+
+    renderHook(() =>
+      useFactoryConfigureEnter(
+        baseOptions({
+          setEditSessionActive,
+          setDraftCanvasSpec,
+          resyncStagedEditorState,
+        }),
+      ),
+    );
+
+    expect(setDraftCanvasSpec).toHaveBeenCalled();
+    const seedCallCount = setDraftCanvasSpec.mock.calls.length;
+    expect(resyncStagedEditorState).toHaveBeenCalledWith(
+      "version-live",
+      expect.objectContaining({ bumpResetNonce: false, signal: expect.any(AbortSignal) }),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(FACTORY_CONFIGURE_ENTER_RESYNC_TIMEOUT_MS);
+    });
+
+    expect(setEditSessionActive).toHaveBeenCalledWith(true);
+    const lastCall = resyncStagedEditorState.mock.calls.at(-1);
+    const signal = lastCall?.[1]?.signal;
+    expect(signal?.aborted).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(setDraftCanvasSpec).toHaveBeenCalledTimes(seedCallCount);
+    expect(setDraftCanvasSpec.mock.calls.some((call) => call[0] === lateSpec)).toBe(false);
+  });
 });

--- a/web_src/src/pages/app/useFactoryConfigureSession.ts
+++ b/web_src/src/pages/app/useFactoryConfigureSession.ts
@@ -1,6 +1,8 @@
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { useEffect, useRef, useState, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 
+import type { ResyncStagedOptions } from "@/hooks/useCanvasStagingResync";
+
 import {
   runFactoryConfigureDiscard,
   runFactoryConfigureSave,
@@ -49,10 +51,7 @@ type UseFactoryConfigureSessionOptions = {
   ) => void;
   draftCanvasSpecsRef: MutableRefObject<Map<string, CanvasesCanvas["spec"] | null>>;
   setDraftCanvasSpec: Dispatch<SetStateAction<CanvasesCanvas["spec"] | null>>;
-  resyncStagedEditorState: (
-    versionId: string,
-    options?: { bumpResetNonce?: boolean; preferCachedStagedSpec?: boolean },
-  ) => Promise<void>;
+  resyncStagedEditorState: (versionId: string, options?: ResyncStagedOptions) => Promise<void>;
   setLastSavedWorkflowSnapshot: (workflow: CanvasesCanvas | null) => void;
   commitStagingPending: boolean;
   resetStagingPending: boolean;

--- a/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.spec.ts
@@ -116,7 +116,7 @@ describe("resolveOnboardingAgent", () => {
     ).toBeUndefined();
   });
 
-  it("prefers a connected provider over hosted credit", () => {
+  it("uses a connected provider when hosted credit has no default model", () => {
     expect(
       resolveOnboardingAgent({
         connected: connected("openai"),
@@ -124,6 +124,24 @@ describe("resolveOnboardingAgent", () => {
         hostedModels: { ...noHostedModels, openrouter: ["anthropic/claude-sonnet-4-6"] },
       })?.providerId,
     ).toBe("openai");
+  });
+
+  it("prefers hosted SuperPlane over a connected org provider when a default model is set", () => {
+    expect(
+      resolveOnboardingAgent({
+        connected: connected("claude"),
+        remainingCreditCents: 5000,
+        hostedModels: noHostedModels,
+        defaultHostedProvider: "anthropic",
+        defaultHostedModel: "claude-sonnet-4-6",
+      }),
+    ).toEqual({
+      component: "runnerSuperPlane",
+      credentialsSource: "hosted",
+      harness: "AGENT_HARNESS_SUPERPLANE",
+      model: "",
+      planningModel: "",
+    });
   });
 });
 

--- a/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.ts
@@ -85,11 +85,22 @@ export function resolveOnboardingAgent(args: {
   defaultHostedProvider?: string;
   defaultHostedModel?: string;
 }): OnboardingAgentPlan | undefined {
+  const hosted = hostedSuperPlanePlan(args);
+  if (hosted) return hosted;
+
   for (const providerId of AGENT_PROVIDER_IDS) {
     if (!args.connected.has(providerId)) continue;
     return planForConnectedProvider(providerId, args.hostedModels);
   }
 
+  return undefined;
+}
+
+function hostedSuperPlanePlan(args: {
+  remainingCreditCents: number;
+  defaultHostedProvider?: string;
+  defaultHostedModel?: string;
+}): OnboardingAgentPlan | undefined {
   if (args.remainingCreditCents <= 0) return undefined;
 
   const defaultProvider = args.defaultHostedProvider?.trim() ?? "";

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -48,9 +48,11 @@ import { useOnboardingGithubConnections } from "./useSelectNewGithubConnection";
 
 const ONBOARDING_INTEGRATIONS = ["github", ...AGENT_PROVIDER_IDS];
 
-// Onboarding never adopts an existing organization GitHub connection on its
-// own. The repository list must come from the account the user picked.
-const ONBOARDING_MANUAL_SELECTIONS = ["github"] as const;
+// Onboarding never adopts an existing organization GitHub or agent
+// connection on its own. GitHub repositories must come from the account the
+// user picked. Agent keys stay unselected so a new workspace can use the
+// canonical SuperPlane template when hosted credit is available.
+const ONBOARDING_MANUAL_SELECTIONS = ["github", ...AGENT_PROVIDER_IDS] as const;
 
 /**
  * Setup only needs the keys that make an agent run. The Anthropic admin key


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A new workspace in an existing organization used org Claude keys instead of the SuperPlane template. Reset to defaults then Save failed because commit tried to change the agent component in place. The SuperPlane runner node did not show its step list. Configure could stay on Loading canvas after create.

This change prefers hosted SuperPlane when credit and a default model exist. It shows configured steps on SuperPlane runner nodes. Commit now deletes and adds a node when the component type changes, and it keeps the same ID. Configure enter opens the canvas after two seconds if the staged-spec fetch hangs, and it aborts a late apply so edits stay. Restore after a component type change drops the old app subscription ID so Setup can subscribe again.

## Test plan

- [ ] Create a second workspace in an org that has Claude and hosted credit.
- [ ] Confirm Plan, Implement, and Backlog use Run SuperPlane Agent.
- [ ] Open Implement and confirm the agent node shows the step list.
- [ ] Reset Implement to factory defaults, then click Save. Confirm Save succeeds.
- [ ] Open Implement after create. Confirm the canvas does not stay on Loading canvas.
- [ ] After Configure opens from a slow staged fetch, edit a node. Confirm the late fetch does not revert the edit.
- [ ] Reset a subscription node to a new type, then Save. Confirm Setup creates a new subscription.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce661641-a51c-40fa-9b8e-05d0c54740dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce661641-a51c-40fa-9b8e-05d0c54740dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61727790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/superplane/-/pull-requests/superplanehq/superplane/7282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge.

<!-- /greptile_comment -->