### PR TITLE
feat: Run OpenRouter Agent via OpenCode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,13 +100,14 @@ To run Runner nodes locally, start `make dev` in the runner repository.
 Compose defaults already point at that broker. Set `TASK_BROKER_*` in `.env`
 only for a remote broker (see `.env.example`).
 
-The runner `make dev` image includes Claude Code, Codex, git, `gh`, and `jq`.
+The runner `make dev` image includes Claude Code, Codex, OpenCode, git, `gh`, and `jq`.
 Factory line apps run on that worker. Do not install those CLIs on the host.
 Connect GitHub and Claude integrations in the organization before you dispatch
 a factory line. Factory nodes use those integrations, not `.env`
 `ANTHROPIC_API_KEY`. After you change the runner Dockerfile, run `make dev`
 again so Compose rebuilds the worker. Check tools with `make doctor-local` in
-the runner repository.
+the runner repository. OpenCode must be on the runner `PATH` for Run OpenRouter
+Agent. SuperPlane does not download OpenCode in the prompt prepare step.
 
 On first UI load, owner setup is enabled (`OWNER_SETUP_ENABLED=yes`), so you are
 prompted to create an admin account. Open registration is disabled by default

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,12 +67,13 @@ To run Runner nodes locally, start `make dev` in the runner repository.
 Compose defaults already point at that broker. Set `TASK_BROKER_*` in `.env`
 only for a remote broker (see `.env.example`).
 
-The runner `make dev` image includes Claude Code, Codex, git, `gh`, and `jq`
+The runner `make dev` image includes Claude Code, Codex, OpenCode, git, `gh`, and `jq`
 so factory line apps can run locally. Do not install those CLIs on the host.
 Connect GitHub and Claude integrations in the organization before you dispatch
 a factory line. Factory nodes use those integrations, not `.env`
 `ANTHROPIC_API_KEY`. After you change the runner Dockerfile, run `make dev`
 again in the runner repository. Check tools with `make doctor-local`.
+OpenCode must be on the runner `PATH` for Run OpenRouter Agent.
 
 ## Additional Development Resources
 

--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -1763,9 +1763,10 @@ function main() {
 
 **Component key:** `runnerOpenRouter`
 
-Runs a SuperPlane-shipped OpenRouter agent on a fleet runner. Prompt turns can use bash, read, edit, and write tools.
+Runs a SuperPlane OpenRouter agent on a fleet runner. The runner starts OpenCode with the selected OpenRouter model.
 
 ### Prerequisites
+- The `opencode` CLI is installed on the runner machine and available on `PATH`.
 - Node.js on the runner `PATH`.
 - An OpenRouter API key stored as a SuperPlane secret or an OpenRouter integration.
 
@@ -1773,7 +1774,7 @@ Runs a SuperPlane-shipped OpenRouter agent on a fleet runner. Prompt turns can u
 Configure an ordered list of **bash** and **prompt** steps:
 
 - **bash** — shell commands (clone a repo, install deps, run tests, push).
-- **prompt** — one OpenRouter agent loop in the same working directory (up to max turns).
+- **prompt** — one OpenCode turn in the same working directory. Later prompts continue one OpenCode session.
 
 ### Configuration
 - **Machine type**: Runner fleet registered on the task-broker (required).
@@ -1782,7 +1783,8 @@ Configure an ordered list of **bash** and **prompt** steps:
 - **Model**: Required. Select a model from Organization LLM Models.
 - **Working directory**: Optional starting directory.
 - **Execution timeout**: Optional wall-clock limit in seconds (1–86400). Defaults to **3600** (1 hour).
-- **Max turns per prompt**: Optional limit on model turns for each prompt step (1–256). Defaults to **128**. After this limit, SuperPlane asks for a final reply without tools.
+
+If OpenRouter rate-limits the selected model, SuperPlane continues the session on the next allowed OpenRouter model.
 
 Use **Run SuperPlane Agent** for SuperPlane-hosted credentials.
 

--- a/pkg/components/runner/environment.go
+++ b/pkg/components/runner/environment.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/superplanehq/superplane/pkg/configuration"
@@ -15,6 +16,11 @@ const (
 
 	EnvironmentValueSourceLiteral = "literal"
 	EnvironmentValueSourceSecret  = "secret"
+
+	// EnvExecutionTimeoutSeconds is the node wall-clock limit in seconds.
+	// OpenRouter wait/retry uses this so a 60s rate-limit pause cannot outlive
+	// the broker task timeout.
+	EnvExecutionTimeoutSeconds = "SUPERPLANE_EXECUTION_TIMEOUT_SECONDS"
 )
 
 // Runner tasks execute with a terminal attached, so commands like `git log`
@@ -355,4 +361,16 @@ func resolveExplicitEnvironment(secrets core.SecretsContext, environment []Envir
 	}
 
 	return resolved, nil
+}
+
+// AttachExecutionTimeoutEnv copies the node timeout into the task environment
+// so agent wrappers can cap waits before the broker kills the task.
+func AttachExecutionTimeoutEnv(environment []BrokerEnvironmentVariable, timeoutSeconds int) []BrokerEnvironmentVariable {
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = DefaultExecutionTimeoutSeconds
+	}
+	return append(environment, BrokerEnvironmentVariable{
+		Name:  EnvExecutionTimeoutSeconds,
+		Value: strconv.Itoa(timeoutSeconds),
+	})
 }

