### PR TITLE
fix: Add workspace switch on workspace setup

### DIFF
--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.chrome.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.chrome.spec.tsx
@@ -1,0 +1,194 @@
+import { render, renderHook, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type * as ReactRouterDom from "react-router";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FactoriesFactory } from "@/api-client";
+
+import { FirstRunSetup } from "./FirstRunSetup";
+import { useOnboardingSetupState, type OnboardingSetupApi } from "./useOnboardingSetupState";
+import type { useOnboardingPageModel } from "./useOnboardingPageModel";
+
+type OnboardingPageModel = ReturnType<typeof useOnboardingPageModel>;
+
+let factory: FactoriesFactory;
+let factories: FactoriesFactory[];
+
+vi.mock("../../layout/factoriesLayoutContext", () => ({
+  useFactoriesLayout: () => ({
+    organizationId: "org-1",
+    factoryId: "factory-1",
+    factoryKey: "PAY",
+    factory,
+    factories,
+  }),
+}));
+
+vi.mock("@/contexts/useAccount", () => ({
+  useAccount: () => ({ account: { id: "account-1", name: "Ada Lovelace", email: "ada@example.com" } }),
+}));
+
+vi.mock("@/hooks/useMe", () => ({
+  useMe: () => ({ data: { id: "user-1" } }),
+}));
+
+vi.mock("@/posthog", () => ({ posthog: { reset: vi.fn() } }));
+
+vi.mock("@/hooks/useRecheckGitHubInstallRequest", () => ({
+  useRecheckGitHubInstallRequest: vi.fn(),
+}));
+
+vi.mock("@/hooks/useBindGitHubInstallation", () => ({
+  useBindGitHubInstallation: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+}));
+
+const navigateSpy = vi.fn();
+
+let accountOrganizations: Array<{ id: string; name: string; slug?: string }>;
+
+vi.mock("@/hooks/useAccountOrganizations", () => ({
+  useAccountOrganizations: () => ({ data: accountOrganizations, refetch: vi.fn() }),
+}));
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof ReactRouterDom>("react-router");
+  return {
+    ...actual,
+    useNavigate: () => navigateSpy,
+  };
+});
+
+vi.mock("./AgentStep", () => ({
+  AgentStep: () => <div data-testid="agent-step" />,
+}));
+
+function setupState(): OnboardingSetupApi {
+  const { result } = renderHook(() => useOnboardingSetupState("Payments Service", { simulateDiscovery: false }));
+  return result.current;
+}
+
+function pageModel(overrides: Partial<OnboardingPageModel> = {}): OnboardingPageModel {
+  return {
+    setup: setupState(),
+    hostedAgentReady: false,
+    openSection: "issues",
+    setOpenSection: vi.fn(),
+    requestConnect: vi.fn(),
+    refreshGithubConnections: vi.fn().mockResolvedValue(undefined),
+    githubConnectionsLoading: false,
+    requestPrivateGitHubConnect: vi.fn(),
+    offersPrivateGitHubAppSetup: false,
+    createVcsConnection: vi.fn(),
+    selectVcsConnection: vi.fn().mockResolvedValue(true),
+    githubConnections: { name: "github", allInstances: [], readyInstances: [] },
+    selectedVcsConnectionId: "github-1",
+    requestConfigure: vi.fn(),
+    integrationDialogs: <></>,
+    repositories: ["acme/payments-service"],
+    repositoriesLoading: false,
+    repositoriesError: null,
+    canConfigureWorkspace: true,
+    saving: false,
+    saveName: vi.fn().mockResolvedValue(true),
+    saveRepository: vi.fn().mockResolvedValue(true),
+    saveIssues: vi.fn().mockResolvedValue(true),
+    finish: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderSetup(model: OnboardingPageModel) {
+  render(
+    <MemoryRouter initialEntries={["/org-1/workspaces/PAY/setup?step=issues"]}>
+      <FirstRunSetup model={model} />
+    </MemoryRouter>,
+  );
+}
+
+describe("FirstRunSetup chrome", () => {
+  beforeEach(() => {
+    factory = { id: "factory-1", key: "PAY", name: "New workspace", onboarding: { vcsIntegrationId: "github-1" } };
+    factories = [factory];
+    accountOrganizations = [{ id: "org-1", name: "Acme" }];
+    navigateSpy.mockClear();
+  });
+
+  it("shows the workspace switch when another workspace exists", () => {
+    factories = [factory, { id: "factory-2", key: "CORE", name: "Core" }];
+
+    renderSetup(pageModel());
+
+    expect(screen.getByTestId("first-run-log-out")).toBeInTheDocument();
+    expect(screen.getByTestId("first-run-workspace-switch")).toHaveTextContent("NW");
+    expect(screen.getByTestId("first-run-workspace-switch")).toHaveAccessibleName(/Switch workspace, New workspace/);
+    expect(screen.queryByTestId("first-run-organization-switch")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-cancel")).not.toBeInTheDocument();
+  });
+
+  it("opens the other workspace from the switch menu", async () => {
+    factories = [factory, { id: "factory-2", key: "CORE", name: "Core", lines: [{ id: "line-core" }] }];
+    const user = userEvent.setup();
+
+    renderSetup(pageModel());
+
+    await user.click(screen.getByTestId("first-run-workspace-switch"));
+    await user.click(screen.getByTestId("first-run-workspace-option-factory-2"));
+
+    expect(navigateSpy).toHaveBeenCalledWith("/org-1/workspaces/CORE/lines/line-core");
+  });
+
+  it("shows Log out and the organization switch when another organization exists", () => {
+    factories = [factory];
+    accountOrganizations = [
+      { id: "org-1", name: "Acme" },
+      { id: "org-2", name: "Other Co" },
+    ];
+
+    renderSetup(pageModel());
+
+    expect(screen.getByTestId("first-run-log-out")).toBeInTheDocument();
+    expect(screen.getByTestId("first-run-organization-switch")).toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-workspace-switch")).not.toBeInTheDocument();
+  });
+
+  it("shows both switches when another workspace and another organization exist", () => {
+    factories = [factory, { id: "factory-2", key: "CORE", name: "Core" }];
+    accountOrganizations = [
+      { id: "org-1", name: "Acme" },
+      { id: "org-2", name: "Other Co" },
+    ];
+
+    renderSetup(pageModel());
+
+    expect(screen.getByTestId("first-run-workspace-switch")).toBeInTheDocument();
+    expect(screen.getByTestId("first-run-organization-switch")).toBeInTheDocument();
+  });
+
+  it("opens the current organization from the switch menu so the user can leave setup", async () => {
+    accountOrganizations = [
+      { id: "org-1", name: "Acme" },
+      { id: "org-2", name: "Other Co" },
+    ];
+    const user = userEvent.setup();
+
+    renderSetup(pageModel());
+
+    await user.click(screen.getByTestId("first-run-organization-switch"));
+    await user.click(screen.getByTestId("first-run-organization-option-org-1"));
+
+    expect(navigateSpy).toHaveBeenCalledWith("/org-1");
+  });
+
+  it("keeps Log out and hides both switches with a single org and single workspace", () => {
+    factories = [factory];
+    accountOrganizations = [{ id: "org-1", name: "Acme" }];
+
+    renderSetup(pageModel());
+
+    expect(screen.getByTestId("first-run-log-out")).toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-organization-switch")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-workspace-switch")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-cancel")).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
@@ -114,7 +114,7 @@ function renderSetup(model: OnboardingPageModel, path = "/org-1/workspaces/PAY/s
 
 describe("FirstRunSetup", () => {
   beforeEach(() => {
-    factory = { id: "factory-1", onboarding: { vcsIntegrationId: "github-1" } };
+    factory = { id: "factory-1", key: "PAY", name: "New workspace", onboarding: { vcsIntegrationId: "github-1" } };
     factories = [factory];
     accountOrganizations = [{ id: "org-1", name: "Acme" }];
     navigateSpy.mockClear();
@@ -573,41 +573,6 @@ describe("FirstRunSetup", () => {
     expect(screen.getByTestId("first-run-agent")).toBeInTheDocument();
   });
 
-  it("shows Log out and the organization switch when another workspace exists", () => {
-    factories = [factory, { id: "factory-2" }];
-
-    renderSetup(pageModel());
-
-    expect(screen.getByTestId("first-run-log-out")).toBeInTheDocument();
-    expect(screen.getByTestId("first-run-organization-switch")).toBeInTheDocument();
-    expect(screen.queryByTestId("first-run-cancel")).not.toBeInTheDocument();
-  });
-
-  it("shows Log out and the organization switch when another organization exists", () => {
-    factories = [factory];
-    accountOrganizations = [
-      { id: "org-1", name: "Acme" },
-      { id: "org-2", name: "Other Co" },
-    ];
-
-    renderSetup(pageModel());
-
-    expect(screen.getByTestId("first-run-log-out")).toBeInTheDocument();
-    expect(screen.getByTestId("first-run-organization-switch")).toBeInTheDocument();
-  });
-
-  it("opens the current organization from the switch menu so the user can leave setup", async () => {
-    factories = [factory, { id: "factory-2" }];
-    const user = userEvent.setup();
-
-    renderSetup(pageModel());
-
-    await user.click(screen.getByTestId("first-run-organization-switch"));
-    await user.click(screen.getByTestId("first-run-organization-option-org-1"));
-
-    expect(navigateSpy).toHaveBeenCalledWith("/org-1");
-  });
-
   it("goes back through every screen to the welcome screen", async () => {
     const user = userEvent.setup();
     const model = pageModel({
@@ -629,16 +594,5 @@ describe("FirstRunSetup", () => {
     expect(screen.getByTestId("first-run-welcome")).toBeInTheDocument();
     // The welcome screen is the first screen, so it offers no Back.
     expect(screen.queryByTestId("first-run-back")).not.toBeInTheDocument();
-  });
-
-  it("keeps Log out and hides the organization switch with a single org and single workspace", () => {
-    factories = [factory];
-    accountOrganizations = [{ id: "org-1", name: "Acme" }];
-
-    renderSetup(pageModel());
-
-    expect(screen.getByTestId("first-run-log-out")).toBeInTheDocument();
-    expect(screen.queryByTestId("first-run-organization-switch")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("first-run-cancel")).not.toBeInTheDocument();
   });
 });

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
@@ -440,20 +440,19 @@ export function FirstRunSetup({ model }: { model: OnboardingPageModel }) {
   // The placeholder workspace under setup is itself in `factories`, so
   // another workspace exists when any factory has a different id.
   const hasOtherWorkspace = factories.some((existing) => existing.id !== factoryId);
-  // The user can also belong to organizations outside the current one. Those
-  // give the user somewhere to go even when this organization has no other
-  // workspace yet.
+  // The organization switch is only for other organizations. Another
+  // workspace in this organization uses the workspace switch.
   const otherOrganizations = (accountOrganizations.data ?? []).filter(
     (organization) => !organizationMatchesRoute(organization, organizationId),
   );
-  const canSwitchOrganization = hasOtherWorkspace || otherOrganizations.length > 0;
 
   const chromeFor = (target: FirstRunScreen): FirstRunChrome => {
     return {
       displayName: firstNameOf(account?.name),
       email: account?.email,
       onLogOut: signOut,
-      organizationSwitch: canSwitchOrganization ? { currentOrganizationRouteId: organizationId } : undefined,
+      organizationSwitch: otherOrganizations.length > 0 ? { currentOrganizationRouteId: organizationId } : undefined,
+      workspaceSwitch: hasOtherWorkspace ? { organizationId, currentFactoryId: factoryId, factories } : undefined,
       stepIndex: STEP_INDEX_FOR_SCREEN[target],
       stepCount: flow.skipAgentScreen ? FIRST_RUN_STEP_COUNT - 1 : FIRST_RUN_STEP_COUNT,
       onBack: backActionFor(target, flow),

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunShell.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunShell.tsx
@@ -8,6 +8,7 @@ import type { ReactNode } from "react";
 import { useFactoriesThemeClass } from "../../../lib/useFactoriesThemeClass";
 import { FIRST_RUN_COPY } from "./firstRunCopy";
 import type { FirstRunChrome } from "./firstRunTypes";
+import { FirstRunWorkspaceSwitch } from "./FirstRunWorkspaceSwitch";
 
 export const FIRST_RUN_STEP_COUNT = 5;
 
@@ -41,29 +42,7 @@ export function FirstRunShell({
           >
             {copy.logOut}
           </Button>
-          {chrome?.organizationSwitch ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  className="text-muted-foreground hover:text-foreground"
-                  aria-label={copy.switchOrganization}
-                  data-testid="first-run-organization-switch"
-                >
-                  <ArrowRightLeft className="size-4" aria-hidden />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" className="w-64">
-                <OrganizationSwitchMenu
-                  currentOrganizationRouteId={chrome.organizationSwitch.currentOrganizationRouteId}
-                  navigateToCurrentOrganization
-                  testIdPrefix="first-run"
-                />
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : null}
+          <FirstRunOrganizationSwitch organizationSwitch={chrome?.organizationSwitch} />
         </div>
         {identity ? (
           <p className="text-right text-[13px] leading-5 text-muted-foreground" data-testid="first-run-signed-in">
@@ -90,6 +69,8 @@ export function FirstRunShell({
         </div>
       </div>
 
+      <FirstRunWorkspaceSwitch switcher={chrome?.workspaceSwitch} />
+
       {chrome ? (
         <nav
           className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center pb-6"
@@ -110,6 +91,38 @@ export function FirstRunShell({
         </nav>
       ) : null}
     </div>
+  );
+}
+
+function FirstRunOrganizationSwitch({
+  organizationSwitch,
+}: {
+  organizationSwitch: FirstRunChrome["organizationSwitch"];
+}) {
+  if (!organizationSwitch) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="text-muted-foreground hover:text-foreground"
+          aria-label={FIRST_RUN_COPY.chrome.switchOrganization}
+          data-testid="first-run-organization-switch"
+        >
+          <ArrowRightLeft className="size-4" aria-hidden />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64">
+        <OrganizationSwitchMenu
+          currentOrganizationRouteId={organizationSwitch.currentOrganizationRouteId}
+          navigateToCurrentOrganization
+          testIdPrefix="first-run"
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunWorkspaceSwitch.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunWorkspaceSwitch.tsx
@@ -22,11 +22,7 @@ export function FirstRunWorkspaceSwitch({
   return <FirstRunWorkspaceSwitchMenu switcher={switcher} />;
 }
 
-function FirstRunWorkspaceSwitchMenu({
-  switcher,
-}: {
-  switcher: NonNullable<FirstRunChrome["workspaceSwitch"]>;
-}) {
+function FirstRunWorkspaceSwitchMenu({ switcher }: { switcher: NonNullable<FirstRunChrome["workspaceSwitch"]> }) {
   const navigate = useNavigate();
   const copy = FIRST_RUN_COPY.chrome;
   const [open, setOpen] = useState(false);

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunWorkspaceSwitch.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunWorkspaceSwitch.tsx
@@ -1,0 +1,74 @@
+import { cn } from "@/lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
+import { Check, Triangle } from "lucide-react";
+import { useState } from "react";
+import { useNavigate } from "react-router";
+
+import { factoriesRailControlClassName, initialsForName } from "../../../layout/factoriesRail";
+import { factoryHomePath, firstFactoryLineId } from "../../../lib/factoryPagePaths";
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+import type { FirstRunChrome, FirstRunWorkspaceOption } from "./firstRunTypes";
+
+function workspaceLabel(factory: FirstRunWorkspaceOption): string {
+  return factory.name?.trim() || "Workspace";
+}
+
+export function FirstRunWorkspaceSwitch({
+  switcher,
+}: {
+  switcher: NonNullable<FirstRunChrome["workspaceSwitch"]> | undefined;
+}) {
+  const navigate = useNavigate();
+  const copy = FIRST_RUN_COPY.chrome;
+  const [open, setOpen] = useState(false);
+
+  if (!switcher) return null;
+
+  const current = switcher.factories.find((factory) => factory.id === switcher.currentFactoryId);
+  const currentName = current ? workspaceLabel(current) : "Workspace";
+
+  return (
+    <div className="pointer-events-auto absolute bottom-0 left-0 z-10 px-6 pb-6">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={`${copy.switchWorkspace}, ${currentName}`}
+            title={currentName}
+            className={cn(
+              factoriesRailControlClassName,
+              "bg-muted text-[11px] font-medium tracking-[-0.01em] text-foreground hover:bg-accent",
+            )}
+            data-testid="first-run-workspace-switch"
+          >
+            {initialsForName(currentName)}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" side="top" sideOffset={8} className="w-64 p-1">
+          <p className="px-2 py-1.5 text-sm font-medium">{copy.switchWorkspace}</p>
+          {switcher.factories.map((factory) => {
+            if (!factory.id) return null;
+            const isCurrent = factory.id === switcher.currentFactoryId;
+            return (
+              <button
+                key={factory.id}
+                type="button"
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                onClick={() => {
+                  setOpen(false);
+                  if (isCurrent || !factory.key) return;
+                  navigate(factoryHomePath(switcher.organizationId, factory.key, firstFactoryLineId(factory)));
+                }}
+                data-testid={`first-run-workspace-option-${factory.id}`}
+              >
+                <Triangle className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                <span className="truncate">{workspaceLabel(factory)}</span>
+                {isCurrent ? <Check className="ml-auto h-3.5 w-3.5 shrink-0" aria-hidden /> : null}
+              </button>
+            );
+          })}
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunWorkspaceSwitch.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunWorkspaceSwitch.tsx
@@ -18,12 +18,18 @@ export function FirstRunWorkspaceSwitch({
 }: {
   switcher: NonNullable<FirstRunChrome["workspaceSwitch"]> | undefined;
 }) {
+  if (!switcher) return null;
+  return <FirstRunWorkspaceSwitchMenu switcher={switcher} />;
+}
+
+function FirstRunWorkspaceSwitchMenu({
+  switcher,
+}: {
+  switcher: NonNullable<FirstRunChrome["workspaceSwitch"]>;
+}) {
   const navigate = useNavigate();
   const copy = FIRST_RUN_COPY.chrome;
   const [open, setOpen] = useState(false);
-
-  if (!switcher) return null;
-
   const current = switcher.factories.find((factory) => factory.id === switcher.currentFactoryId);
   const currentName = current ? workspaceLabel(current) : "Workspace";
 

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunCopy.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunCopy.ts
@@ -8,6 +8,7 @@ export const FIRST_RUN_COPY = {
   chrome: {
     logOut: "Log out",
     switchOrganization: "Switch organization",
+    switchWorkspace: "Switch workspace",
     loggedInAs: "Logged in as",
     stepLabel: (step: number, total: number) => `Step ${step} of ${total}`,
     back: "Back",

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunTypes.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunTypes.ts
@@ -1,14 +1,30 @@
 export type FirstRunScreenId = "welcome" | "connect" | "choose" | "tickets" | "analysis" | "board";
 
+export type FirstRunWorkspaceOption = {
+  id?: string;
+  key?: string;
+  name?: string;
+  lines?: Array<{ id?: string }> | null;
+};
+
 export type FirstRunChrome = {
   email?: string;
   displayName?: string;
   onLogOut?: () => void;
   /**
-   * Set when the user has another workspace or another organization to
-   * open. The shell shows the organization switch next to Log out.
+   * Set when the user belongs to another organization. The shell shows
+   * the organization switch next to Log out.
    */
   organizationSwitch?: { currentOrganizationRouteId: string };
+  /**
+   * Set when another workspace exists in this organization. The shell
+   * shows the workspace initials in the bottom-left corner.
+   */
+  workspaceSwitch?: {
+    organizationId: string;
+    currentFactoryId: string;
+    factories: FirstRunWorkspaceOption[];
+  };
   stepIndex: number;
   /** Number of step dots. Set it when the flow skips a screen. */
   stepCount?: number;


### PR DESCRIPTION
## Summary

Workspace setup hid the sidebar. A user with one organization could not open another workspace and leave setup.

This change adds a workspace button in the bottom-left corner when another workspace exists. The organization switch stays visible only when the user belongs to another organization.

## Test plan

- [ ] Open workspace setup from Create new workspace when the organization already has a workspace.
- [ ] Confirm the initials button shows in the bottom-left corner.
- [ ] Open the popover and select the other workspace.
- [ ] Confirm SuperPlane opens that workspace and leaves setup.
- [ ] Open workspace setup with one organization and one workspace.
- [ ] Confirm the workspace button and the organization switch are hidden.
- [ ] Open workspace setup with two organizations.
- [ ] Confirm the organization switch still shows next to Log out.


Made with [Cursor](https://cursor.com)





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61801401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/superplane/-/pull-requests/superplanehq/superplane/7289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge because no blocking failure remains.

<!-- /greptile_comment -->