### PR TITLE
docs: Require a Stable Factory GitHub App Tunnel

### DIFF
--- a/docs/contributing/connecting-to-3rdparty-services-from-development.md
+++ b/docs/contributing/connecting-to-3rdparty-services-from-development.md
@@ -82,24 +82,18 @@ that points at a stable public tunnel.
 
 ### 1. Start a stable tunnel
 
-Use one HTTPS URL that does not change across restarts. A new URL forces a
-new GitHub App or a full rewrite of the callback and webhook fields.
+The tunnel URL must be stable. A URL that changes on restart forces a new
+GitHub App or a rewrite of the callback and webhook fields.
 
-Prefer Cloudflare when ngrok blocks your account or shows an interstitial:
-
-```bash
-cloudflared tunnel --url http://localhost:8000
-```
-
-Copy the `https://<name>.trycloudflare.com` URL. Set both values in `.env`:
+Set both values in `.env` to the same HTTPS tunnel URL:
 
 ```env
-BASE_URL=https://<name>.trycloudflare.com
-WEBHOOKS_BASE_URL=https://<name>.trycloudflare.com
+BASE_URL=https://<stable-tunnel-url>
+WEBHOOKS_BASE_URL=https://<stable-tunnel-url>
 ```
 
-If you already have a stable ngrok domain, use that URL instead. See the
-ngrok steps above. Restart SuperPlane after you change these values.
+Restart SuperPlane after you change these values. See the tunnel steps
+above if you still need to expose `localhost:8000`.
 
 ### 2. Create a public GitHub App
 


### PR DESCRIPTION
## Summary

A changing tunnel URL breaks GitHub App callbacks and webhooks.
This change states that the factory GitHub App tunnel URL must be stable.
It removes vendor preference from the local setup guide.

## Test plan

- [ ] Open docs/contributing/connecting-to-3rdparty-services-from-development.md.
- [ ] Confirm the factory GitHub App section requires a stable tunnel URL.
- [ ] Confirm the section does not name a preferred tunnel vendor.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61760923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/superplane/-/pull-requests/superplanehq/superplane/7285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a></h2>

The documentation-only change appears safe to merge.

<!-- /greptile_comment -->