--- a/pkg/components/runner/environment_test.go
+++ b/pkg/components/runner/environment_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -308,6 +309,19 @@ func Test__ValidateEnvironmentFromConfigurationField(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+}
+
+func TestAttachExecutionTimeoutEnvUsesDefaultWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	got := AttachExecutionTimeoutEnv(nil, 0)
+	require.Len(t, got, 1)
+	assert.Equal(t, EnvExecutionTimeoutSeconds, got[0].Name)
+	assert.Equal(t, fmt.Sprintf("%d", DefaultExecutionTimeoutSeconds), got[0].Value)
+
+	got = AttachExecutionTimeoutEnv([]BrokerEnvironmentVariable{{Name: "KEEP", Value: "1"}}, 90)
+	require.Len(t, got, 2)
+	assert.Equal(t, "90", got[1].Value)
 }
 
 func strPtr(v string) *string {

--- a/pkg/components/runner/follow_up_loop.js
+++ b/pkg/components/runner/follow_up_loop.js
@@ -197,9 +197,7 @@ async function runLoop(helpers) {
 async function main() {
   const taskDir = readEnv("SUPERPLANE_TASK_DIR");
   const model = String(process.argv[2] || "").trim();
-  // Forward any additional argv (for example OpenRouter's max-turns) straight
-  // through to run.js so every runner's follow-up prompt uses the same
-  // arguments as its original prompt step.
+  // Forward extra argv so follow-up prompts match the original prompt step.
   const extraArgs = process.argv.slice(3);
   const code = await runLoop({
     waitOnce,

--- a/pkg/components/runner/openrouter/component.go
+++ b/pkg/components/runner/openrouter/component.go
@@ -149,6 +149,7 @@ func (c *RunOpenRouter) Execute(ctx core.ExecutionContext) error {
 	}
 
 	environment = runner.AttachPlanningSessionEnv(ctx, environment, spec.ExecutionTimeoutSeconds)
+	environment = runner.AttachExecutionTimeoutEnv(environment, spec.ExecutionTimeoutSeconds)
 
 	task := buildOpenRouterBrokerTask(spec, resolved.Usage, resolved.Setups, byokOpenRouterFallbackModels(ctx, spec.Model))
 	task = applyPlanningFollowUp(task, environment, spec)

--- a/pkg/components/runner/openrouter/component.go
+++ b/pkg/components/runner/openrouter/component.go
@@ -10,10 +10,9 @@ import (
 )
 
 const (
-	ComponentName        = "runnerOpenRouter"
-	FinishedEventType    = "runnerOpenRouter.finished"
-	envOpenRouterAPIKey  = "OPENROUTER_API_KEY"
-	envOpenRouterBaseURL = "OPENROUTER_BASE_URL"
+	ComponentName       = "runnerOpenRouter"
+	FinishedEventType   = "runnerOpenRouter.finished"
+	envOpenRouterAPIKey = "OPENROUTER_API_KEY"
 )
 
 func init() {
@@ -52,9 +51,10 @@ func (c *RunOpenRouter) Description() string {
 }
 
 func (c *RunOpenRouter) Documentation() string {
-	return `Runs a SuperPlane-shipped OpenRouter agent on a fleet runner. Prompt turns can use bash, read, edit, and write tools.
+	return `Runs a SuperPlane OpenRouter agent on a fleet runner. The runner starts OpenCode with the selected OpenRouter model.
 
 ## Prerequisites
+- The ` + "`opencode`" + ` CLI is installed on the runner machine and available on ` + "`PATH`" + `.
 - Node.js on the runner ` + "`PATH`" + `.
 - An OpenRouter API key stored as a SuperPlane secret or an OpenRouter integration.
 
@@ -62,7 +62,7 @@ func (c *RunOpenRouter) Documentation() string {
 Configure an ordered list of **bash** and **prompt** steps:
 
 - **bash** — shell commands (clone a repo, install deps, run tests, push).
-- **prompt** — one OpenRouter agent loop in the same working directory (up to max turns).
+- **prompt** — one OpenCode turn in the same working directory. Later prompts continue one OpenCode session.
 
 ## Configuration
 - **Machine type**: Runner fleet registered on the task-broker (required).
@@ -71,7 +71,8 @@ Configure an ordered list of **bash** and **prompt** steps:
 - **Model**: Required. Select a model from Organization LLM Models.
 - **Working directory**: Optional starting directory.
 - **Execution timeout**: Optional wall-clock limit in seconds (1–86400). Defaults to **3600** (1 hour).
-- **Max turns per prompt**: Optional limit on model turns for each prompt step (1–256). Defaults to **128**. After this limit, SuperPlane asks for a final reply without tools.
+
+If OpenRouter rate-limits the selected model, SuperPlane continues the session on the next allowed OpenRouter model.
 
 Use **Run SuperPlane Agent** for SuperPlane-hosted credentials.
 
@@ -101,24 +102,6 @@ func (c *RunOpenRouter) Configuration() []configuration.Field {
 		runner.EnvironmentFromConfigurationField(),
 		runner.AgentEnvironmentField(envOpenRouterAPIKey),
 		runner.AgentTimeoutField(),
-		maxTurnsField(),
-	}
-}
-
-func maxTurnsField() configuration.Field {
-	return configuration.Field{
-		Name:        "maxTurns",
-		Label:       "Max turns per prompt",
-		Type:        configuration.FieldTypeNumber,
-		Required:    false,
-		Default:     DefaultMaxTurns,
-		Description: "Maximum model turns for each prompt step. Defaults to 128. After this limit, SuperPlane asks for a final reply without tools.",
-		TypeOptions: &configuration.TypeOptions{
-			Number: &configuration.NumberTypeOptions{
-				Min: runner.IntPtr(0),
-				Max: runner.IntPtr(MaxTurnsLimit),
-			},
-		},
 	}
 }
 
@@ -167,11 +150,9 @@ func (c *RunOpenRouter) Execute(ctx core.ExecutionContext) error {
 
 	environment = runner.AttachPlanningSessionEnv(ctx, environment, spec.ExecutionTimeoutSeconds)
 
-	task := buildOpenRouterBrokerTask(spec, resolved.Usage, resolved.Setups)
+	task := buildOpenRouterBrokerTask(spec, resolved.Usage, resolved.Setups, byokOpenRouterFallbackModels(ctx, spec.Model))
 	task = applyPlanningFollowUp(task, environment, spec)
-	if runner.HasPlanningSessionToken(environment) {
-		task.Files = append(task.Files, runner.PlanningSessionMCPScriptFile())
-	}
+	task = attachPlanningSessionFiles(task, environment)
 	taskID, err := broker.CreateTask(runner.CreateTaskParams{
 		MachineType:    spec.MachineType,
 		Commands:       task.Commands,

--- a/pkg/components/runner/openrouter/fallback.go
+++ b/pkg/components/runner/openrouter/fallback.go
@@ -1,0 +1,77 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/superplanehq/superplane/pkg/components/runner"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+const fallbackModelsFileName = "openrouter_models.json"
+
+// OrderedFallbackModels puts the selected model first, then other allowlisted
+// ids in the given order. Duplicates and blank ids are dropped.
+func OrderedFallbackModels(selected string, allowed []string) []string {
+	selected = catalogModelID(selected)
+	seen := make(map[string]struct{}, len(allowed)+1)
+	out := make([]string, 0, len(allowed)+1)
+	if selected != "" {
+		out = append(out, selected)
+		seen[selected] = struct{}{}
+	}
+	for _, id := range allowed {
+		id = catalogModelID(id)
+		if id == "" {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+// FallbackModelsFile is the JSON list run.js reads when OpenRouter rate-limits.
+func FallbackModelsFile(selected string, allowed []string) runner.BrokerTaskFile {
+	models := OrderedFallbackModels(selected, allowed)
+	raw, err := json.Marshal(models)
+	if err != nil {
+		raw = []byte("[]")
+	}
+	return runner.BrokerTaskFile{
+		Path:    fallbackModelsFileName,
+		Content: string(raw) + "\n",
+		Mode:    "0644",
+	}
+}
+
+func catalogModelID(model string) string {
+	trimmed := strings.TrimSpace(model)
+	return strings.TrimPrefix(trimmed, "openrouter/")
+}
+
+func byokOpenRouterFallbackModels(ctx core.ExecutionContext, selected string) []string {
+	orgID, err := uuid.Parse(strings.TrimSpace(ctx.OrganizationID))
+	if err != nil {
+		return OrderedFallbackModels(selected, nil)
+	}
+	ids, err := models.ResolveSelectableLLMModels(
+		database.DB(context.Background()),
+		orgID,
+		nil,
+		models.UsageProviderOpenRouter,
+		models.UsageFundingSourceBYOK,
+	)
+	if err != nil {
+		return OrderedFallbackModels(selected, nil)
+	}
+	return OrderedFallbackModels(selected, ids)
+}

--- a/pkg/components/runner/openrouter/run.js
+++ b/pkg/components/runner/openrouter/run.js
@@ -142,7 +142,7 @@ function writeSessionID(taskDir, sessionID) {
 }
 
 function opencodeRunArgs({ model, sessionID, prompt, cwd }) {
-  const args = ["run", "--format", "json", "--auto", "--pure"];
+  const args = ["--pure", "run", "--format", "json", "--auto"];
   const prefixed = openRouterModelId(model);
   if (prefixed) {
     args.push("-m", prefixed);
@@ -203,6 +203,7 @@ function openCodeProcessEnv(taskDir, baseEnv = process.env) {
     ...baseEnv,
     OPENCODE_CONFIG: path.join(taskDir, "opencode.json"),
     OPENCODE_DISABLE_AUTOUPDATE: "1",
+    OPENCODE_PURE: "1",
     XDG_DATA_HOME: path.join(xdg, "data"),
     XDG_CONFIG_HOME: path.join(xdg, "config"),
     XDG_CACHE_HOME: path.join(xdg, "cache"),
@@ -299,19 +300,17 @@ async function runPrompt(promptFile, model, helpers = {}) {
       lastCost = spawnResult.cost;
     }
     lastErrorText = spawnResult.errorText || "";
-    const classKind = classifyOpenRouterError(lastErrorText);
-    const retryable = classKind === "rate_limit";
-    const hardFail = classKind === "hard";
     const spawnFailed = spawnResult.exitCode !== 0 || spawnResult.resultFailed;
-    if (!spawnFailed && !retryable) {
+    if (!spawnFailed) {
       failed = false;
       exitCode = spawnResult.exitCode;
       break;
     }
-    if (hardFail || !retryable) {
+    const classKind = classifyOpenRouterError(lastErrorText);
+    if (classKind !== "rate_limit") {
       failed = true;
       exitCode = spawnResult.exitCode !== 0 ? spawnResult.exitCode : 1;
-      if (lastErrorText && classKind !== "rate_limit") {
+      if (lastErrorText) {
         println(truncateText(lastErrorText));
       }
       break;
@@ -401,16 +400,33 @@ async function spawnOpenCodeTurn(args, env, cwd, formatter, helpers) {
     });
   }
 
-  const rl = readline.createInterface({ input: child.stdout, crlfDelay: Infinity });
-  rl.on("line", (raw) => formatter.handleLine(raw));
+  const stdout = child.stdout;
+  const rl = stdout ? readline.createInterface({ input: stdout, crlfDelay: Infinity }) : null;
+  if (rl) {
+    rl.on("line", (raw) => formatter.handleLine(raw));
+  }
+  const stdoutDone = rl
+    ? new Promise((resolve) => {
+        rl.on("close", resolve);
+      })
+    : Promise.resolve();
 
-  const exitCode = await Promise.all([
-    new Promise((resolve, reject) => {
-      child.on("error", reject);
+  let exitCode;
+  try {
+    exitCode = await new Promise((resolve, reject) => {
+      child.on("error", (err) => {
+        if (stdout && typeof stdout.destroy === "function") {
+          stdout.destroy();
+        }
+        reject(err);
+      });
       child.on("close", (code) => resolve(code == null ? 1 : code));
-    }),
-    new Promise((resolve) => rl.on("close", resolve)),
-  ]).then(([code]) => code);
+    });
+  } catch (err) {
+    await stdoutDone;
+    throw err;
+  }
+  await stdoutDone;
 
   const snapshot = formatter.snapshot();
   const errorText = [snapshot.errorText, stderrText].filter(Boolean).join("\n");
@@ -873,4 +889,6 @@ module.exports = {
   buildOpenCodeConfig,
   orderedFallbackModels,
   rateLimitWaitMs,
+  waitDeadlineMs,
+  openCodeProcessEnv,
 };

--- a/pkg/components/runner/openrouter/run.js
+++ b/pkg/components/runner/openrouter/run.js
@@ -2,105 +2,31 @@
 "use strict";
 
 /**
- * SuperPlane OpenRouter agent: bash, read, edit, write tools.
- * Planning sessions (SUPERPLANE_PLANNING_SESSION_ID set) drop edit/write and
- * add the propose_draft/survey planning tools instead.
+ * Run OpenCode against OpenRouter and format JSONL into live logs.
  *
- *   node run.js <prompt-file> [model] [max-turns]
+ *   node run.js <prompt-file> [model]
  */
 
 const fs = require("fs");
 const path = require("path");
-const { spawnSync } = require("child_process");
+const readline = require("readline");
+const { spawn } = require("child_process");
 
-const DEFAULT_MAX_TURNS = 128;
-const MAX_TURNS_LIMIT = 256;
-const BASE_SYSTEM_PROMPT =
-  "You are a coding agent on a SuperPlane fleet runner. Use bash, read, edit, and write tools. Write assistant messages as plain terminal text.";
+const TOOL_RESULT_MAX_CHARS = 800;
+const TOOL_RESULT_MAX_LINES = 24;
+const NEW_ACCOUNT_RPM_WAIT_MS = 60_000;
+const DEFAULT_WAIT_CAP_MS = 3_600_000;
+const FALLBACK_MODELS_FILE = "openrouter_models.json";
+const SESSION_FILE = "opencode_session";
+
 const PLANNING_SYSTEM_PROMPT =
-  "This is a SuperPlane planning session. Use the bash and read tools only to explore the repository for context; " +
-  "do not edit or write any files. Call propose_draft only when the user asked for a task in this turn. Call survey " +
-  "to ask questions. SuperPlane waits after you stop. Do not create work orders yourself. When the user creates or " +
-  "skips a draft, acknowledge that in one short sentence and ask what they want to do next. Do not call propose_draft " +
-  "unless they ask for a task. When the user starts a refine, read the current task, tell them you are ready, and " +
-  "ask what they want to change. Do not call propose_draft until they say what to change. Write to the user in plain " +
-  "text.";
-const WRAP_UP_PROMPT =
-  "You have no remaining tool turns. Do not call tools. Write a plain-text summary of what you completed and what remains.";
-const TOOL_NUDGE =
-  "Use the bash, read, edit, or write tools to do the work. Do not only describe the changes.";
-const TOOLS = [
-  {
-    type: "function",
-    function: {
-      name: "bash",
-      description: "Run a shell command in the current working directory.",
-      parameters: {
-        type: "object",
-        properties: { command: { type: "string" } },
-        required: ["command"],
-      },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "read",
-      description: "Read a UTF-8 text file.",
-      parameters: {
-        type: "object",
-        properties: { path: { type: "string" } },
-        required: ["path"],
-      },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "write",
-      description: "Write a UTF-8 text file, creating parent directories.",
-      parameters: {
-        type: "object",
-        properties: { path: { type: "string" }, content: { type: "string" } },
-        required: ["path", "content"],
-      },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "edit",
-      description: "Replace the first exact occurrence of old_text in a file with new_text.",
-      parameters: {
-        type: "object",
-        properties: {
-          path: { type: "string" },
-          old_text: { type: "string" },
-          new_text: { type: "string" },
-        },
-        required: ["path", "old_text", "new_text"],
-      },
-    },
-  },
-];
-// Planning sessions may only explore the repo (bash is documented read-only
-// in its tool description and the system prompt; edit/write are dropped
-// entirely so the model has no structured way to change files).
-const PLANNING_TOOLS = [
-  {
-    type: "function",
-    function: {
-      name: "bash",
-      description: "Run a read-only shell command (inspect files, search, run tests). Do not modify the repository.",
-      parameters: {
-        type: "object",
-        properties: { command: { type: "string" } },
-        required: ["command"],
-      },
-    },
-  },
-  TOOLS[1], // read
-];
+  "This is a SuperPlane planning session. Call the propose_draft tool only when the user asked for a task in this turn. " +
+  "Call the survey tool to ask questions. SuperPlane waits after you stop. Do not create work orders yourself. " +
+  "When the user creates or skips a draft, acknowledge that in one short sentence and ask what they want to do next. " +
+  "Do not call propose_draft unless they ask for a task. When the user starts a refine, read the current task, tell " +
+  "them you are ready, and ask what they want to change. Do not call propose_draft until they say what to change. " +
+  "Write to the user in plain text. Only explore the repository (read files, search, run read-only commands); do not " +
+  "edit or write any files.";
 
 function envFlag(env, name) {
   return Boolean(String((env && env[name]) || "").trim());
@@ -110,41 +36,192 @@ function planningEnabled(env = process.env) {
   return envFlag(env, "SUPERPLANE_PLANNING_SESSION_ID");
 }
 
-// The planning MCP server module is shipped alongside run.js only for
-// planning sessions (see runner.PlanningSessionMCPScriptFile). Reuse its
-// proposeDraft/proposeSurvey HTTP calls here instead of duplicating the
-// request contract.
-function loadPlanningHelpers(env = process.env) {
-  const taskDir = env.SUPERPLANE_TASK_DIR;
-  if (!taskDir) {
-    return null;
-  }
-  const script = path.join(taskDir, "planning_session_mcp.js");
-  if (!fs.existsSync(script)) {
-    return null;
-  }
-  return require(script);
+function catalogModelId(model) {
+  return String(model || "")
+    .trim()
+    .replace(/^openrouter\//, "");
 }
 
-function toFunctionTool(def) {
+function openRouterModelId(model) {
+  const trimmed = String(model || "").trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed.startsWith("openrouter/")) {
+    return trimmed;
+  }
+  return `openrouter/${trimmed}`;
+}
+
+function classifyOpenRouterError(text) {
+  const raw = String(text || "");
+  const lower = raw.toLowerCase();
+  if (
+    /invalid api key|incorrect api key|unauthorized|authentication|insufficient credit|insufficient credits|unknown model|model not found|context (length|window|overflow)|maximum context|prompt is too long/.test(
+      lower,
+    )
+  ) {
+    return "hard";
+  }
+  if (
+    /new-account-rpm|rate limit exceeded|rate limit reached|please retry shortly|\b429\b/.test(lower) ||
+    /too many requests/.test(lower)
+  ) {
+    return "rate_limit";
+  }
+  return "other";
+}
+
+function parseRetryAfterMs(text) {
+  const match = String(text || "").match(/retry-after:\s*(\d+)/i);
+  if (!match) {
+    return null;
+  }
+  const seconds = Number(match[1]);
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return null;
+  }
+  return seconds * 1000;
+}
+
+function rateLimitWaitMs(errorText) {
+  const fromHeader = parseRetryAfterMs(errorText);
+  if (fromHeader != null) {
+    return fromHeader;
+  }
+  return NEW_ACCOUNT_RPM_WAIT_MS;
+}
+
+function orderedFallbackModels(selected, allowed) {
+  const first = catalogModelId(selected);
+  const seen = new Set();
+  const out = [];
+  if (first) {
+    out.push(first);
+    seen.add(first);
+  }
+  const list = Array.isArray(allowed) ? allowed : [];
+  for (const raw of list) {
+    const id = catalogModelId(raw);
+    if (!id || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+function loadFallbackModels(taskDir, selected) {
+  const file = path.join(taskDir, FALLBACK_MODELS_FILE);
+  if (!fs.existsSync(file)) {
+    return orderedFallbackModels(selected, []);
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+    return orderedFallbackModels(selected, parsed);
+  } catch (_err) {
+    return orderedFallbackModels(selected, []);
+  }
+}
+
+function readSessionID(taskDir) {
+  const file = path.join(taskDir, SESSION_FILE);
+  if (!fs.existsSync(file)) {
+    return "";
+  }
+  return fs.readFileSync(file, "utf8").trim();
+}
+
+function writeSessionID(taskDir, sessionID) {
+  const id = String(sessionID || "").trim();
+  if (!id) {
+    return;
+  }
+  fs.writeFileSync(path.join(taskDir, SESSION_FILE), `${id}\n`);
+}
+
+function opencodeRunArgs({ model, sessionID, prompt, cwd }) {
+  const args = ["run", "--format", "json", "--auto", "--pure"];
+  const prefixed = openRouterModelId(model);
+  if (prefixed) {
+    args.push("-m", prefixed);
+  }
+  if (cwd) {
+    args.push("--dir", cwd);
+  }
+  if (sessionID) {
+    args.push("--session", sessionID);
+  }
+  args.push(prompt);
+  return args;
+}
+
+function buildOpenCodeConfig({ taskDir, env = process.env, planning = false } = {}) {
+  const config = {
+    $schema: "https://opencode.ai/config.json",
+    permission: planning
+      ? { "*": "allow", edit: "deny", question: "deny" }
+      : { "*": "allow" },
+  };
+  const options = {};
+  const apiKey = String((env && env.OPENROUTER_API_KEY) || "").trim();
+  const baseURL = String((env && env.OPENROUTER_BASE_URL) || "").trim();
+  if (apiKey) {
+    options.apiKey = apiKey;
+  }
+  if (baseURL) {
+    options.baseURL = baseURL;
+  }
+  if (Object.keys(options).length > 0) {
+    config.provider = { openrouter: { options } };
+  }
+  if (planning && taskDir) {
+    config.mcp = {
+      superplane: {
+        type: "local",
+        command: ["node", path.join(taskDir, "planning_session_mcp.js")],
+        enabled: true,
+      },
+    };
+  }
+  return config;
+}
+
+function writeOpenCodeConfig(taskDir, env) {
+  const config = buildOpenCodeConfig({
+    taskDir,
+    env,
+    planning: planningEnabled(env),
+  });
+  fs.writeFileSync(path.join(taskDir, "opencode.json"), `${JSON.stringify(config, null, 2)}\n`);
+}
+
+function openCodeProcessEnv(taskDir, baseEnv = process.env) {
+  const xdg = path.join(taskDir, "xdg");
   return {
-    type: "function",
-    function: { name: def.name, description: def.description, parameters: def.inputSchema },
+    ...baseEnv,
+    OPENCODE_CONFIG: path.join(taskDir, "opencode.json"),
+    OPENCODE_DISABLE_AUTOUPDATE: "1",
+    XDG_DATA_HOME: path.join(xdg, "data"),
+    XDG_CONFIG_HOME: path.join(xdg, "config"),
+    XDG_CACHE_HOME: path.join(xdg, "cache"),
   };
 }
 
-function planningToolDefs(helpers) {
-  const defs = (helpers && Array.isArray(helpers.TOOLS) && helpers.TOOLS) || [];
-  return [...PLANNING_TOOLS, ...defs.map(toFunctionTool)];
+function ensureXdgDirs(taskDir) {
+  for (const name of ["data", "config", "cache"]) {
+    fs.mkdirSync(path.join(taskDir, "xdg", name), { recursive: true });
+  }
 }
 
 function main() {
   const args = process.argv.slice(2);
   if (args.length < 1) {
-    console.error("usage: node run.js <prompt-file> [model] [max-turns]");
+    console.error("usage: node run.js <prompt-file> [model]");
     process.exit(2);
   }
-  runPrompt(args[0], args[1] || "", args[2])
+  runPrompt(args[0], args[1] || "")
     .then((code) => process.exit(code))
     .catch((err) => {
       console.error(err && err.message ? err.message : err);
@@ -152,134 +229,603 @@ function main() {
     });
 }
 
-async function runPrompt(promptFile, model, maxTurns = DEFAULT_MAX_TURNS) {
-  const resultFile = process.env.SUPERPLANE_RESULT_FILE;
+async function runPrompt(promptFile, model, helpers = {}) {
+  const env = helpers.env || process.env;
+  const sp = env.SUPERPLANE_TASK_DIR;
+  if (!sp) {
+    throw new Error("SUPERPLANE_TASK_DIR is required");
+  }
+  const resultFile = env.SUPERPLANE_RESULT_FILE;
   if (!resultFile) {
     throw new Error("SUPERPLANE_RESULT_FILE is required");
   }
-  const apiKey = process.env.OPENROUTER_API_KEY;
-  if (!apiKey) {
-    throw new Error("OPENROUTER_API_KEY is required");
-  }
-  if (!model) {
-    throw new Error("model is required");
-  }
 
-  const planning = planningEnabled(process.env);
-  const planningHelpers = planning ? loadPlanningHelpers(process.env) : null;
-  const tools = planning ? planningToolDefs(planningHelpers) : TOOLS;
+  let prompt = fs.readFileSync(promptFile, "utf8");
+  const promptCountPath = path.join(sp, "prompt_count");
+  const promptCount = Number.parseInt(fs.readFileSync(promptCountPath, "utf8").trim(), 10) || 0;
+  const startedAt = Date.now();
+  const now = helpers.now || Date.now;
+  const sleep = helpers.sleep || defaultSleep;
+  const cwd = helpers.cwd || process.cwd();
+  const planning = planningEnabled(env);
   if (planning) {
-    process.stdout.write("Planning session tools enabled\n");
-    process.stdout.write(`allowed tools: ${tools.map((tool) => tool.function.name).join(", ")}\n`);
+    println("Planning session tools enabled");
+    prompt = `${prompt}\n\n${PLANNING_SYSTEM_PROMPT}`;
   }
 
-  const prompt = fs.readFileSync(promptFile, "utf8");
-  const baseURL = (process.env.OPENROUTER_BASE_URL || "https://openrouter.ai/api/v1").replace(/\/$/, "");
-  const messages = [
-    { role: "system", content: planning ? PLANNING_SYSTEM_PROMPT : BASE_SYSTEM_PROMPT },
-    { role: "user", content: prompt },
-  ];
+  ensureXdgDirs(sp);
+  writeOpenCodeConfig(sp, env);
+  const childEnv = openCodeProcessEnv(sp, env);
 
-  const usage = {
+  const models = loadFallbackModels(sp, model);
+  let currentModel = models[0] || catalogModelId(model);
+  const usedThisWindow = new Set();
+  const deadline = waitDeadlineMs(env, now);
+  let lastResult = {};
+  let lastUsage = emptyUsage();
+  let lastCost = 0;
+  let sessionID = readSessionID(sp);
+  if (promptCount > 0 && sessionID) {
+    println("Continuing OpenCode session");
+  }
+
+  const telemetry = loadTurnTelemetry();
+  const formatter = createOpenCodeFormatter(telemetry, (id) => {
+    sessionID = id || sessionID;
+    writeSessionID(sp, sessionID);
+  });
+
+  let failed = false;
+  let exitCode = 0;
+  let lastErrorText = "";
+
+  while (true) {
+    const args = opencodeRunArgs({
+      model: currentModel,
+      sessionID: sessionID || undefined,
+      prompt,
+      cwd,
+    });
+    const spawnResult = await spawnOpenCodeTurn(args, childEnv, cwd, formatter, helpers);
+    if (spawnResult.sessionID) {
+      sessionID = spawnResult.sessionID;
+      writeSessionID(sp, sessionID);
+    }
+    if (spawnResult.usage && tokenTotal(spawnResult.usage) > 0) {
+      lastUsage = spawnResult.usage;
+      lastResult = spawnResult.lastEvent || lastResult;
+    }
+    if (spawnResult.cost != null) {
+      lastCost = spawnResult.cost;
+    }
+    lastErrorText = spawnResult.errorText || "";
+    const classKind = classifyOpenRouterError(lastErrorText);
+    const retryable = classKind === "rate_limit";
+    const hardFail = classKind === "hard";
+    const spawnFailed = spawnResult.exitCode !== 0 || spawnResult.resultFailed;
+    if (!spawnFailed && !retryable) {
+      failed = false;
+      exitCode = spawnResult.exitCode;
+      break;
+    }
+    if (hardFail || !retryable) {
+      failed = true;
+      exitCode = spawnResult.exitCode !== 0 ? spawnResult.exitCode : 1;
+      if (lastErrorText && classKind !== "rate_limit") {
+        println(truncateText(lastErrorText));
+      }
+      break;
+    }
+
+    usedThisWindow.add(catalogModelId(currentModel));
+    const nextModel = models.find((id) => !usedThisWindow.has(id));
+    if (nextModel) {
+      println(`Rate limit on ${catalogModelId(currentModel)} — switching to ${nextModel}`);
+      currentModel = nextModel;
+      continue;
+    }
+
+    const waitMs = rateLimitWaitMs(lastErrorText);
+    const remaining = deadline == null ? waitMs : Math.max(0, deadline - now());
+    if (remaining <= 0) {
+      failed = true;
+      exitCode = 1;
+      println("Rate limit wait exceeded the execution timeout");
+      break;
+    }
+    println("Rate limit notice — waiting to continue…");
+    await sleep(Math.min(waitMs, remaining));
+    usedThisWindow.clear();
+    currentModel = models[0] || currentModel;
+  }
+
+  formatter.flush(failed);
+  const usage = lastUsage;
+  if (tokenTotal(usage) > 0) {
+    telemetry.updateCurrentUsage(usage);
+  }
+  const payload = {
+    type: "result",
+    result: resultTextFrom(lastResult, formatter),
+    model: openRouterModelId(currentModel) || model,
+    usage,
+  };
+  if (lastCost) {
+    payload.total_cost_usd = lastCost;
+  }
+  telemetry.attachToResult(payload, { name: promptSeriesName(promptFile) });
+  fs.writeFileSync(resultFile, `${JSON.stringify(payload)}\n`);
+  accumulateLLMUsage(payload);
+  fs.writeFileSync(promptCountPath, `${promptCount + 1}\n`);
+  formatTurnResult({
+    is_error: failed,
+    num_turns: payload.telemetry && payload.telemetry.num_turns ? payload.telemetry.num_turns : 1,
+    duration_ms: Date.now() - startedAt,
+    total_cost_usd: payload.total_cost_usd,
+  });
+  return failed ? exitCode || 1 : 0;
+}
+
+function waitDeadlineMs(env, now) {
+  const seconds = Number((env && env.SUPERPLANE_EXECUTION_TIMEOUT_SECONDS) || 0);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return now() + DEFAULT_WAIT_CAP_MS;
+  }
+  return now() + seconds * 1000;
+}
+
+function defaultSleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function defaultSpawnOpenCode(args, options) {
+  return spawn("opencode", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: options.env,
+    cwd: options.cwd,
+  });
+}
+
+async function spawnOpenCodeTurn(args, env, cwd, formatter, helpers) {
+  if (formatter && typeof formatter.beginSpawn === "function") {
+    formatter.beginSpawn();
+  }
+  const spawnOpenCode = helpers.spawnOpenCode || defaultSpawnOpenCode;
+  const child = spawnOpenCode(args, { env, cwd });
+  let stderrText = "";
+  if (child.stderr) {
+    child.stderr.on("data", (chunk) => {
+      stderrText += String(chunk);
+    });
+  }
+
+  const rl = readline.createInterface({ input: child.stdout, crlfDelay: Infinity });
+  rl.on("line", (raw) => formatter.handleLine(raw));
+
+  const exitCode = await Promise.all([
+    new Promise((resolve, reject) => {
+      child.on("error", reject);
+      child.on("close", (code) => resolve(code == null ? 1 : code));
+    }),
+    new Promise((resolve) => rl.on("close", resolve)),
+  ]).then(([code]) => code);
+
+  const snapshot = formatter.snapshot();
+  const errorText = [snapshot.errorText, stderrText].filter(Boolean).join("\n");
+  return {
+    exitCode,
+    errorText,
+    resultFailed: snapshot.resultFailed,
+    sessionID: snapshot.sessionID,
+    usage: snapshot.usage,
+    cost: snapshot.cost,
+    lastEvent: snapshot.lastEvent,
+  };
+}
+
+function emptyUsage() {
+  return {
     input_tokens: 0,
     output_tokens: 0,
     cache_read_input_tokens: 0,
+    cache_creation_input_tokens: 0,
     reasoning_tokens: 0,
   };
-  let lastText = "";
-  let costMicros = 0;
-  let pendingToolCalls = false;
-  let nudgedForTools = false;
-  let numTurns = 0;
-  let exitCode = 1;
-  const startedAt = Date.now();
-  const turnLimit = resolveMaxTurns(maxTurns);
-  const telemetry = loadTurnTelemetry();
+}
 
-  try {
-    for (let turn = 0; turn < turnLimit; turn += 1) {
-      numTurns += 1;
-      const response = await chat(baseURL, apiKey, model, messages, true, tools);
-      addUsage(usage, response.usage);
-      costMicros += usageCostMicros(response.usage);
-
-      const message = (response.choices && response.choices[0] && response.choices[0].message) || {};
-      messages.push(message);
-      const text = assistantText(message);
-      telemetry.beginTurn(turnUsageFromResponse(response.usage), { message: text, forceNew: true });
-      if (text) {
-        lastText = text;
-        process.stdout.write(`${lastText}\n`);
-      }
-
-      const toolCalls = extractToolCalls(message);
-      pendingToolCalls = toolCalls.length > 0;
-      if (!pendingToolCalls) {
-        if (!planning && !nudgedForTools) {
-          nudgedForTools = true;
-          process.stderr.write("OpenRouter agent returned no tool calls; asking it to use tools\n");
-          messages.push({ role: "user", content: TOOL_NUDGE });
-          continue;
-        }
-        break;
-      }
-      for (const call of toolCalls) {
-        const name = call.function && call.function.name;
-        const args = parseArgs(call.function && call.function.arguments);
-        const kind = String(name || "tool").toLowerCase();
-        const toolStartedAt = Date.now();
-        writeLiveLogRecord(
-          telemetry.stampToolStart({
-            type: "tool_start",
-            id: call.id,
-            kind,
-            text: toolPreview(kind, args),
-            started_at: toolStartedAt,
-          }),
-        );
-        const result = await dispatchTool(name, args, { planning, planningHelpers });
-        if (result.output) {
-          process.stdout.write(`${result.output}\n`);
-        }
-        writeLiveLogRecord(
-          telemetry.stampToolEnd({
-            type: "tool_end",
-            id: call.id,
-            kind,
-            status: result.failed ? "failed" : "passed",
-            duration_ms: Math.max(0, Date.now() - toolStartedAt),
-          }),
-        );
-        messages.push({
-          role: "tool",
-          tool_call_id: call.id,
-          content: result.output,
-        });
-      }
-    }
-
-    if (pendingToolCalls) {
-      const wrapUp = await requestWrapUp(baseURL, apiKey, model, messages, usage, lastText, turnLimit);
-      lastText = wrapUp.text;
-      costMicros += wrapUp.costMicros;
-      numTurns += 1;
-      telemetry.beginTurn(turnUsageFromResponse(wrapUp.usage), { message: lastText, forceNew: true });
-    }
-    exitCode = 0;
+function tokenTotal(usage) {
+  if (!usage || typeof usage !== "object") {
     return 0;
-  } catch (err) {
-    console.error(err && err.message ? err.message : err);
-    exitCode = 1;
-    return 1;
-  } finally {
-    writeResult(resultFile, model, usage, costMicros, lastText, telemetry);
-    formatTurnResult({
-      is_error: exitCode !== 0,
-      num_turns: numTurns || 1,
-      total_cost_usd: costMicros > 0 ? costMicros / 1000000 : undefined,
-      duration_ms: Date.now() - startedAt,
-    });
   }
+  return (
+    Number(usage.input_tokens || 0) +
+    Number(usage.output_tokens || 0) +
+    Number(usage.cache_read_input_tokens || 0) +
+    Number(usage.cache_creation_input_tokens || 0) +
+    Number(usage.reasoning_tokens || 0)
+  );
+}
+
+function usageFromStepFinish(part) {
+  const tokens = (part && part.tokens) || {};
+  const cache = tokens.cache || {};
+  const usage = {
+    input_tokens: Number(tokens.input || 0),
+    output_tokens: Number(tokens.output || 0),
+    cache_read_input_tokens: Number(cache.read || 0),
+    cache_creation_input_tokens: Number(cache.write || 0),
+    reasoning_tokens: Number(tokens.reasoning || 0),
+  };
+  if (part && part.cost != null && Number.isFinite(Number(part.cost))) {
+    usage.total_cost_usd = Number(part.cost);
+  }
+  return usage;
+}
+
+function errorTextFromEvent(event) {
+  if (!event) {
+    return "";
+  }
+  if (typeof event.error === "string") {
+    return event.error;
+  }
+  const err = event.error && typeof event.error === "object" ? event.error : event;
+  const data = err.data && typeof err.data === "object" ? err.data : {};
+  return String(err.message || data.message || err.name || "").trim();
+}
+
+function resultTextFrom(lastEvent, formatter) {
+  if (formatter && typeof formatter.lastText === "function") {
+    const text = formatter.lastText();
+    if (text) {
+      return text;
+    }
+  }
+  const part = lastEvent && lastEvent.part;
+  if (part && typeof part.text === "string") {
+    return part.text;
+  }
+  return "";
+}
+
+function accumulateLLMUsage(payload) {
+  const taskDir = process.env.SUPERPLANE_TASK_DIR;
+  if (!taskDir) {
+    return;
+  }
+  const script = path.join(taskDir, "llm_usage.js");
+  if (!fs.existsSync(script)) {
+    return;
+  }
+  require(script).accumulate(taskDir, payload);
+}
+
+function loadTurnTelemetry() {
+  const taskDir = process.env.SUPERPLANE_TASK_DIR;
+  const candidates = [];
+  if (taskDir) {
+    candidates.push(path.join(taskDir, "turn_telemetry.js"));
+  }
+  candidates.push(path.join(__dirname, "..", "turn_telemetry.js"));
+  for (const file of candidates) {
+    if (fs.existsSync(file)) {
+      return require(file).createTurnTelemetry();
+    }
+  }
+  return require("../turn_telemetry").createTurnTelemetry();
+}
+
+function promptSeriesName(promptFile) {
+  const base = path.basename(promptFile || "", path.extname(promptFile || ""));
+  const words = base.replace(/^\d+-/, "").split("-").filter(Boolean);
+  if (words.length === 0) {
+    return "";
+  }
+  return words.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(" ");
+}
+
+function writeLiveLogRecord(rec) {
+  process.stdout.write(`${JSON.stringify(rec)}\n`);
+}
+
+function println(text = "") {
+  process.stdout.write(`${text}\n`);
+}
+
+function createOpenCodeFormatter(telemetry, onSession) {
+  const tracker = telemetry || loadTurnTelemetry();
+  const tools = createToolTracker(tracker);
+  let sessionID = "";
+  let resultFailed = false;
+  let errorText = "";
+  let lastText = "";
+  let lastEvent = {};
+  let usage = emptyUsage();
+  let cost = 0;
+  let roundOpen = false;
+
+  function rememberSession(event) {
+    const id = String((event && event.sessionID) || (event && event.part && event.part.sessionID) || "").trim();
+    if (!id) {
+      return;
+    }
+    sessionID = id;
+    if (onSession) {
+      onSession(id);
+    }
+  }
+
+  function beginRound(eventUsage, extra) {
+    tracker.beginTurn(eventUsage, extra);
+    roundOpen = true;
+  }
+
+  return {
+    beginSpawn() {
+      resultFailed = false;
+      errorText = "";
+    },
+    handleLine(raw) {
+      const line = String(raw || "").trim();
+      if (!line) {
+        return;
+      }
+      let event;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        println(line);
+        return;
+      }
+      if (!event || typeof event !== "object" || Array.isArray(event)) {
+        return;
+      }
+      this.handleEvent(event);
+    },
+    handleEvent(event) {
+      rememberSession(event);
+      lastEvent = event;
+      const type = String(event.type || "");
+      const part = event.part && typeof event.part === "object" ? event.part : {};
+      switch (type) {
+        case "step_start":
+          beginRound(undefined, {});
+          break;
+        case "text": {
+          const text = typeof part.text === "string" ? part.text : "";
+          if (text.trim()) {
+            lastText = text.replace(/\s+$/, "");
+            if (!roundOpen) {
+              beginRound(undefined, { message: lastText });
+            }
+            println(lastText);
+          }
+          break;
+        }
+        case "reasoning": {
+          const thinking = typeof part.text === "string" ? part.text : "";
+          if (thinking.trim()) {
+            println("Thinking");
+            println(truncateText(thinking.trim()));
+            println();
+          }
+          break;
+        }
+        case "tool_use":
+          if (!roundOpen) {
+            beginRound(undefined, { hasTools: true });
+          }
+          formatToolUse(part, tools);
+          break;
+        case "step_finish": {
+          usage = usageFromStepFinish(part);
+          if (part.cost != null && Number.isFinite(Number(part.cost))) {
+            cost = Number(part.cost);
+          }
+          if (!roundOpen) {
+            beginRound(usage, { message: lastText });
+          } else {
+            tracker.updateCurrentUsage(usage);
+          }
+          roundOpen = false;
+          break;
+        }
+        case "error": {
+          const text = errorTextFromEvent(event);
+          errorText = text;
+          if (classifyOpenRouterError(text) !== "rate_limit") {
+            resultFailed = true;
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    flush(failed) {
+      tools.flush(Boolean(failed));
+    },
+    snapshot() {
+      return {
+        sessionID,
+        resultFailed,
+        errorText,
+        usage,
+        cost,
+        lastEvent,
+      };
+    },
+    lastText() {
+      return lastText;
+    },
+    resultFailed() {
+      return resultFailed;
+    },
+  };
+}
+
+function createToolTracker(telemetry) {
+  const openTools = new Map();
+  const fifo = [];
+  let anonSeq = 0;
+
+  function resolveKey(id, creating) {
+    const key = id != null && String(id).trim() ? String(id).trim() : "";
+    if (key) {
+      return key;
+    }
+    if (creating) {
+      const generated = `anon-${anonSeq}`;
+      anonSeq += 1;
+      fifo.push(generated);
+      return generated;
+    }
+    return fifo.shift() || "";
+  }
+
+  return {
+    start(kind, text, id) {
+      const key = resolveKey(id, true);
+      const startedAt = Date.now();
+      openTools.set(key, { kind, text: text || kind, startedAt, emitted: false });
+      return key;
+    },
+    emitStart(id) {
+      let key = id != null && String(id).trim() ? String(id).trim() : "";
+      if (!key || !openTools.has(key)) {
+        key = fifo[0] || key;
+      }
+      const tool = openTools.get(key);
+      if (!tool || tool.emitted) {
+        return key;
+      }
+      tool.emitted = true;
+      writeLiveLogRecord(
+        telemetry.stampToolStart({
+          type: "tool_start",
+          id: key,
+          kind: tool.kind,
+          text: tool.text,
+          started_at: tool.startedAt,
+        }),
+      );
+      return key;
+    },
+    end(failed, id) {
+      this.emitStart(id);
+      let key = resolveKey(id, false);
+      if (!openTools.has(key)) {
+        key = fifo.shift() || key;
+      }
+      const tool = openTools.get(key);
+      if (!tool) {
+        return;
+      }
+      openTools.delete(key);
+      const fifoIndex = fifo.indexOf(key);
+      if (fifoIndex >= 0) {
+        fifo.splice(fifoIndex, 1);
+      }
+      writeLiveLogRecord(
+        telemetry.stampToolEnd({
+          type: "tool_end",
+          id: key,
+          kind: tool.kind,
+          status: failed ? "failed" : "passed",
+          duration_ms: Math.max(0, Date.now() - tool.startedAt),
+        }),
+      );
+    },
+    flush(failed) {
+      for (const key of [...openTools.keys()]) {
+        this.end(failed, key);
+      }
+    },
+  };
+}
+
+function formatToolUse(part, tools) {
+  const name = String(part.tool || part.name || "tool");
+  const kind = name.toLowerCase();
+  const state = part.state && typeof part.state === "object" ? part.state : {};
+  const id = part.callID || part.id || "";
+  const started = tools.start(kind, toolInputDetail(name, state.input) || kind, id);
+  tools.emitStart(started);
+  const output = typeof state.output === "string" ? state.output : "";
+  if (output.trim()) {
+    println(truncateText(output.replace(/\s+$/, "")));
+  } else if (state.error) {
+    const errText = typeof state.error === "string" ? state.error : JSON.stringify(state.error);
+    if (errText.trim()) {
+      println(truncateText(errText));
+    }
+  }
+  const failed = state.status === "error" || Boolean(state.error);
+  tools.end(failed, started);
+}
+
+function toolInputDetail(name, rawInput) {
+  if (rawInput == null || typeof rawInput !== "object" || Array.isArray(rawInput)) {
+    if (rawInput == null) {
+      return "";
+    }
+    return truncateText(String(rawInput));
+  }
+  const lowered = name.toLowerCase();
+  if (lowered === "bash") {
+    const command = rawInput.command;
+    if (typeof command === "string" && command.trim()) {
+      return command.trim().split(/\r?\n/).join(" ");
+    }
+  }
+  if (["read", "write", "edit", "notebookedit"].includes(lowered)) {
+    for (const key of ["file_path", "path", "notebook_path"]) {
+      const value = rawInput[key];
+      if (typeof value === "string" && value.trim()) {
+        let detail = value.trim();
+        if ((lowered === "write" || lowered === "edit") && typeof rawInput.content === "string") {
+          detail += ` (${rawInput.content.length} chars)`;
+        }
+        return detail;
+      }
+    }
+  }
+  if (lowered === "grep") {
+    const parts = [];
+    if (rawInput.pattern) {
+      parts.push(`pattern: ${rawInput.pattern}`);
+    }
+    if (rawInput.path) {
+      parts.push(`path: ${rawInput.path}`);
+    }
+    if (parts.length) {
+      return parts.join(" · ");
+    }
+  }
+  if (lowered === "glob" && rawInput.pattern) {
+    return String(rawInput.pattern);
+  }
+  try {
+    return truncateText(JSON.stringify(rawInput));
+  } catch {
+    return truncateText(String(rawInput));
+  }
+}
+
+function truncateText(text) {
+  let lines = String(text || "").split(/\r?\n/);
+  if (lines.length > TOOL_RESULT_MAX_LINES) {
+    const kept = lines.slice(0, TOOL_RESULT_MAX_LINES);
+    const omitted = lines.length - TOOL_RESULT_MAX_LINES;
+    text = `${kept.join("\n")}\n… (${omitted} more lines)`;
+    lines = text.split(/\r?\n/);
+  }
+  if (text.length > TOOL_RESULT_MAX_CHARS) {
+    text = `${text.slice(0, TOOL_RESULT_MAX_CHARS - 1).replace(/\s+$/, "")}…`;
+  }
+  return text;
 }
 
 function formatTurnResult(event) {
@@ -302,288 +848,29 @@ function formatTurnResult(event) {
   process.stdout.write(`${parts.join(" · ")}\n`);
 }
 
-function writeResult(resultFile, model, usage, costMicros, lastText, telemetry) {
-  const payload = {
-    type: "result",
-    result: lastText,
-    model,
-    usage,
-  };
-  if (costMicros > 0) {
-    payload.total_cost_usd = costMicros / 1000000;
+function formatOpenCodeJsonLines(rawLines) {
+  const formatter = createOpenCodeFormatter(loadTurnTelemetry());
+  for (const line of rawLines) {
+    formatter.handleLine(line);
   }
-  if (telemetry) {
-    telemetry.attachToResult(payload);
-  }
-  fs.writeFileSync(resultFile, `${JSON.stringify(payload)}\n`);
-  accumulateLLMUsage(payload);
-}
-
-function loadTurnTelemetry() {
-  const taskDir = process.env.SUPERPLANE_TASK_DIR;
-  const candidates = [];
-  if (taskDir) {
-    candidates.push(path.join(taskDir, "turn_telemetry.js"));
-  }
-  candidates.push(path.join(__dirname, "..", "turn_telemetry.js"));
-  for (const file of candidates) {
-    if (fs.existsSync(file)) {
-      return require(file).createTurnTelemetry();
-    }
-  }
-  return require("../turn_telemetry").createTurnTelemetry();
-}
-
-function resolveMaxTurns(maxTurns) {
-  const n = Number(maxTurns);
-  if (!(n > 0)) {
-    return DEFAULT_MAX_TURNS;
-  }
-  return Math.min(Math.floor(n), MAX_TURNS_LIMIT);
-}
-
-function extractToolCalls(message) {
-  if (!message) {
-    return [];
-  }
-  if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
-    return message.tool_calls;
-  }
-  if (message.function_call && message.function_call.name) {
-    return [
-      {
-        id: String(message.function_call.name) + "-legacy",
-        type: "function",
-        function: message.function_call,
-      },
-    ];
-  }
-  if (!Array.isArray(message.content)) {
-    return [];
-  }
-  const calls = [];
-  for (const part of message.content) {
-    const fn = (part && (part.functionCall || part.function_call)) || null;
-    if (!fn || !fn.name) {
-      continue;
-    }
-    const rawArgs = fn.arguments || fn.args || {};
-    calls.push({
-      id: String(fn.id || fn.name),
-      type: "function",
-      function: {
-        name: fn.name,
-        arguments: typeof rawArgs === "string" ? rawArgs : JSON.stringify(rawArgs),
-      },
-    });
-  }
-  return calls;
-}
-
-function assistantText(message) {
-  if (!message || !message.content) {
-    return "";
-  }
-  if (Array.isArray(message.content)) {
-    return message.content.map((part) => part.text || "").join("");
-  }
-  return String(message.content);
-}
-
-async function requestWrapUp(baseURL, apiKey, model, messages, usage, lastText, turnLimit) {
-  process.stderr.write(
-    `OpenRouter agent reached ${turnLimit} turns; requesting a final response without tools\n`,
-  );
-  messages.push({ role: "user", content: WRAP_UP_PROMPT });
-  const response = await chat(baseURL, apiKey, model, messages, false);
-  addUsage(usage, response.usage);
-  const message = (response.choices && response.choices[0] && response.choices[0].message) || {};
-  const text = assistantText(message);
-  if (text) {
-    process.stdout.write(`${text}\n`);
-  }
-  return {
-    text: text || lastText,
-    costMicros: usageCostMicros(response.usage),
-    usage: response.usage,
-  };
-}
-
-function turnUsageFromResponse(usage) {
-  const turn = {
-    input_tokens: 0,
-    output_tokens: 0,
-    cache_read_input_tokens: 0,
-    reasoning_tokens: 0,
-  };
-  addUsage(turn, usage);
-  const costMicros = usageCostMicros(usage);
-  if (costMicros > 0) {
-    turn.total_cost_usd = costMicros / 1000000;
-  }
-  return turn;
-}
-
-async function chat(baseURL, apiKey, model, messages, withTools, tools = TOOLS) {
-  const payload = {
-    model,
-    messages,
-    usage: { include: true },
-  };
-  if (withTools) {
-    payload.tools = tools;
-    payload.tool_choice = "auto";
-    payload.provider = { require_parameters: true };
-  }
-  const response = await fetch(`${baseURL}/chat/completions`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(payload),
-  });
-  const body = await response.json();
-  if (!response.ok) {
-    throw new Error(body.error && body.error.message ? body.error.message : `OpenRouter HTTP ${response.status}`);
-  }
-  return body;
-}
-
-function addUsage(total, usage) {
-  if (!usage) {
-    return;
-  }
-  total.input_tokens += Number(usage.prompt_tokens || usage.input_tokens || 0);
-  total.output_tokens += Number(usage.completion_tokens || usage.output_tokens || 0);
-  const details = usage.prompt_tokens_details || {};
-  total.cache_read_input_tokens += Number(details.cached_tokens || usage.cache_read_input_tokens || 0);
-  const completionDetails = usage.completion_tokens_details || {};
-  total.reasoning_tokens += Number(completionDetails.reasoning_tokens || usage.reasoning_tokens || 0);
-}
-
-function usageCostMicros(usage) {
-  if (!usage || usage.cost == null) {
-    return 0;
-  }
-  return Math.round(Number(usage.cost) * 1000000);
-}
-
-function parseArgs(raw) {
-  if (!raw) {
-    return {};
-  }
-  if (typeof raw === "object") {
-    return raw;
-  }
-  try {
-    return JSON.parse(raw);
-  } catch (_err) {
-    return {};
-  }
-}
-
-// dispatchTool routes bash/read/write/edit through the synchronous local
-// tool runner and propose_draft/survey through the async planning helpers
-// (network calls to SuperPlane). Planning sessions never see write/edit in
-// their tool list, but reject them here too in case a model hallucinates a
-// call to a tool it was not offered.
-async function dispatchTool(name, args, ctx) {
-  if (ctx.planning) {
-    if (name === "propose_draft" || name === "survey") {
-      return runPlanningTool(name, args, ctx.planningHelpers);
-    }
-    if (name === "write" || name === "edit") {
-      return { output: `${name} is not available in a planning session`, failed: true };
-    }
-  }
-  return runTool(name, args);
-}
-
-async function runPlanningTool(name, args, helpers) {
-  if (!helpers) {
-    return { output: "planning tools are not available in this run", failed: true };
-  }
-  try {
-    const result = name === "propose_draft" ? await helpers.proposeDraft(args) : await helpers.proposeSurvey(args);
-    return { output: JSON.stringify(result), failed: false };
-  } catch (err) {
-    return { output: err && err.message ? err.message : String(err), failed: true };
-  }
-}
-
-function runTool(name, args) {
-  try {
-    if (name === "bash") {
-      const result = spawnSync("bash", ["-lc", String(args.command || "")], {
-        encoding: "utf8",
-        cwd: process.cwd(),
-        env: process.env,
-        timeout: 120000,
-        maxBuffer: 2 * 1024 * 1024,
-      });
-      const output = `${result.stdout || ""}${result.stderr || ""}`.trim();
-      if (result.status !== 0) {
-        return { output: output || `command failed with exit ${result.status}`, failed: true };
-      }
-      return { output: output || "(no output)", failed: false };
-    }
-    if (name === "read") {
-      return { output: fs.readFileSync(args.path, "utf8"), failed: false };
-    }
-    if (name === "write") {
-      fs.mkdirSync(path.dirname(args.path), { recursive: true });
-      fs.writeFileSync(args.path, args.content ?? "", "utf8");
-      return { output: `wrote ${args.path}`, failed: false };
-    }
-    if (name === "edit") {
-      const current = fs.readFileSync(args.path, "utf8");
-      if (!current.includes(args.old_text)) {
-        return { output: "old_text not found", failed: true };
-      }
-      fs.writeFileSync(args.path, current.replace(args.old_text, args.new_text), "utf8");
-      return { output: `edited ${args.path}`, failed: false };
-    }
-    return { output: `unknown tool: ${name}`, failed: true };
-  } catch (err) {
-    return { output: err && err.message ? err.message : String(err), failed: true };
-  }
-}
-
-function writeLiveLogRecord(rec) {
-  process.stdout.write(`${JSON.stringify(rec)}\n`);
-}
-
-function toolPreview(kind, args) {
-  if (!args || typeof args !== "object") {
-    return kind;
-  }
-  if (kind === "bash" && typeof args.command === "string" && args.command.trim()) {
-    return args.command.trim();
-  }
-  if (kind === "propose_draft" && typeof args.title === "string" && args.title.trim()) {
-    return args.title.trim();
-  }
-  if (typeof args.path === "string" && args.path.trim()) {
-    return args.path.trim();
-  }
-  return kind;
-}
-
-function accumulateLLMUsage(payload) {
-  const taskDir = process.env.SUPERPLANE_TASK_DIR;
-  if (!taskDir) {
-    return;
-  }
-  const script = path.join(taskDir, "llm_usage.js");
-  if (!fs.existsSync(script)) {
-    return;
-  }
-  require(script).accumulate(taskDir, payload);
+  const failed = formatter.resultFailed();
+  formatter.flush(failed);
+  return { failed };
 }
 
 if (require.main === module) {
   main();
 }
 
-module.exports = { runPrompt, formatTurnResult, DEFAULT_MAX_TURNS, MAX_TURNS_LIMIT, planningEnabled };
+module.exports = {
+  runPrompt,
+  formatOpenCodeJsonLines,
+  formatTurnResult,
+  opencodeRunArgs,
+  planningEnabled,
+  classifyOpenRouterError,
+  openRouterModelId,
+  buildOpenCodeConfig,
+  orderedFallbackModels,
+  rateLimitWaitMs,
+};

--- a/pkg/components/runner/openrouter/run_test.go
+++ b/pkg/components/runner/openrouter/run_test.go
@@ -36,7 +36,7 @@ func TestOpencodeRunArgsIncludesJSONAutoPureAndPrefix(t *testing.T) {
 		"session": "",
 	})
 	assert.Equal(t, []string{
-		"run", "--format", "json", "--auto", "--pure",
+		"--pure", "run", "--format", "json", "--auto",
 		"-m", "openrouter/x-ai/grok-4.6",
 		"--dir", "/tmp/repo",
 		"do the work",
@@ -248,7 +248,7 @@ func TestRunPromptContinuesSessionOnLaterPrompt(t *testing.T) {
 			`{"type":"text","sessionID":"ses_keep","part":{"type":"text","text":"first done"}}`,
 			`{"type":"step_finish","sessionID":"ses_keep","part":{"type":"step-finish","tokens":{"input":1,"output":1}}}`,
 		},
-	}})
+	}}, nil, nil)
 	assert.Equal(t, 0, first.exitCode)
 	session, err := os.ReadFile(filepath.Join(dir, "opencode_session"))
 	require.NoError(t, err)
@@ -261,7 +261,7 @@ func TestRunPromptContinuesSessionOnLaterPrompt(t *testing.T) {
 			`{"type":"text","sessionID":"ses_keep","part":{"type":"text","text":"second done"}}`,
 			`{"type":"step_finish","sessionID":"ses_keep","part":{"type":"step-finish","tokens":{"input":1,"output":1}}}`,
 		},
-	}})
+	}}, nil, nil)
 	assert.Equal(t, 0, second.exitCode)
 	require.NotEmpty(t, second.spawns)
 	assert.Contains(t, second.spawns[0], "--session")
@@ -290,7 +290,64 @@ func TestRunPromptWritesOpenRouterBaseURLIntoConfig(t *testing.T) {
 	assert.Contains(t, result.spawns[0], "--format")
 	assert.Contains(t, result.spawns[0], "json")
 	assert.Contains(t, result.spawns[0], "--auto")
-	assert.Contains(t, result.spawns[0], "--pure")
+	assert.Equal(t, "--pure", result.spawns[0][0])
+	assert.Equal(t, "run", result.spawns[0][1])
+}
+
+func TestRunPromptDoesNotSwitchWhenSuccessfulSpawnLogs429(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model:    "x-ai/grok-4.6",
+		fallback: []string{"x-ai/grok-4.6", "anthropic/claude-sonnet-4-6"},
+		spawns: []spawnScript{{
+			ExitCode: 0,
+			Stderr:   "HTTP 429 Too Many Requests",
+			Stdout: []string{
+				`{"type":"error","sessionID":"ses_ok","error":{"data":{"message":"Rate limit exceeded: new-account-rpm/x-ai/grok-4.6. Please retry shortly."}}}`,
+				`{"type":"text","sessionID":"ses_ok","part":{"type":"text","text":"recovered"}}`,
+				`{"type":"step_finish","sessionID":"ses_ok","part":{"type":"step-finish","tokens":{"input":1,"output":1}}}`,
+			},
+		}},
+	})
+	assert.Equal(t, 0, result.exitCode)
+	require.Len(t, result.spawns, 1)
+	assert.Empty(t, result.sleeps)
+	assert.NotContains(t, result.output, "switching to")
+	assert.NotContains(t, result.output, "waiting to continue")
+	payload := resultPayload(t, result.resultFile)
+	assert.Equal(t, "recovered", payload["result"])
+}
+
+func TestRunPromptStopsWaitingWhenExecutionTimeoutExpires(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model:     "x-ai/grok-4.6",
+		fallback:  []string{"x-ai/grok-4.6"},
+		nowValues: []int64{0, 2000},
+		env: map[string]string{
+			"SUPERPLANE_EXECUTION_TIMEOUT_SECONDS": "1",
+		},
+		spawns: []spawnScript{{
+			ExitCode: 1,
+			Stderr:   "Rate limit exceeded: new-account-rpm/x-ai/grok-4.6. Please retry shortly.",
+			Stdout:   []string{`{"type":"error","error":{"data":{"message":"Rate limit exceeded: new-account-rpm/x-ai/grok-4.6. Please retry shortly."}}}`},
+		}},
+	})
+	assert.Equal(t, 1, result.exitCode)
+	require.Len(t, result.spawns, 1)
+	assert.Empty(t, result.sleeps)
+	assert.Contains(t, result.output, "Rate limit wait exceeded the execution timeout")
+}
+
+func TestWaitDeadlineMsUsesExecutionTimeoutSeconds(t *testing.T) {
+	deadline := jsWaitDeadline(t, map[string]string{"SUPERPLANE_EXECUTION_TIMEOUT_SECONDS": "30"}, 1000)
+	assert.Equal(t, float64(31000), deadline)
+}
+
+func TestOpenCodeProcessEnvSetsPureAndIsolatesHomes(t *testing.T) {
+	env := jsOpenCodeProcessEnv(t, "/task")
+	assert.Equal(t, "1", env["OPENCODE_PURE"])
+	assert.Equal(t, "1", env["OPENCODE_DISABLE_AUTOUPDATE"])
+	assert.Equal(t, "/task/opencode.json", env["OPENCODE_CONFIG"])
+	assert.Equal(t, "/task/xdg/data", env["XDG_DATA_HOME"])
 }
 
 type spawnScript struct {
@@ -300,10 +357,11 @@ type spawnScript struct {
 }
 
 type promptHarness struct {
-	model    string
-	fallback []string
-	spawns   []spawnScript
-	env      map[string]string
+	model     string
+	fallback  []string
+	spawns    []spawnScript
+	env       map[string]string
+	nowValues []int64
 }
 
 type openRouterPromptResult struct {
@@ -328,15 +386,20 @@ func runOpenRouterPrompt(t *testing.T, harness promptHarness) openRouterPromptRe
 	raw, err := json.Marshal(fallback)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "openrouter_models.json"), raw, 0o644))
-	return runPromptInDir(t, dir, "prompt.txt", harness.model, harness.spawns, harness.env)
+	return runPromptInDir(t, dir, "prompt.txt", harness.model, harness.spawns, harness.env, harness.nowValues)
 }
 
-func runPromptInDir(t *testing.T, dir, promptName, model string, spawns []spawnScript, extraEnv ...map[string]string) openRouterPromptResult {
+func runPromptInDir(t *testing.T, dir, promptName, model string, spawns []spawnScript, extraEnv map[string]string, nowValues []int64) openRouterPromptResult {
 	t.Helper()
 	resultFile := filepath.Join(dir, "result.json")
 	script, err := filepath.Abs("run.js")
 	require.NoError(t, err)
 	spawnsJSON, err := json.Marshal(spawns)
+	require.NoError(t, err)
+	if nowValues == nil {
+		nowValues = []int64{}
+	}
+	nowJSON, err := json.Marshal(nowValues)
 	require.NoError(t, err)
 	harnessFile := filepath.Join(dir, "harness.js")
 	require.NoError(t, os.WriteFile(harnessFile, []byte(fmt.Sprintf(`
@@ -344,9 +407,11 @@ const fs = require("fs");
 const { PassThrough } = require("stream");
 const { runPrompt } = require(%q);
 const spawns = %s;
+const nowValues = %s;
 const calls = [];
 const sleeps = [];
 let index = 0;
+let nowIndex = 0;
 function mockChild(spec) {
   const stdout = new PassThrough();
   const stderr = new PassThrough();
@@ -385,6 +450,9 @@ runPrompt(%q, %q, {
     sleeps.push(ms);
     return Promise.resolve();
   },
+  now: nowValues.length
+    ? () => nowValues[Math.min(nowIndex++, nowValues.length - 1)]
+    : undefined,
   cwd: %q,
 })
   .then((code) => {
@@ -396,7 +464,7 @@ runPrompt(%q, %q, {
     console.error(err && err.message ? err.message : err);
     process.exit(1);
   });
-`, script, spawnsJSON, filepath.Join(dir, promptName), model, dir)), 0o644))
+`, script, spawnsJSON, nowJSON, filepath.Join(dir, promptName), model, dir)), 0o644))
 
 	spawnsFile := filepath.Join(dir, "spawns.json")
 	cmd := exec.Command("node", harnessFile)
@@ -407,8 +475,8 @@ runPrompt(%q, %q, {
 		"OPENROUTER_API_KEY=test",
 		"SPAWNS_FILE="+spawnsFile,
 	)
-	if len(extraEnv) > 0 {
-		for key, value := range extraEnv[0] {
+	if extraEnv != nil {
+		for key, value := range extraEnv {
 			env = append(env, key+"="+value)
 		}
 	}
@@ -450,6 +518,33 @@ func copyScript(t *testing.T, dir, src, dest string) {
 	body, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, dest), body, 0o644))
+}
+
+func jsWaitDeadline(t *testing.T, env map[string]string, nowMs int64) float64 {
+	t.Helper()
+	script, err := filepath.Abs("run.js")
+	require.NoError(t, err)
+	payload, err := json.Marshal(map[string]any{"env": env, "now": nowMs})
+	require.NoError(t, err)
+	cmd := exec.Command("node", "-e", `const { waitDeadlineMs } = require(process.argv[1]); const input = JSON.parse(process.argv[2]); process.stdout.write(String(waitDeadlineMs(input.env, () => input.now)));`, script, string(payload))
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	var deadline float64
+	_, err = fmt.Sscan(string(out), &deadline)
+	require.NoError(t, err)
+	return deadline
+}
+
+func jsOpenCodeProcessEnv(t *testing.T, taskDir string) map[string]string {
+	t.Helper()
+	script, err := filepath.Abs("run.js")
+	require.NoError(t, err)
+	cmd := exec.Command("node", "-e", `const { openCodeProcessEnv } = require(process.argv[1]); process.stdout.write(JSON.stringify(openCodeProcessEnv(process.argv[2], {})));`, script, taskDir)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	var env map[string]string
+	require.NoError(t, json.Unmarshal(out, &env))
+	return env
 }
 
 func jsString(t *testing.T, fn, arg string) string {

--- a/pkg/components/runner/openrouter/run_test.go
+++ b/pkg/components/runner/openrouter/run_test.go
@@ -6,126 +6,304 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRunPromptReturnsZeroWhenModelStops(t *testing.T) {
-	result := runOpenRouterPrompt(t, promptHarness{maxTurns: 2})
-	assert.Equal(t, 0, result.exitCode)
-	require.Len(t, result.requests, 2)
-	assertToolRouting(t, result.requests[0], true)
-	assertToolRouting(t, result.requests[1], true)
-	require.GreaterOrEqual(t, len(result.requests[1]["messages"].([]any)), 3)
-	assert.Equal(t, "working", resultText(t, result.resultFile))
-	assert.Regexp(t, `✓ done · \d+ turns · \$\d+\.\d{4} · \d+\.\d+s`, result.output)
+func TestOpenRouterModelIdPrefixesCatalogIds(t *testing.T) {
+	assert.Equal(t, "openrouter/anthropic/claude-sonnet-4-6", jsString(t, "openRouterModelId", "anthropic/claude-sonnet-4-6"))
+	assert.Equal(t, "openrouter/anthropic/claude-sonnet-4-6", jsString(t, "openRouterModelId", "openrouter/anthropic/claude-sonnet-4-6"))
 }
 
-func TestRunPromptRequiresToolCapableProviders(t *testing.T) {
-	result := runOpenRouterPrompt(t, promptHarness{maxTurns: 1})
-	assert.Equal(t, 0, result.exitCode)
-	require.NotEmpty(t, result.requests)
-	assertToolRouting(t, result.requests[0], true)
+func TestClassifyOpenRouterErrorDetectsRateLimitsAndHardFailures(t *testing.T) {
+	rpm := "Rate limit exceeded: new-account-rpm/x-ai/grok-4.6-20260810. Rate limit reached: new accounts are limited to 20 requests per minute for this model. Please retry shortly."
+	assert.Equal(t, "rate_limit", jsClassify(t, rpm))
+	assert.Equal(t, "rate_limit", jsClassify(t, "HTTP 429 Too Many Requests"))
+	assert.Equal(t, "hard", jsClassify(t, "Invalid API key"))
+	assert.Equal(t, "hard", jsClassify(t, "Insufficient credits"))
+	assert.Equal(t, "hard", jsClassify(t, "unknown model: nope"))
+	assert.Equal(t, "other", jsClassify(t, "provider exploded"))
 }
 
-func TestRunPromptWrapsUpWithoutToolsWhenTurnLimitHits(t *testing.T) {
-	result := runOpenRouterPrompt(t, promptHarness{alwaysTools: true, maxTurns: 2})
-	assert.Equal(t, 0, result.exitCode)
-	require.Len(t, result.requests, 3)
-	assertToolRouting(t, result.requests[0], true)
-	assertToolRouting(t, result.requests[1], true)
-	assertToolRouting(t, result.requests[2], false)
-	assert.Contains(t, result.output, "requesting a final response without tools")
-	assert.Equal(t, "final summary", resultText(t, result.resultFile))
+func TestOpencodeRunArgsIncludesJSONAutoPureAndPrefix(t *testing.T) {
+	args := jsOpencodeArgs(t, map[string]any{
+		"model":   "x-ai/grok-4.6",
+		"prompt":  "do the work",
+		"cwd":     "/tmp/repo",
+		"session": "",
+	})
+	assert.Equal(t, []string{
+		"run", "--format", "json", "--auto", "--pure",
+		"-m", "openrouter/x-ai/grok-4.6",
+		"--dir", "/tmp/repo",
+		"do the work",
+	}, args)
+	assert.NotContains(t, args, "--agent")
 }
 
-func TestRunPromptRunsLegacyFunctionCall(t *testing.T) {
-	result := runOpenRouterPrompt(t, promptHarness{legacyFunctionCall: true, maxTurns: 2})
-	assert.Equal(t, 0, result.exitCode)
-	require.GreaterOrEqual(t, len(result.requests), 2)
-	assert.Contains(t, result.output, `"type":"tool_start"`)
-	assert.Contains(t, result.output, `"kind":"bash"`)
-	assert.NotContains(t, result.output, "[bash]")
+func TestOpencodeRunArgsContinuesSession(t *testing.T) {
+	args := jsOpencodeArgs(t, map[string]any{
+		"model":     "anthropic/claude-sonnet-4-6",
+		"prompt":    "next",
+		"cwd":       "/tmp/repo",
+		"sessionID": "ses_abc",
+	})
+	assert.Contains(t, args, "--session")
+	assert.Contains(t, args, "ses_abc")
+	assert.Contains(t, args, "-m")
+	assert.Contains(t, args, "openrouter/anthropic/claude-sonnet-4-6")
 }
 
-func TestRunPromptMarksFilesystemToolErrorsFailed(t *testing.T) {
-	result := runOpenRouterPrompt(t, promptHarness{missingRead: true, maxTurns: 2})
-	assert.Equal(t, 0, result.exitCode)
-	assert.Contains(t, result.output, `"type":"tool_end"`)
-	assert.Contains(t, result.output, `"status":"failed"`)
-	assert.Contains(t, result.output, `"kind":"read"`)
+func TestBuildOpenCodeConfigWritesBaseURLAndPlanningMCP(t *testing.T) {
+	config := jsBuildConfig(t, "/task", map[string]string{
+		"OPENROUTER_API_KEY":             "sk-or",
+		"OPENROUTER_BASE_URL":            "https://proxy.example/openrouter",
+		"SUPERPLANE_PLANNING_SESSION_ID": "session-1",
+	})
+	provider, _ := config["provider"].(map[string]any)
+	openrouter, _ := provider["openrouter"].(map[string]any)
+	options, _ := openrouter["options"].(map[string]any)
+	assert.Equal(t, "sk-or", options["apiKey"])
+	assert.Equal(t, "https://proxy.example/openrouter", options["baseURL"])
+	permission, _ := config["permission"].(map[string]any)
+	assert.Equal(t, "deny", permission["edit"])
+	assert.Equal(t, "deny", permission["question"])
+	assert.Equal(t, "allow", permission["*"])
+	mcp, _ := config["mcp"].(map[string]any)
+	superplane, _ := mcp["superplane"].(map[string]any)
+	assert.Equal(t, "local", superplane["type"])
+	command, _ := superplane["command"].([]any)
+	require.Equal(t, 2, len(command))
+	assert.Equal(t, "node", command[0])
+	assert.Equal(t, "/task/planning_session_mcp.js", command[1])
 }
 
-func TestRunPromptRecordsPerResponseTurnUsage(t *testing.T) {
-	result := runOpenRouterPrompt(t, promptHarness{alwaysTools: true, maxTurns: 2})
+func TestBuildOpenCodeConfigAllowsEditsOutsidePlanning(t *testing.T) {
+	config := jsBuildConfig(t, "/task", map[string]string{})
+	permission, _ := config["permission"].(map[string]any)
+	assert.Equal(t, "allow", permission["*"])
+	assert.Nil(t, permission["edit"])
+	assert.Nil(t, config["mcp"])
+}
+
+func TestFormatOpenCodeJsonLinesEmitsToolRecords(t *testing.T) {
+	output := runOpenCodeFormatter(t, []string{
+		`{"type":"step_start","sessionID":"ses_1","part":{"type":"step-start"}}`,
+		`{"type":"text","sessionID":"ses_1","part":{"type":"text","text":"I will check git status."}}`,
+		`{"type":"tool_use","sessionID":"ses_1","part":{"id":"t1","callID":"call_1","tool":"bash","state":{"status":"completed","input":{"command":"git status"},"output":"On branch main"}}}`,
+		`{"type":"step_finish","sessionID":"ses_1","part":{"type":"step-finish","reason":"stop","cost":0.002,"tokens":{"input":100,"output":20,"reasoning":0,"cache":{"read":0,"write":0}}}}`,
+	})
+	assert.Contains(t, output, "I will check git status.")
+	assert.Contains(t, output, "On branch main")
+	records := liveLogRecords(t, output)
+	require.GreaterOrEqual(t, len(records), 2)
+	assert.Equal(t, "tool_start", records[0]["type"])
+	assert.Equal(t, "bash", records[0]["kind"])
+	assert.Equal(t, "git status", records[0]["text"])
+	assert.Equal(t, float64(1), records[0]["turn"])
+	end := records[len(records)-1]
+	assert.Equal(t, "tool_end", end["type"])
+	assert.Equal(t, "passed", end["status"])
+	assert.Contains(t, output, `"type":"turn"`)
+}
+
+func TestFormatOpenCodeJsonLinesMarksFailedTools(t *testing.T) {
+	output := runOpenCodeFormatter(t, []string{
+		`{"type":"tool_use","sessionID":"ses_1","part":{"callID":"call_read","tool":"read","state":{"status":"error","input":{"path":"missing.txt"},"error":"ENOENT"}}}`,
+	})
+	records := liveLogRecords(t, output)
+	require.GreaterOrEqual(t, len(records), 2)
+	assert.Equal(t, "read", records[0]["kind"])
+	assert.Equal(t, "failed", records[len(records)-1]["status"])
+	assert.Contains(t, output, "ENOENT")
+}
+
+func TestFormatOpenCodeJsonLinesTreatsNonRateLimitErrorAsFailed(t *testing.T) {
+	failed := formatOpenCodeJSONLinesFailed(t, []string{
+		`{"type":"error","error":{"name":"APIError","data":{"message":"Invalid API key"}}}`,
+	})
+	assert.True(t, failed)
+}
+
+func TestFormatOpenCodeJsonLinesDoesNotFailRateLimitError(t *testing.T) {
+	failed := formatOpenCodeJSONLinesFailed(t, []string{
+		`{"type":"error","error":{"data":{"message":"Rate limit exceeded: new-account-rpm/x-ai/grok-4.6-20260810. Please retry shortly."}}}`,
+	})
+	assert.False(t, failed)
+}
+
+func TestFormatTurnResultWritesClaudeStyleDoneLine(t *testing.T) {
+	output := runTurnResult(t, map[string]any{
+		"is_error":       false,
+		"num_turns":      1,
+		"duration_ms":    1600,
+		"total_cost_usd": 0.0022,
+	})
+	assert.Equal(t, "✓ done · 1 turns · $0.0022 · 1.6s\n", output)
+}
+
+func TestRunPromptSwitchesModelAfterNewAccountRPM(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model: "x-ai/grok-4.6",
+		fallback: []string{
+			"x-ai/grok-4.6",
+			"anthropic/claude-sonnet-4-6",
+		},
+		spawns: []spawnScript{
+			{
+				ExitCode: 1,
+				Stderr:   "Rate limit exceeded: new-account-rpm/x-ai/grok-4.6-20260810. Rate limit reached: new accounts are limited to 20 requests per minute for this model. Please retry shortly.",
+				Stdout: []string{
+					`{"type":"step_start","sessionID":"ses_1","part":{"type":"step-start"}}`,
+					`{"type":"error","sessionID":"ses_1","error":{"data":{"message":"Rate limit exceeded: new-account-rpm/x-ai/grok-4.6-20260810. Rate limit reached: new accounts are limited to 20 requests per minute for this model. Please retry shortly."}}}`,
+				},
+			},
+			{
+				ExitCode: 0,
+				Stdout: []string{
+					`{"type":"step_start","sessionID":"ses_1","part":{"type":"step-start"}}`,
+					`{"type":"text","sessionID":"ses_1","part":{"type":"text","text":"working"}}`,
+					`{"type":"step_finish","sessionID":"ses_1","part":{"type":"step-finish","reason":"stop","cost":0.002,"tokens":{"input":11,"output":3,"cache":{"read":0,"write":0}}}}`,
+				},
+			},
+		},
+	})
+	assert.Equal(t, 0, result.exitCode)
+	require.Len(t, result.spawns, 2)
+	assert.Contains(t, result.spawns[0], "-m")
+	assert.Contains(t, result.spawns[0], "openrouter/x-ai/grok-4.6")
+	assert.NotContains(t, result.spawns[0], "--session")
+	assert.Contains(t, result.spawns[1], "--session")
+	assert.Contains(t, result.spawns[1], "ses_1")
+	assert.Contains(t, result.spawns[1], "openrouter/anthropic/claude-sonnet-4-6")
+	assert.Contains(t, result.output, "Rate limit on x-ai/grok-4.6 — switching to anthropic/claude-sonnet-4-6")
+	assert.NotContains(t, result.output, "new accounts are limited to 20 requests")
+	assert.Regexp(t, `✓ done · \d+ turns`, result.output)
 	payload := resultPayload(t, result.resultFile)
-	telemetry, ok := payload["telemetry"].(map[string]any)
-	require.True(t, ok)
-	turns, ok := telemetry["turns"].([]any)
-	require.True(t, ok)
-	require.Len(t, turns, 3)
-	for i, raw := range turns {
-		turn, ok := raw.(map[string]any)
-		require.True(t, ok)
-		usage, ok := turn["usage"].(map[string]any)
-		require.True(t, ok)
-		assert.Equal(t, float64(11), usage["input_tokens"], "turn %d input", i+1)
-		assert.Equal(t, float64(3), usage["output_tokens"], "turn %d output", i+1)
-	}
-	usage, ok := payload["usage"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, float64(33), usage["input_tokens"])
-	assert.Equal(t, float64(9), usage["output_tokens"])
+	assert.Equal(t, "working", payload["result"])
 }
 
-func TestRunPromptKeepsUsageWhenLaterChatFails(t *testing.T) {
-	result := runOpenRouterPrompt(t, promptHarness{alwaysTools: true, maxTurns: 4, failOnRequest: 2})
+func TestRunPromptWaitsWhenOnlyOneModelIsRateLimited(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model:    "x-ai/grok-4.6",
+		fallback: []string{"x-ai/grok-4.6"},
+		spawns: []spawnScript{
+			{
+				ExitCode: 1,
+				Stderr:   "Rate limit exceeded: new-account-rpm/x-ai/grok-4.6-20260810. Please retry shortly.",
+				Stdout:   []string{`{"type":"error","error":{"data":{"message":"Rate limit exceeded: new-account-rpm/x-ai/grok-4.6-20260810. Please retry shortly."}}}`},
+			},
+			{
+				ExitCode: 0,
+				Stdout: []string{
+					`{"type":"text","sessionID":"ses_wait","part":{"type":"text","text":"ok"}}`,
+					`{"type":"step_finish","sessionID":"ses_wait","part":{"type":"step-finish","tokens":{"input":1,"output":1}}}`,
+				},
+			},
+		},
+	})
+	assert.Equal(t, 0, result.exitCode)
+	require.Len(t, result.spawns, 2)
+	assert.Contains(t, result.spawns[0], "openrouter/x-ai/grok-4.6")
+	assert.Contains(t, result.spawns[1], "openrouter/x-ai/grok-4.6")
+	assert.Equal(t, []float64{60000}, result.sleeps)
+	assert.Contains(t, result.output, "Rate limit notice — waiting to continue…")
+	assert.NotContains(t, result.output, "switching to")
+}
+
+func TestRunPromptFailsImmediatelyOnInvalidAPIKey(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model:    "anthropic/claude-sonnet-4-6",
+		fallback: []string{"anthropic/claude-sonnet-4-6", "openai/gpt-4.1"},
+		spawns: []spawnScript{
+			{
+				ExitCode: 1,
+				Stderr:   "Invalid API key",
+				Stdout:   []string{`{"type":"error","error":{"data":{"message":"Invalid API key"}}}`},
+			},
+		},
+	})
 	assert.Equal(t, 1, result.exitCode)
-	assert.Contains(t, result.output, "provider exploded")
-	assert.Regexp(t, `✗ failed · \d+ turns · \$0\.0020 · \d+\.\d+s`, result.output)
+	require.Len(t, result.spawns, 1)
+	assert.Empty(t, result.sleeps)
+	assert.NotContains(t, result.output, "switching to")
+	assert.Contains(t, result.output, "Invalid API key")
+	assert.Regexp(t, `✗ failed`, result.output)
+}
 
-	payload := resultPayload(t, result.resultFile)
-	usage, ok := payload["usage"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, float64(11), usage["input_tokens"])
-	assert.Equal(t, float64(3), usage["output_tokens"])
-	assert.InDelta(t, 0.002, payload["total_cost_usd"], 1e-9)
-	assert.Equal(t, "openai/gpt-4.1", payload["model"])
+func TestRunPromptContinuesSessionOnLaterPrompt(t *testing.T) {
+	dir := t.TempDir()
+	writeTaskHelpers(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "prompt_count"), []byte("0\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "prompt.txt"), []byte("first"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "openrouter_models.json"), []byte(`["anthropic/claude-sonnet-4-6"]`), 0o644))
 
-	sidecar := resultPayload(t, filepath.Join(result.taskDir, "llm_usage.json"))
-	sidecarUsage, ok := sidecar["usage"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, float64(11), sidecarUsage["input_tokens"])
-	assert.Equal(t, float64(3), sidecarUsage["output_tokens"])
-	assert.InDelta(t, 0.002, sidecar["total_cost_usd"], 1e-9)
+	first := runPromptInDir(t, dir, "prompt.txt", "anthropic/claude-sonnet-4-6", []spawnScript{{
+		ExitCode: 0,
+		Stdout: []string{
+			`{"type":"step_start","sessionID":"ses_keep","part":{"type":"step-start"}}`,
+			`{"type":"text","sessionID":"ses_keep","part":{"type":"text","text":"first done"}}`,
+			`{"type":"step_finish","sessionID":"ses_keep","part":{"type":"step-finish","tokens":{"input":1,"output":1}}}`,
+		},
+	}})
+	assert.Equal(t, 0, first.exitCode)
+	session, err := os.ReadFile(filepath.Join(dir, "opencode_session"))
+	require.NoError(t, err)
+	assert.Equal(t, "ses_keep\n", string(session))
 
-	telemetry, ok := payload["telemetry"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, float64(1), telemetry["num_turns"])
-	turns, ok := telemetry["turns"].([]any)
-	require.True(t, ok)
-	require.Len(t, turns, 1)
-	first, ok := turns[0].(map[string]any)
-	require.True(t, ok)
-	tools, ok := first["tools"].([]any)
-	require.True(t, ok)
-	require.NotEmpty(t, tools)
-	tool, ok := tools[0].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "bash", tool["kind"])
-	assert.Equal(t, "true", tool["text"])
-	assert.Contains(t, result.output, `"type":"turn"`)
-	assert.Contains(t, result.output, `"turn":1`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "prompt2.txt"), []byte("second"), 0o644))
+	second := runPromptInDir(t, dir, "prompt2.txt", "anthropic/claude-sonnet-4-6", []spawnScript{{
+		ExitCode: 0,
+		Stdout: []string{
+			`{"type":"text","sessionID":"ses_keep","part":{"type":"text","text":"second done"}}`,
+			`{"type":"step_finish","sessionID":"ses_keep","part":{"type":"step-finish","tokens":{"input":1,"output":1}}}`,
+		},
+	}})
+	assert.Equal(t, 0, second.exitCode)
+	require.NotEmpty(t, second.spawns)
+	assert.Contains(t, second.spawns[0], "--session")
+	assert.Contains(t, second.spawns[0], "ses_keep")
+	assert.Contains(t, second.output, "Continuing OpenCode session")
+}
+
+func TestRunPromptWritesOpenRouterBaseURLIntoConfig(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model: "anthropic/claude-sonnet-4-6",
+		env: map[string]string{
+			"OPENROUTER_BASE_URL": "https://hosted.example/openrouter",
+		},
+		spawns: []spawnScript{{
+			ExitCode: 0,
+			Stdout: []string{
+				`{"type":"text","sessionID":"ses_cfg","part":{"type":"text","text":"ok"}}`,
+				`{"type":"step_finish","sessionID":"ses_cfg","part":{"type":"step-finish","tokens":{"input":1,"output":1}}}`,
+			},
+		}},
+	})
+	assert.Equal(t, 0, result.exitCode)
+	raw, err := os.ReadFile(filepath.Join(result.taskDir, "opencode.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "https://hosted.example/openrouter")
+	assert.Contains(t, result.spawns[0], "--format")
+	assert.Contains(t, result.spawns[0], "json")
+	assert.Contains(t, result.spawns[0], "--auto")
+	assert.Contains(t, result.spawns[0], "--pure")
+}
+
+type spawnScript struct {
+	ExitCode int      `json:"exitCode"`
+	Stdout   []string `json:"stdout"`
+	Stderr   string   `json:"stderr"`
 }
 
 type promptHarness struct {
-	alwaysTools        bool
-	legacyFunctionCall bool
-	missingRead        bool
-	maxTurns           int
-	failOnRequest      int
+	model    string
+	fallback []string
+	spawns   []spawnScript
+	env      map[string]string
 }
 
 type openRouterPromptResult struct {
@@ -133,109 +311,108 @@ type openRouterPromptResult struct {
 	output     string
 	resultFile string
 	taskDir    string
-	requests   []map[string]any
+	spawns     [][]string
+	sleeps     []float64
 }
 
 func runOpenRouterPrompt(t *testing.T, harness promptHarness) openRouterPromptResult {
 	t.Helper()
-
 	dir := t.TempDir()
-	resultFile := filepath.Join(dir, "result.json")
-	promptFile := filepath.Join(dir, "prompt.txt")
-	harnessFile := filepath.Join(dir, "harness.js")
-	requestsFile := filepath.Join(dir, "requests.json")
-	require.NoError(t, os.WriteFile(promptFile, []byte("do the work"), 0o644))
+	writeTaskHelpers(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "prompt_count"), []byte("0\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "prompt.txt"), []byte("do the work"), 0o644))
+	fallback := harness.fallback
+	if len(fallback) == 0 {
+		fallback = []string{harness.model}
+	}
+	raw, err := json.Marshal(fallback)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "openrouter_models.json"), raw, 0o644))
+	return runPromptInDir(t, dir, "prompt.txt", harness.model, harness.spawns, harness.env)
+}
 
+func runPromptInDir(t *testing.T, dir, promptName, model string, spawns []spawnScript, extraEnv ...map[string]string) openRouterPromptResult {
+	t.Helper()
+	resultFile := filepath.Join(dir, "result.json")
 	script, err := filepath.Abs("run.js")
 	require.NoError(t, err)
-	usageScript, err := filepath.Abs("../llm_usage.js")
+	spawnsJSON, err := json.Marshal(spawns)
 	require.NoError(t, err)
-	usageBody, err := os.ReadFile(usageScript)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "llm_usage.js"), usageBody, 0o644))
-	telemetryScript, err := filepath.Abs("../turn_telemetry.js")
-	require.NoError(t, err)
-	telemetryBody, err := os.ReadFile(telemetryScript)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "turn_telemetry.js"), telemetryBody, 0o644))
-
+	harnessFile := filepath.Join(dir, "harness.js")
 	require.NoError(t, os.WriteFile(harnessFile, []byte(fmt.Sprintf(`
 const fs = require("fs");
+const { PassThrough } = require("stream");
 const { runPrompt } = require(%q);
-const requests = [];
-const alwaysTools = %t;
-const legacyFunctionCall = %t;
-const missingRead = %t;
-const failOnRequest = %d;
-let toolTurns = 0;
-let requestCount = 0;
-global.fetch = async (_url, init) => {
-  const body = JSON.parse(init.body);
-  requests.push(body);
-  requestCount += 1;
-  if (failOnRequest > 0 && requestCount === failOnRequest) {
-    return {
-      ok: false,
-      status: 502,
-      json: async () => ({ error: { message: "provider exploded" } }),
-    };
-  }
-  const hasTools = Array.isArray(body.tools) && body.tools.length > 0;
-  let message = { content: hasTools ? "working" : "final summary" };
-  if (alwaysTools && hasTools) {
-    message = {
-      content: "working",
-      tool_calls: [{
-        id: "call_1",
-        type: "function",
-        function: { name: "bash", arguments: JSON.stringify({ command: "true" }) },
-      }],
-    };
-  } else if (legacyFunctionCall && hasTools && toolTurns === 0) {
-    toolTurns += 1;
-    message = {
-      content: "working",
-      function_call: { name: "bash", arguments: JSON.stringify({ command: "true" }) },
-    };
-  } else if (missingRead && hasTools && toolTurns === 0) {
-    toolTurns += 1;
-    message = {
-      content: "working",
-      tool_calls: [{
-        id: "call_read",
-        type: "function",
-        function: { name: "read", arguments: JSON.stringify({ path: "/definitely/missing/file.txt" }) },
-      }],
-    };
-  }
-  return {
-    ok: true,
-    json: async () => ({
-      usage: { prompt_tokens: 11, completion_tokens: 3, cost: 0.002 },
-      choices: [{ message }],
-    }),
+const spawns = %s;
+const calls = [];
+const sleeps = [];
+let index = 0;
+function mockChild(spec) {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const listeners = {};
+  const child = {
+    stdout,
+    stderr,
+    on(event, cb) {
+      listeners[event] = cb;
+      return child;
+    },
   };
-};
-runPrompt(%q, "openai/gpt-4.1", %d)
+  setImmediate(() => {
+    for (const line of spec.stdout || []) {
+      stdout.write(line + "\n");
+    }
+    stdout.end();
+    if (spec.stderr) {
+      stderr.write(spec.stderr);
+    }
+    stderr.end();
+    if (listeners.close) {
+      listeners.close(spec.exitCode == null ? 0 : spec.exitCode);
+    }
+  });
+  return child;
+}
+runPrompt(%q, %q, {
+  spawnOpenCode(args) {
+    const spec = spawns[index] || { exitCode: 1, stderr: "unexpected extra spawn", stdout: [] };
+    index += 1;
+    calls.push(args);
+    return mockChild(spec);
+  },
+  sleep(ms) {
+    sleeps.push(ms);
+    return Promise.resolve();
+  },
+  cwd: %q,
+})
   .then((code) => {
-    fs.writeFileSync(process.env.REQUESTS_FILE, JSON.stringify(requests));
+    fs.writeFileSync(process.env.SPAWNS_FILE, JSON.stringify({ calls, sleeps }));
     process.exit(code);
   })
   .catch((err) => {
-    fs.writeFileSync(process.env.REQUESTS_FILE, JSON.stringify(requests));
+    fs.writeFileSync(process.env.SPAWNS_FILE, JSON.stringify({ calls, sleeps }));
     console.error(err && err.message ? err.message : err);
     process.exit(1);
   });
-`, script, harness.alwaysTools, harness.legacyFunctionCall, harness.missingRead, harness.failOnRequest, promptFile, harness.maxTurns)), 0o644))
+`, script, spawnsJSON, filepath.Join(dir, promptName), model, dir)), 0o644))
 
+	spawnsFile := filepath.Join(dir, "spawns.json")
 	cmd := exec.Command("node", harnessFile)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
+	env := append(os.Environ(),
 		"SUPERPLANE_RESULT_FILE="+resultFile,
 		"SUPERPLANE_TASK_DIR="+dir,
 		"OPENROUTER_API_KEY=test",
-		"REQUESTS_FILE="+requestsFile,
+		"SPAWNS_FILE="+spawnsFile,
 	)
+	if len(extraEnv) > 0 {
+		for key, value := range extraEnv[0] {
+			env = append(env, key+"="+value)
+		}
+	}
+	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	exitCode := 0
 	if err != nil {
@@ -243,235 +420,143 @@ runPrompt(%q, "openai/gpt-4.1", %d)
 		require.Truef(t, ok, "node harness failed: %v\n%s", err, out)
 		exitCode = exitErr.ExitCode()
 	}
-
-	raw, readErr := os.ReadFile(requestsFile)
+	recorded := struct {
+		Calls  [][]string `json:"calls"`
+		Sleeps []float64  `json:"sleeps"`
+	}{}
+	raw, readErr := os.ReadFile(spawnsFile)
 	require.NoError(t, readErr)
-	var requests []map[string]any
-	require.NoError(t, json.Unmarshal(raw, &requests))
-
+	require.NoError(t, json.Unmarshal(raw, &recorded))
 	return openRouterPromptResult{
 		exitCode:   exitCode,
 		output:     string(out),
 		resultFile: resultFile,
 		taskDir:    dir,
-		requests:   requests,
+		spawns:     recorded.Calls,
+		sleeps:     recorded.Sleeps,
 	}
 }
 
-func TestRunPromptPlanningAdvertisesPlanningToolsNotWriteEdit(t *testing.T) {
-	result := runOpenRouterPlanningPrompt(t, "none")
-	assert.Equal(t, 0, result.exitCode)
-	require.NotEmpty(t, result.chatRequests)
-	names := toolNames(t, result.chatRequests[0])
-	assert.Contains(t, names, "propose_draft")
-	assert.Contains(t, names, "survey")
-	assert.Contains(t, names, "bash")
-	assert.Contains(t, names, "read")
-	assert.NotContains(t, names, "write")
-	assert.NotContains(t, names, "edit")
-	assert.Empty(t, result.planningRequests)
-	require.Len(t, result.chatRequests, 1)
-	assert.NotContains(t, result.output, "asking it to use tools")
-}
-
-func TestRunPromptPlanningProposeDraftPostsToDraftsEndpoint(t *testing.T) {
-	result := runOpenRouterPlanningPrompt(t, "propose_draft")
-	assert.Equal(t, 0, result.exitCode)
-	require.Len(t, result.planningRequests, 1)
-	req := result.planningRequests[0]
-	assert.Contains(t, req["url"], "/api/v1/runner/planning-sessions/drafts")
-	assert.Equal(t, "POST", req["method"])
-	headers, ok := req["headers"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "Bearer test-run-token", headers["Authorization"])
-	body, ok := req["body"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "Add dark mode", body["title"])
-	assert.Equal(t, "Add a dark color scheme", body["description"])
-}
-
-func TestRunPromptPlanningSurveyPostsToSurveysEndpoint(t *testing.T) {
-	result := runOpenRouterPlanningPrompt(t, "survey")
-	assert.Equal(t, 0, result.exitCode)
-	require.Len(t, result.planningRequests, 1)
-	req := result.planningRequests[0]
-	assert.Contains(t, req["url"], "/api/v1/runner/planning-sessions/surveys")
-	body, ok := req["body"].(map[string]any)
-	require.True(t, ok)
-	questions, ok := body["questions"].([]any)
-	require.True(t, ok)
-	require.Len(t, questions, 1)
-	question := questions[0].(map[string]any)
-	assert.Equal(t, "Which theme?", question["prompt"])
-}
-
-type openRouterPlanningResult struct {
-	exitCode         int
-	output           string
-	resultFile       string
-	chatRequests     []map[string]any
-	planningRequests []map[string]any
-}
-
-// toolMode selects which tool call (if any) the fake model returns on its
-// first tool-enabled turn: "propose_draft", "survey", or "none".
-func runOpenRouterPlanningPrompt(t *testing.T, toolMode string) openRouterPlanningResult {
+func writeTaskHelpers(t *testing.T, dir string) {
 	t.Helper()
+	copyScript(t, dir, "../llm_usage.js", "llm_usage.js")
+	copyScript(t, dir, "../turn_telemetry.js", "turn_telemetry.js")
+}
 
-	dir := t.TempDir()
-	resultFile := filepath.Join(dir, "result.json")
-	promptFile := filepath.Join(dir, "prompt.txt")
-	harnessFile := filepath.Join(dir, "harness.js")
-	requestsFile := filepath.Join(dir, "requests.json")
-	require.NoError(t, os.WriteFile(promptFile, []byte("what should we build next?"), 0o644))
+func copyScript(t *testing.T, dir, src, dest string) {
+	t.Helper()
+	path, err := filepath.Abs(src)
+	require.NoError(t, err)
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, dest), body, 0o644))
+}
 
+func jsString(t *testing.T, fn, arg string) string {
+	t.Helper()
 	script, err := filepath.Abs("run.js")
 	require.NoError(t, err)
-	planningScript, err := filepath.Abs("../planning_session_mcp.js")
-	require.NoError(t, err)
-	planningBody, err := os.ReadFile(planningScript)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "planning_session_mcp.js"), planningBody, 0o644))
-
-	require.NoError(t, os.WriteFile(harnessFile, []byte(fmt.Sprintf(`
-const fs = require("fs");
-const { runPrompt } = require(%q);
-const chatRequests = [];
-const planningRequests = [];
-const toolMode = %q;
-let toolTurn = 0;
-global.fetch = async (url, init) => {
-  const target = String(url);
-  if (target.endsWith("/chat/completions")) {
-    const body = JSON.parse(init.body);
-    chatRequests.push(body);
-    const hasTools = Array.isArray(body.tools) && body.tools.length > 0;
-    let message = { content: hasTools ? "" : "Thanks, noted." };
-    if (hasTools && toolTurn === 0 && toolMode === "propose_draft") {
-      toolTurn += 1;
-      message = {
-        content: "",
-        tool_calls: [{
-          id: "call_1",
-          type: "function",
-          function: {
-            name: "propose_draft",
-            arguments: JSON.stringify({ title: "Add dark mode", description: "Add a dark color scheme" }),
-          },
-        }],
-      };
-    } else if (hasTools && toolTurn === 0 && toolMode === "survey") {
-      toolTurn += 1;
-      message = {
-        content: "",
-        tool_calls: [{
-          id: "call_1",
-          type: "function",
-          function: {
-            name: "survey",
-            arguments: JSON.stringify({ questions: [{ prompt: "Which theme?", options: ["Dark", "Light"] }] }),
-          },
-        }],
-      };
-    }
-    return { ok: true, json: async () => ({ usage: { prompt_tokens: 5, completion_tokens: 2 }, choices: [{ message }] }) };
-  }
-  const body = init.body ? JSON.parse(init.body) : undefined;
-  planningRequests.push({ url: target, method: init.method, headers: init.headers, body });
-  if (target.endsWith("/drafts")) {
-    return { ok: true, text: async () => JSON.stringify({ status: "created", work_order_key: "WO-1" }) };
-  }
-  if (target.endsWith("/surveys")) {
-    return { ok: true, text: async () => JSON.stringify({ status: "ok" }) };
-  }
-  return { ok: false, status: 404, text: async () => "not found" };
-};
-runPrompt(%q, "openai/gpt-4.1", 4)
-  .then((code) => {
-    fs.writeFileSync(process.env.REQUESTS_FILE, JSON.stringify({ chatRequests, planningRequests }));
-    process.exit(code);
-  })
-  .catch((err) => {
-    fs.writeFileSync(process.env.REQUESTS_FILE, JSON.stringify({ chatRequests, planningRequests }));
-    console.error(err && err.message ? err.message : err);
-    process.exit(1);
-  });
-`, script, toolMode, promptFile)), 0o644))
-
-	cmd := exec.Command("node", harnessFile)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"SUPERPLANE_RESULT_FILE="+resultFile,
-		"SUPERPLANE_TASK_DIR="+dir,
-		"SUPERPLANE_PLANNING_SESSION_ID=session-1",
-		"SUPERPLANE_BASE_URL=https://superplane.example",
-		"SUPERPLANE_RUN_TOKEN=test-run-token",
-		"OPENROUTER_API_KEY=test",
-		"REQUESTS_FILE="+requestsFile,
-	)
+	cmd := exec.Command("node", "-e", `const m = require(process.argv[1]); process.stdout.write(m[process.argv[2]](process.argv[3]));`, script, fn, arg)
 	out, err := cmd.CombinedOutput()
-	exitCode := 0
-	if err != nil {
-		exitErr, ok := err.(*exec.ExitError)
-		require.Truef(t, ok, "node harness failed: %v\n%s", err, out)
-		exitCode = exitErr.ExitCode()
-	}
-
-	raw, readErr := os.ReadFile(requestsFile)
-	require.NoError(t, readErr)
-	var parsed struct {
-		ChatRequests     []map[string]any `json:"chatRequests"`
-		PlanningRequests []map[string]any `json:"planningRequests"`
-	}
-	require.NoError(t, json.Unmarshal(raw, &parsed))
-
-	return openRouterPlanningResult{
-		exitCode:         exitCode,
-		output:           string(out),
-		resultFile:       resultFile,
-		chatRequests:     parsed.ChatRequests,
-		planningRequests: parsed.PlanningRequests,
-	}
+	require.NoError(t, err, string(out))
+	return string(out)
 }
 
-func toolNames(t *testing.T, request map[string]any) []string {
+func jsClassify(t *testing.T, text string) string {
 	t.Helper()
-	tools, ok := request["tools"].([]any)
-	require.True(t, ok)
-	names := make([]string, 0, len(tools))
-	for _, raw := range tools {
-		tool, ok := raw.(map[string]any)
-		require.True(t, ok)
-		fn, ok := tool["function"].(map[string]any)
-		require.True(t, ok)
-		name, _ := fn["name"].(string)
-		names = append(names, name)
-	}
-	return names
+	script, err := filepath.Abs("run.js")
+	require.NoError(t, err)
+	cmd := exec.Command("node", "-e", `const { classifyOpenRouterError } = require(process.argv[1]); process.stdout.write(classifyOpenRouterError(process.argv[2]));`, script, text)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	return string(out)
 }
 
-func assertToolRouting(t *testing.T, request map[string]any, wantTools bool) {
+func jsOpencodeArgs(t *testing.T, input map[string]any) []string {
 	t.Helper()
-	_, hasTools := request["tools"]
-	if !wantTools {
-		assert.False(t, hasTools)
-		_, hasChoice := request["tool_choice"]
-		assert.False(t, hasChoice)
-		_, hasProvider := request["provider"]
-		assert.False(t, hasProvider)
-		return
-	}
-	assert.NotEmpty(t, request["tools"])
-	assert.Equal(t, "auto", request["tool_choice"])
-	provider, ok := request["provider"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, true, provider["require_parameters"])
+	script, err := filepath.Abs("run.js")
+	require.NoError(t, err)
+	payload, err := json.Marshal(input)
+	require.NoError(t, err)
+	cmd := exec.Command("node", "-e", `const { opencodeRunArgs } = require(process.argv[1]); process.stdout.write(JSON.stringify(opencodeRunArgs(JSON.parse(process.argv[2]))));`, script, string(payload))
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	var args []string
+	require.NoError(t, json.Unmarshal(out, &args))
+	return args
 }
 
-func resultText(t *testing.T, resultFile string) string {
+func jsBuildConfig(t *testing.T, taskDir string, env map[string]string) map[string]any {
 	t.Helper()
-	text, _ := resultPayload(t, resultFile)["result"].(string)
-	return text
+	script, err := filepath.Abs("run.js")
+	require.NoError(t, err)
+	payload, err := json.Marshal(map[string]any{"taskDir": taskDir, "env": env, "planning": env["SUPERPLANE_PLANNING_SESSION_ID"] != ""})
+	require.NoError(t, err)
+	cmd := exec.Command("node", "-e", `const { buildOpenCodeConfig } = require(process.argv[1]); process.stdout.write(JSON.stringify(buildOpenCodeConfig(JSON.parse(process.argv[2]))));`, script, string(payload))
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	var config map[string]any
+	require.NoError(t, json.Unmarshal(out, &config))
+	return config
+}
+
+func runOpenCodeFormatter(t *testing.T, lines []string) string {
+	t.Helper()
+	script, err := filepath.Abs("run.js")
+	require.NoError(t, err)
+	payload, err := json.Marshal(lines)
+	require.NoError(t, err)
+	cmd := exec.Command("node", "-e", `const { formatOpenCodeJsonLines } = require(process.argv[1]); formatOpenCodeJsonLines(JSON.parse(process.argv[2]));`, script, string(payload))
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	return string(out)
+}
+
+func formatOpenCodeJSONLinesFailed(t *testing.T, lines []string) bool {
+	t.Helper()
+	script, err := filepath.Abs("run.js")
+	require.NoError(t, err)
+	payload, err := json.Marshal(lines)
+	require.NoError(t, err)
+	cmd := exec.Command("node", "-e", `const { formatOpenCodeJsonLines } = require(process.argv[1]); process.stdout.write(JSON.stringify(formatOpenCodeJsonLines(JSON.parse(process.argv[2]))));`, script, string(payload))
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	var result struct {
+		Failed bool `json:"failed"`
+	}
+	require.NoError(t, json.Unmarshal(out, &result), string(out))
+	return result.Failed
+}
+
+func runTurnResult(t *testing.T, event map[string]any) string {
+	t.Helper()
+	script, err := filepath.Abs("run.js")
+	require.NoError(t, err)
+	payload, err := json.Marshal(event)
+	require.NoError(t, err)
+	cmd := exec.Command("node", "-e", `const { formatTurnResult } = require(process.argv[1]); formatTurnResult(JSON.parse(process.argv[2]));`, script, string(payload))
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	return string(out)
+}
+
+func liveLogRecords(t *testing.T, output string) []map[string]any {
+	t.Helper()
+	var records []map[string]any
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec["type"] == "tool_start" || rec["type"] == "tool_end" {
+			records = append(records, rec)
+		}
+	}
+	return records
 }
 
 func resultPayload(t *testing.T, path string) map[string]any {

--- a/pkg/components/runner/openrouter/spec.go
+++ b/pkg/components/runner/openrouter/spec.go
@@ -7,10 +7,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/components/runner"
 )
 
-const (
-	DefaultMaxTurns = 128
-	MaxTurnsLimit   = 256
-)
+const opencodeMissingMessage = "opencode CLI not found on PATH; install OpenCode on the runner"
 
 type RunOpenRouterSpec struct {
 	MachineType             string                        `mapstructure:"machineType"`
@@ -21,7 +18,9 @@ type RunOpenRouterSpec struct {
 	EnvironmentFrom         []runner.EnvironmentFromEntry `mapstructure:"environmentFrom"`
 	Environment             []runner.EnvironmentVariable  `mapstructure:"environment"`
 	ExecutionTimeoutSeconds int                           `mapstructure:"executionTimeoutSeconds"`
-	MaxTurns                int                           `mapstructure:"maxTurns"`
+	// MaxTurns is kept so old node JSON still decodes. OpenCode does not
+	// take a turn cap; the wrapper ignores this value.
+	MaxTurns int `mapstructure:"maxTurns"`
 }
 
 func decodeRunOpenRouterSpec(raw any) (RunOpenRouterSpec, error) {
@@ -36,7 +35,6 @@ func decodeRunOpenRouterSpec(raw any) (RunOpenRouterSpec, error) {
 	if spec.ExecutionTimeoutSeconds <= 0 {
 		spec.ExecutionTimeoutSeconds = runner.DefaultExecutionTimeoutSeconds
 	}
-	spec.MaxTurns = effectiveMaxTurns(spec.MaxTurns)
 	return spec, nil
 }
 
@@ -70,11 +68,6 @@ func validateRunOpenRouterSpec(spec RunOpenRouterSpec) error {
 			return fmt.Errorf("execution timeout must be between 1 and %d seconds, or 0 to use the default (%d seconds)", runner.MaxExecutionTimeoutSecondsRequest, runner.DefaultExecutionTimeoutSeconds)
 		}
 	}
-	if spec.MaxTurns != 0 {
-		if spec.MaxTurns < 1 || spec.MaxTurns > MaxTurnsLimit {
-			return fmt.Errorf("max turns must be between 1 and %d, or 0 to use the default (%d)", MaxTurnsLimit, DefaultMaxTurns)
-		}
-	}
 	return nil
 }
 
@@ -84,11 +77,10 @@ type OpenRouterBrokerTask struct {
 	Files    []runner.BrokerTaskFile
 }
 
-func buildOpenRouterBrokerTask(spec RunOpenRouterSpec, usage string, setups []runner.IntegrationSetup) OpenRouterBrokerTask {
-	maxTurns := effectiveMaxTurns(spec.MaxTurns)
+func buildOpenRouterBrokerTask(spec RunOpenRouterSpec, usage string, setups []runner.IntegrationSetup, fallbackModels []string) OpenRouterBrokerTask {
 	commands, files := runner.BuildAgentBrokerTask(runner.AgentBrokerTaskInput{
 		PrepareName:      "Prepare OpenRouter agent",
-		PrepareScript:    runner.NodePrepareScript("", "", spec.WorkingDirectory),
+		PrepareScript:    runner.NodePrepareScript("opencode", opencodeMissingMessage, spec.WorkingDirectory),
 		RunScriptName:    "run.js",
 		RunScript:        runScript,
 		WorkingDirectory: spec.WorkingDirectory,
@@ -98,22 +90,30 @@ func buildOpenRouterBrokerTask(spec RunOpenRouterSpec, usage string, setups []ru
 		Model:            strings.TrimSpace(spec.Model),
 		PromptCommand: func(promptName, model string) string {
 			return fmt.Sprintf(
-				`node "$SUPERPLANE_TASK_DIR/run.js" "$SUPERPLANE_TASK_DIR/prompts/%s" %s %d`,
+				`node "$SUPERPLANE_TASK_DIR/run.js" "$SUPERPLANE_TASK_DIR/prompts/%s" %s`,
 				promptName,
 				runner.ShellSingleQuote(model),
-				maxTurns,
 			)
 		},
 	})
+	files = append(files, FallbackModelsFile(spec.Model, fallbackModels))
 	return OpenRouterBrokerTask{Commands: commands, Files: files}
 }
 
-func BuildBrokerTask(spec RunOpenRouterSpec, usage string, setups []runner.IntegrationSetup) OpenRouterBrokerTask {
-	return buildOpenRouterBrokerTask(spec, usage, setups)
+func BuildBrokerTask(spec RunOpenRouterSpec, usage string, setups []runner.IntegrationSetup, fallbackModels []string) OpenRouterBrokerTask {
+	return buildOpenRouterBrokerTask(spec, usage, setups, fallbackModels)
 }
 
 func ApplyPlanningFollowUp(task OpenRouterBrokerTask, environment []runner.BrokerEnvironmentVariable, spec RunOpenRouterSpec) OpenRouterBrokerTask {
 	return applyPlanningFollowUp(task, environment, spec)
+}
+
+func attachPlanningSessionFiles(task OpenRouterBrokerTask, environment []runner.BrokerEnvironmentVariable) OpenRouterBrokerTask {
+	if !runner.HasPlanningSessionToken(environment) {
+		return task
+	}
+	task.Files = append(task.Files, runner.PlanningSessionMCPFiles()...)
+	return task
 }
 
 // applyPlanningFollowUp keeps the machine on after canvas steps when this run
@@ -131,17 +131,12 @@ func applyPlanningFollowUp(task OpenRouterBrokerTask, environment []runner.Broke
 func planningFollowUpCommand(spec RunOpenRouterSpec) runner.BrokerCommand {
 	workdir := planningFollowUpWorkingDirectory(spec)
 	model := strings.TrimSpace(spec.Model)
-	maxTurns := effectiveMaxTurns(spec.MaxTurns)
 	return runner.BrokerCommand{
 		Name: "Wait for the next message",
 		Command: runner.WrapAgentStepCommand(
 			runner.WrapCommandInWorkingDirectory(
 				workdir,
-				fmt.Sprintf(
-					`node "$SUPERPLANE_TASK_DIR/follow_up_loop.js" %s %d`,
-					runner.ShellSingleQuote(model),
-					maxTurns,
-				),
+				fmt.Sprintf(`node "$SUPERPLANE_TASK_DIR/follow_up_loop.js" %s`, runner.ShellSingleQuote(model)),
 			),
 		),
 		Kind:    runner.LiveLogKindPrompt,
@@ -156,11 +151,4 @@ func planningFollowUpWorkingDirectory(spec RunOpenRouterSpec) string {
 		}
 	}
 	return strings.TrimSpace(spec.WorkingDirectory)
-}
-
-func effectiveMaxTurns(maxTurns int) int {
-	if maxTurns <= 0 {
-		return DefaultMaxTurns
-	}
-	return maxTurns
 }

--- a/pkg/components/runner/openrouter/spec_test.go
+++ b/pkg/components/runner/openrouter/spec_test.go
@@ -1,9 +1,10 @@
 package openrouter
 
 import (
-	"fmt"
+	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/superplanehq/superplane/pkg/components/runner"
@@ -64,7 +65,7 @@ func TestValidateRunOpenRouterSpecRequiresModel(t *testing.T) {
 	require.Contains(t, err.Error(), "model is required")
 }
 
-func TestDecodeRunOpenRouterSpecDefaultsMaxTurns(t *testing.T) {
+func TestDecodeRunOpenRouterSpecIgnoresOmittedMaxTurns(t *testing.T) {
 	t.Parallel()
 
 	spec, err := decodeRunOpenRouterSpec(map[string]any{
@@ -76,7 +77,7 @@ func TestDecodeRunOpenRouterSpecDefaultsMaxTurns(t *testing.T) {
 		"credentials": map[string]any{"source": "hosted"},
 	})
 	require.NoError(t, err)
-	require.Equal(t, DefaultMaxTurns, spec.MaxTurns)
+	require.Equal(t, 0, spec.MaxTurns)
 	require.Equal(t, runner.DefaultExecutionTimeoutSeconds, spec.ExecutionTimeoutSeconds)
 }
 
@@ -96,64 +97,57 @@ func TestDecodeRunOpenRouterSpecKeepsExplicitMaxTurns(t *testing.T) {
 	require.Equal(t, 64, spec.MaxTurns)
 }
 
-func TestValidateRunOpenRouterSpecRejectsMaxTurnsAboveLimit(t *testing.T) {
+func TestValidateRunOpenRouterSpecIgnoresLegacyMaxTurns(t *testing.T) {
 	t.Parallel()
 
 	prompt := "fix tests"
 	spec := validOpenRouterSpec(prompt)
-	spec.MaxTurns = MaxTurnsLimit + 1
-	err := validateRunOpenRouterSpec(spec)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "max turns")
+	spec.MaxTurns = 9999
+	require.NoError(t, validateRunOpenRouterSpec(spec))
 }
 
-func TestValidateConfigurationOpenRouterRejectsMaxTurnsAboveLimit(t *testing.T) {
-	t.Parallel()
-
-	fields := (&RunOpenRouter{}).Configuration()
-	err := configuration.ValidateConfiguration(fields, map[string]any{
-		"machineType": "e1-large-amd64",
-		"credentials": map[string]any{
-			"source":      "integration",
-			"integration": map[string]any{"name": "openrouter"},
-		},
-		"model":    "anthropic/claude-sonnet-4-6",
-		"maxTurns": MaxTurnsLimit + 1,
-		"steps": []any{
-			map[string]any{"name": "Prompt", "type": "prompt", "prompt": "fix tests"},
-		},
-	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "at most")
-}
-
-func TestBuildOpenRouterBrokerTaskPassesMaxTurns(t *testing.T) {
+func TestBuildOpenRouterBrokerTaskOmitsMaxTurnsArgv(t *testing.T) {
 	t.Parallel()
 
 	prompt := "fix tests"
 	spec := validOpenRouterSpec(prompt)
 	spec.MaxTurns = 64
-	task := buildOpenRouterBrokerTask(spec, "", nil)
+	task := buildOpenRouterBrokerTask(spec, "", nil, nil)
 	require.GreaterOrEqual(t, len(task.Commands), 2)
-	require.Contains(t, task.Commands[1].Command, `node "$SUPERPLANE_TASK_DIR/run.js" "$SUPERPLANE_TASK_DIR/prompts/01-prompt.txt" 'anthropic/claude-sonnet-4-6' 64`)
+	require.Contains(t, task.Commands[1].Command, `node "$SUPERPLANE_TASK_DIR/run.js" "$SUPERPLANE_TASK_DIR/prompts/01-prompt.txt" 'anthropic/claude-sonnet-4-6'`)
+	require.NotContains(t, task.Commands[1].Command, " 64")
 }
 
-func TestBuildOpenRouterBrokerTaskDefaultsMaxTurns(t *testing.T) {
+func TestBuildOpenRouterBrokerTaskRequiresOpenCode(t *testing.T) {
 	t.Parallel()
 
-	prompt := "fix tests"
-	spec := validOpenRouterSpec(prompt)
-	spec.MaxTurns = 0
-	task := buildOpenRouterBrokerTask(spec, "", nil)
-	require.GreaterOrEqual(t, len(task.Commands), 2)
-	require.Contains(t, task.Commands[1].Command, fmt.Sprintf("'anthropic/claude-sonnet-4-6' %d", DefaultMaxTurns))
+	task := buildOpenRouterBrokerTask(validOpenRouterSpec("fix tests"), "", nil, nil)
+	prepare := requireTaskFile(t, task.Files, "prepare.sh").Content
+	require.Contains(t, prepare, "opencode CLI not found on PATH; install OpenCode on the runner")
+	require.Contains(t, prepare, "command -v opencode")
+	require.Contains(t, prepare, "command -v node")
+}
+
+func TestBuildOpenRouterBrokerTaskWritesFallbackModels(t *testing.T) {
+	t.Parallel()
+
+	task := buildOpenRouterBrokerTask(
+		validOpenRouterSpec("fix tests"),
+		"",
+		nil,
+		[]string{"openai/gpt-4.1", "anthropic/claude-sonnet-4-6"},
+	)
+	file := requireTaskFile(t, task.Files, "openrouter_models.json")
+	var models []string
+	require.NoError(t, json.Unmarshal([]byte(file.Content), &models))
+	require.Equal(t, []string{"anthropic/claude-sonnet-4-6", "openai/gpt-4.1"}, models)
 }
 
 func TestApplyPlanningFollowUpLeavesLineAutomationsUnchanged(t *testing.T) {
 	t.Parallel()
 
 	spec := validOpenRouterSpec("fix tests")
-	base := buildOpenRouterBrokerTask(spec, "", nil)
+	base := buildOpenRouterBrokerTask(spec, "", nil, nil)
 	got := applyPlanningFollowUp(base, nil, spec)
 	require.Len(t, got.Commands, len(base.Commands))
 	require.Len(t, got.Files, len(base.Files))
@@ -166,7 +160,7 @@ func TestApplyPlanningFollowUpAppendsWaitLoopForPlanningToken(t *testing.T) {
 	spec := validOpenRouterSpec(prompt)
 	spec.MaxTurns = 32
 	spec.Steps[0].WorkingDirectory = "repo"
-	base := buildOpenRouterBrokerTask(spec, "", nil)
+	base := buildOpenRouterBrokerTask(spec, "", nil, nil)
 	got := applyPlanningFollowUp(base, []runner.BrokerEnvironmentVariable{{
 		Name:  runner.EnvSuperplanePlanningID,
 		Value: "session-1",
@@ -176,7 +170,8 @@ func TestApplyPlanningFollowUpAppendsWaitLoopForPlanningToken(t *testing.T) {
 	last := got.Commands[len(got.Commands)-1]
 	require.Equal(t, "Wait for the next message", last.Name)
 	require.Equal(t, runner.LiveLogKindPrompt, last.Kind)
-	require.Contains(t, last.Command, `node "$SUPERPLANE_TASK_DIR/follow_up_loop.js" 'anthropic/claude-sonnet-4-6' 32`)
+	require.Contains(t, last.Command, `node "$SUPERPLANE_TASK_DIR/follow_up_loop.js" 'anthropic/claude-sonnet-4-6'`)
+	require.NotContains(t, last.Command, " 32")
 	require.Contains(t, last.Command, `cd "$_sp_root"/'repo'`)
 
 	var found bool
@@ -187,6 +182,40 @@ func TestApplyPlanningFollowUpAppendsWaitLoopForPlanningToken(t *testing.T) {
 		}
 	}
 	require.True(t, found, "expected follow_up_loop.js task file")
+}
+
+func TestAttachPlanningSessionFilesShipsMCP(t *testing.T) {
+	t.Parallel()
+
+	spec := validOpenRouterSpec("greet")
+	base := buildOpenRouterBrokerTask(spec, "", nil, nil)
+	got := attachPlanningSessionFiles(base, []runner.BrokerEnvironmentVariable{{
+		Name:  runner.EnvSuperplanePlanningID,
+		Value: "session-1",
+	}})
+	require.Equal(t, runner.PlanningSessionMCPScript(), requireTaskFile(t, got.Files, "planning_session_mcp.js").Content)
+	require.Equal(t, runner.PlanningSessionMCPConfigJSON(), requireTaskFile(t, got.Files, "mcp.json").Content)
+}
+
+func TestOrderedFallbackModelsPutsSelectedFirst(t *testing.T) {
+	t.Parallel()
+
+	got := OrderedFallbackModels("x-ai/grok-4.6", []string{"anthropic/claude-sonnet-4-6", "x-ai/grok-4.6", "openai/gpt-4.1"})
+	require.Equal(t, []string{"x-ai/grok-4.6", "anthropic/claude-sonnet-4-6", "openai/gpt-4.1"}, got)
+}
+
+func TestRunScriptSpawnsOpenCodeNotChatCompletions(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(t, runScript, "--format")
+	assert.Contains(t, runScript, "--auto")
+	assert.Contains(t, runScript, "--pure")
+	assert.Contains(t, runScript, "openrouter/")
+	assert.Contains(t, runScript, "OPENCODE_CONFIG")
+	assert.Contains(t, runScript, "OPENROUTER_BASE_URL")
+	assert.NotContains(t, runScript, "/chat/completions")
+	assert.NotContains(t, runScript, "--agent")
+	assert.NotContains(t, runScript, "proposeDraft")
 }
 
 func validOpenRouterSpec(prompt string) RunOpenRouterSpec {
@@ -219,4 +248,23 @@ func TestValidateConfigurationOpenRouterRequiresModel(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "model")
+}
+
+func TestConfigurationOmitsMaxTurns(t *testing.T) {
+	t.Parallel()
+
+	for _, field := range (&RunOpenRouter{}).Configuration() {
+		assert.NotEqual(t, "maxTurns", field.Name)
+	}
+}
+
+func requireTaskFile(t *testing.T, files []runner.BrokerTaskFile, path string) runner.BrokerTaskFile {
+	t.Helper()
+	for _, file := range files {
+		if file.Path == path {
+			return file
+		}
+	}
+	t.Fatalf("missing task file %q", path)
+	return runner.BrokerTaskFile{}
 }

--- a/pkg/components/runner/planning_session_assets.go
+++ b/pkg/components/runner/planning_session_assets.go
@@ -2,9 +2,9 @@ package runner
 
 import _ "embed"
 
-// Planning sessions run every code runner (Claude, Codex, OpenRouter) in a
-// read-only "explore, then propose a draft" mode. These assets are shared by
-// every runner so the wait loop and the MCP tool contract behave identically
+// Planning sessions run every code runner (Claude, Codex, OpenCode/OpenRouter)
+// in a read-only "explore, then propose a draft" mode. These assets are shared
+// by every runner so the wait loop and the MCP tool contract behave identically
 // regardless of which agent CLI is executing the turn.
 
 //go:embed planning_session_mcp.js
@@ -17,7 +17,7 @@ var planningSessionMCPConfig string
 var followUpLoopScript string
 
 // PlanningSessionMCPScript is the stdio MCP server exposing propose_draft and
-// survey. Runners that speak MCP (Claude, Codex) ship it under
+// survey. Runners that speak MCP (Claude, Codex, OpenCode) ship it under
 // SUPERPLANE_TASK_DIR as planning_session_mcp.js.
 func PlanningSessionMCPScript() string { return planningSessionMCPScript }
 
@@ -28,10 +28,8 @@ func PlanningSessionMCPConfigJSON() string { return planningSessionMCPConfig }
 // run.js --continue (or the runner's equivalent) for each one.
 func FollowUpLoopScript() string { return followUpLoopScript }
 
-// PlanningSessionMCPScriptFile is just the MCP server task file. Runners that
-// do not speak MCP (OpenRouter) still ship this file so their tool loop can
-// require() its exported proposeDraft/proposeSurvey helpers instead of
-// duplicating the SuperPlane planning-endpoint request contract.
+// PlanningSessionMCPScriptFile is just the MCP server task file. Attach it
+// together with PlanningSessionMCPConfigFile for runners that speak MCP.
 func PlanningSessionMCPScriptFile() BrokerTaskFile {
 	return BrokerTaskFile{Path: "planning_session_mcp.js", Content: planningSessionMCPScript, Mode: "0644"}
 }

--- a/pkg/components/runner/superplane/component.go
+++ b/pkg/components/runner/superplane/component.go
@@ -165,7 +165,7 @@ func (c *RunSuperPlane) Execute(ctx core.ExecutionContext) error {
 	}
 
 	environment = runner.AttachPlanningSessionEnv(ctx, environment, spec.ExecutionTimeoutSeconds)
-	commands, files, err := buildSuperPlaneBrokerTask(runModel.Provider, spec, runModel.Model, resolved.Usage, resolved.Setups, environment)
+	commands, files, err := buildSuperPlaneBrokerTask(runModel.Provider, spec, runModel.Model, resolved.Usage, resolved.Setups, environment, access.AllowedModels)
 	if err != nil {
 		return err
 	}
@@ -266,6 +266,7 @@ func buildSuperPlaneBrokerTask(
 	usage string,
 	setups []runner.IntegrationSetup,
 	environment []runner.BrokerEnvironmentVariable,
+	fallbackModels []string,
 ) ([]runner.BrokerCommand, []runner.BrokerTaskFile, error) {
 	switch provider {
 	case models.UsageProviderAnthropic:
@@ -296,8 +297,12 @@ func buildSuperPlaneBrokerTask(
 			WorkingDirectory:        spec.WorkingDirectory,
 			ExecutionTimeoutSeconds: spec.ExecutionTimeoutSeconds,
 		}
-		task := openrouter.ApplyPlanningFollowUp(openrouter.BuildBrokerTask(openRouterSpec, usage, setups), environment, openRouterSpec)
-		return withPlanningSessionFiles(task.Commands, task.Files, environment, runner.PlanningSessionMCPScriptFile())
+		task := openrouter.ApplyPlanningFollowUp(
+			openrouter.BuildBrokerTask(openRouterSpec, usage, setups, fallbackModels),
+			environment,
+			openRouterSpec,
+		)
+		return withPlanningSessionFiles(task.Commands, task.Files, environment, runner.PlanningSessionMCPFiles()...)
 	default:
 		return nil, nil, fmt.Errorf("unsupported SuperPlane agent provider: %s", provider)
 	}

--- a/pkg/components/runner/superplane/component.go
+++ b/pkg/components/runner/superplane/component.go
@@ -165,6 +165,7 @@ func (c *RunSuperPlane) Execute(ctx core.ExecutionContext) error {
 	}
 
 	environment = runner.AttachPlanningSessionEnv(ctx, environment, spec.ExecutionTimeoutSeconds)
+	environment = runner.AttachExecutionTimeoutEnv(environment, spec.ExecutionTimeoutSeconds)
 	commands, files, err := buildSuperPlaneBrokerTask(runModel.Provider, spec, runModel.Model, resolved.Usage, resolved.Setups, environment, access.AllowedModels)
 	if err != nil {
 		return err

--- a/pkg/components/runner/superplane/component_test.go
+++ b/pkg/components/runner/superplane/component_test.go
@@ -62,6 +62,7 @@ func TestRunSuperPlaneExecuteUsesNodeModelOverDefault(t *testing.T) {
 		AllowedModels: []string{"anthropic/claude-sonnet-4-6", "x-ai/grok-4.6"},
 	})
 	assert.Equal(t, "sk-or", requireEnvironmentValue(t, req.Environment, envOpenRouterAPIKey))
+	assert.Equal(t, "3600", requireEnvironmentValue(t, req.Environment, runner.EnvExecutionTimeoutSeconds))
 	modelsFile := requireTaskFile(t, req.Files, "openrouter_models.json")
 	assert.JSONEq(t, `["anthropic/claude-sonnet-4-6","x-ai/grok-4.6"]`, modelsFile.Content)
 	prepare := requireTaskFile(t, req.Files, "prepare.sh").Content

--- a/pkg/components/runner/superplane/component_test.go
+++ b/pkg/components/runner/superplane/component_test.go
@@ -59,9 +59,37 @@ func TestRunSuperPlaneExecuteUsesNodeModelOverDefault(t *testing.T) {
 		Model:    "claude-sonnet-4-6",
 	}, core.HostedLLMAccess{
 		APIKey:        "sk-or",
-		AllowedModels: []string{"anthropic/claude-sonnet-4-6"},
+		AllowedModels: []string{"anthropic/claude-sonnet-4-6", "x-ai/grok-4.6"},
 	})
 	assert.Equal(t, "sk-or", requireEnvironmentValue(t, req.Environment, envOpenRouterAPIKey))
+	modelsFile := requireTaskFile(t, req.Files, "openrouter_models.json")
+	assert.JSONEq(t, `["anthropic/claude-sonnet-4-6","x-ai/grok-4.6"]`, modelsFile.Content)
+	prepare := requireTaskFile(t, req.Files, "prepare.sh").Content
+	assert.Contains(t, prepare, "opencode CLI not found")
+	assert.NotContains(t, strings.Join(commandStrings(req.Commands), "\n"), " 128")
+}
+
+func TestBuildSuperPlaneBrokerTaskOpenRouterShipsPlanningMCP(t *testing.T) {
+	prompt := "hello"
+	spec := RunSuperPlaneSpec{
+		MachineType: testRunnerMachineType,
+		Steps: []runner.AgentStep{
+			{Name: "Hello", Type: runner.AgentStepPrompt, Prompt: &prompt},
+		},
+	}
+	_, files, err := buildSuperPlaneBrokerTask(
+		models.UsageProviderOpenRouter,
+		spec,
+		"anthropic/claude-sonnet-4-6",
+		"",
+		nil,
+		[]runner.BrokerEnvironmentVariable{{Name: runner.EnvSuperplanePlanningID, Value: "session-1"}},
+		[]string{"anthropic/claude-sonnet-4-6"},
+	)
+	require.NoError(t, err)
+	assert.True(t, hasTaskFile(files, "planning_session_mcp.js"))
+	assert.True(t, hasTaskFile(files, "mcp.json"))
+	assert.True(t, hasTaskFile(files, "openrouter_models.json"))
 }
 
 func TestRunSuperPlaneExecuteUsesNodeModelWhenDefaultIsMissing(t *testing.T) {
@@ -215,6 +243,25 @@ func hasTaskFile(files []runner.BrokerTaskFile, path string) bool {
 		}
 	}
 	return false
+}
+
+func requireTaskFile(t *testing.T, files []runner.BrokerTaskFile, path string) runner.BrokerTaskFile {
+	t.Helper()
+	for _, file := range files {
+		if file.Path == path {
+			return file
+		}
+	}
+	t.Fatalf("missing task file %q", path)
+	return runner.BrokerTaskFile{}
+}
+
+func commandStrings(commands []runner.BrokerCommand) []string {
+	out := make([]string, 0, len(commands))
+	for _, command := range commands {
+		out = append(out, command.Command)
+	}
+	return out
 }
 
 func TestRunSuperPlaneExecuteRejectsPrivateHostedBaseURL(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Run OpenRouter Agent starts OpenCode on the runner instead of a custom chat loop.

Prompt steps continue one OpenCode session. On a per-model RPM or 429 limit, SuperPlane switches to the next allowed OpenRouter model.

Prepare fails with a clear message when `opencode` is not on PATH. Pin OpenCode in the runner image in a separate repository.

The wrapper classifies rate limits only after a failed spawn. A recovered OpenCode run that logs 429 on stderr does not switch models.

`--pure` is a global OpenCode flag, so the argv puts it before `run`. The task environment also sets `OPENCODE_PURE=1`.

The task environment includes `SUPERPLANE_EXECUTION_TIMEOUT_SECONDS` so a 60s wait cannot exceed the node timeout.

## Test plan

- [x] Run `go test ./pkg/components/runner/openrouter ./pkg/components/runner/superplane ./pkg/components/runner`
- [x] Confirm prepare.sh requires `opencode` on PATH
- [x] Confirm a new-account-rpm fixture switches `--session` to the next allowed model
- [x] Confirm an invalid API key fails with no model switch
- [x] Confirm hosted Execute writes `openrouter_models.json` from the allowlist
- [x] Confirm `OPENROUTER_BASE_URL` is written into task `opencode.json`
- [x] Confirm a successful spawn with 429 on stderr does not switch models
- [x] Confirm `SUPERPLANE_EXECUTION_TIMEOUT_SECONDS` is present on the broker task
- [x] Confirm argv is `opencode --pure run ...`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d5a5f56-59b1-4093-9fea-4bdf5a2d095c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d5a5f56-59b1-4093-9fea-4bdf5a2d095c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61866360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/superplane/-/pull-requests/superplanehq/superplane/7287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a></h2>

The PR is not safe to merge because planning sessions can still modify repository files through unrestricted shell commands.

<!-- /greptile_comment -->