### PR TITLE
fix: Wait for e2e API before first test

### DIFF
--- a/scripts/test_e2e_autoparallel.sh
+++ b/scripts/test_e2e_autoparallel.sh
@@ -18,7 +18,7 @@ fi
 all_tests=()
 while IFS= read -r file; do
   while IFS= read -r name; do
-    [[ -n "$name" ]] && all_tests+=("$name")
+    [[ -n "$name" && "$name" != "TestMain" ]] && all_tests+=("$name")
   done < <(awk '
     /^func[[:space:]]+Test[[:alnum:]_]*[[:space:]]*\(/ {
       line=$0

--- a/test/e2e/test_context.go
+++ b/test/e2e/test_context.go
@@ -1,10 +1,12 @@
 package e2e
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -74,6 +76,12 @@ func (s *TestContext) Start() {
 		os.Setenv("GITHUB_CLIENT_ID", "e2e-github-client-id")
 		os.Setenv("GITHUB_CLIENT_SECRET", "e2e-github-client-secret")
 	}
+	if os.Getenv("BLOB_STORAGE_PROVIDER") == "" {
+		os.Setenv("BLOB_STORAGE_PROVIDER", "filesystem")
+	}
+	if os.Getenv("BLOB_STORAGE_LOCAL_PATH") == "" {
+		os.Setenv("BLOB_STORAGE_LOCAL_PATH", filepath.Join(os.TempDir(), "superplane-e2e-blobs"))
+	}
 
 	s.AgentProvider = support.NewAgentProvider()
 	s.ResetAgentProvider()
@@ -130,8 +138,12 @@ func (s *TestContext) launchBrowser() {
 
 func (s *TestContext) startAppServer() {
 	go server.Start()
-	time.Sleep(500 * time.Millisecond)
 	s.baseURL = os.Getenv("BASE_URL")
+	// server.Start logs "SuperPlane is UP" before ListenAndServe. A fixed
+	// sleep races on CI: the first test then times out on /setup and, when
+	// that test reset owner setup, later tests in the shard stay on /setup.
+	waitForHTTP(s.baseURL+"/health", 60*time.Second)
+	waitForHTTP(s.baseURL+"/setup", 60*time.Second)
 }
 
 func (s *TestContext) Shutdown() {
@@ -160,16 +172,29 @@ func (s *TestContext) startVite() {
 	}
 
 	s.viteCmd = cmd
+	waitForHTTP("http://127.0.0.1:5173/", 60*time.Second)
+}
 
-	deadline := time.Now().Add(30 * time.Second)
+func waitForHTTP(url string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
 	for time.Now().Before(deadline) {
-		resp, err := http.Get("http://127.0.0.1:5173/")
+		resp, err := http.Get(url)
 		if err == nil {
 			resp.Body.Close()
-			break
+			if resp.StatusCode < 500 {
+				return
+			}
+			lastErr = fmt.Errorf("status %d", resp.StatusCode)
+		} else {
+			lastErr = err
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no response")
+	}
+	panic("wait for " + url + ": " + lastErr.Error())
 }
 
 const initScript = `


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`make test.e2e.autoparallel` can fail on Semaphore shard 4. The first test opens `/setup` before the API listens. Playwright then times out. That test also resets owner setup, so later tests in the same shard stay on the setup page.

This change waits for `/health` and `/setup` before any test runs. It also sets filesystem blob storage when those variables are empty, and it skips `TestMain` in the shard list.

## Test plan

- [x] Run shard 4 with `SHARD_INDEX=4 SHARD_COUNT=10 make test.e2e.autoparallel`
- [ ] Confirm Semaphore E2E shards pass on this branch
- [ ] Confirm the first test can open `/setup` after the wait
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85f851c5-0f41-448c-a45b-a7137e1b798c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85f851c5-0f41-448c-a45b-a7137e1b798c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

