### PR TITLE
fix: Make GitHub onboarding approval reliable

### DIFF
--- a/pkg/integrations/github/common/metadata.go
+++ b/pkg/integrations/github/common/metadata.go
@@ -1,6 +1,9 @@
 package common
 
-import "slices"
+import (
+	"slices"
+	"strings"
+)
 
 type Metadata struct {
 	InstallationID string            `mapstructure:"installationId" json:"installationId"`
@@ -23,6 +26,10 @@ type Metadata struct {
 	// InstallRequestedAccount is the GitHub organization (or user) login the
 	// member asked an admin to approve.
 	InstallRequestedAccount string `mapstructure:"installRequestedAccount" json:"installRequestedAccount,omitempty"`
+	// InstallRequests contains every open GitHub App installation request for
+	// the member who started this connection. The legacy scalar fields above
+	// mirror this collection for compatibility with older clients.
+	InstallRequests []InstallRequest `mapstructure:"installRequests" json:"installRequests,omitempty"`
 	// StartedByGitHubLogin is the GitHub login of the member who authorized
 	// the connect OAuth. The request callback from GitHub does not name the
 	// requested organization, so Sync finds that member's App install request
@@ -41,6 +48,13 @@ type PendingInstallation struct {
 	ID           string `mapstructure:"id" json:"id"`
 	AccountLogin string `mapstructure:"accountLogin" json:"accountLogin"`
 	AccountType  string `mapstructure:"accountType" json:"accountType"`
+}
+
+type InstallRequest struct {
+	ID             string `mapstructure:"id" json:"id,omitempty"`
+	AccountLogin   string `mapstructure:"accountLogin" json:"accountLogin,omitempty"`
+	RequesterLogin string `mapstructure:"requesterLogin" json:"requesterLogin,omitempty"`
+	CreatedAt      string `mapstructure:"createdAt" json:"createdAt,omitempty"`
 }
 
 type GitHubAppMetadata struct {
@@ -65,4 +79,86 @@ func (m Metadata) AllowsStartedBy(userID string) bool {
 	}
 
 	return userID != "" && m.StartedByUserID == userID
+}
+
+func (m Metadata) HasInstallRequests() bool {
+	return len(m.InstallRequests) > 0 || m.InstallRequested
+}
+
+func (m Metadata) CurrentInstallRequests() []InstallRequest {
+	if len(m.InstallRequests) > 0 {
+		return slices.Clone(m.InstallRequests)
+	}
+	if !m.InstallRequested {
+		return nil
+	}
+	return []InstallRequest{{
+		AccountLogin:   strings.TrimSpace(m.InstallRequestedAccount),
+		RequesterLogin: strings.TrimSpace(m.StartedByGitHubLogin),
+	}}
+}
+
+func (m *Metadata) SetInstallRequests(requests []InstallRequest) {
+	m.InstallRequests = uniqueInstallRequests(requests)
+	m.InstallRequested = len(m.InstallRequests) > 0
+	m.InstallRequestedAccount = singleInstallRequestAccount(m.InstallRequests)
+}
+
+func (m *Metadata) SetPendingInstallations(installations []PendingInstallation) {
+	unique := make([]PendingInstallation, 0, len(installations))
+	for _, installation := range installations {
+		installation.ID = strings.TrimSpace(installation.ID)
+		installation.AccountLogin = strings.TrimSpace(installation.AccountLogin)
+		if installation.ID == "" || slices.ContainsFunc(unique, func(existing PendingInstallation) bool {
+			return existing.ID == installation.ID
+		}) {
+			continue
+		}
+		unique = append(unique, installation)
+	}
+	m.PendingInstallations = unique
+}
+
+func uniqueInstallRequests(requests []InstallRequest) []InstallRequest {
+	unique := make([]InstallRequest, 0, len(requests))
+	hasKnownRequest := slices.ContainsFunc(requests, func(request InstallRequest) bool {
+		return strings.TrimSpace(request.ID) != "" || strings.TrimSpace(request.AccountLogin) != ""
+	})
+	for _, request := range requests {
+		request.ID = strings.TrimSpace(request.ID)
+		request.AccountLogin = strings.TrimSpace(request.AccountLogin)
+		request.RequesterLogin = strings.TrimSpace(request.RequesterLogin)
+		if request.ID == "" && request.AccountLogin == "" && hasKnownRequest {
+			continue
+		}
+		if slices.ContainsFunc(unique, func(existing InstallRequest) bool {
+			if request.ID == "" && request.AccountLogin == "" {
+				return existing.ID == "" && existing.AccountLogin == ""
+			}
+			if request.ID != "" && existing.ID != "" {
+				return request.ID == existing.ID
+			}
+			return request.AccountLogin != "" && strings.EqualFold(request.AccountLogin, existing.AccountLogin)
+		}) {
+			continue
+		}
+		unique = append(unique, request)
+	}
+	return unique
+}
+
+func singleInstallRequestAccount(requests []InstallRequest) string {
+	accounts := []string{}
+	for _, request := range requests {
+		if request.AccountLogin == "" || slices.ContainsFunc(accounts, func(account string) bool {
+			return strings.EqualFold(account, request.AccountLogin)
+		}) {
+			continue
+		}
+		accounts = append(accounts, request.AccountLogin)
+	}
+	if len(accounts) != 1 {
+		return ""
+	}
+	return accounts[0]
 }

--- a/pkg/integrations/github/common/metadata_test.go
+++ b/pkg/integrations/github/common/metadata_test.go
@@ -27,3 +27,40 @@ func Test__Metadata_AllowsStartedBy(t *testing.T) {
 	assert.False(t, Metadata{StartedByUserID: "user-1"}.AllowsStartedBy("user-2"))
 	assert.False(t, Metadata{StartedByUserID: "user-1"}.AllowsStartedBy(""))
 }
+
+func Test__Metadata_SetInstallRequests(t *testing.T) {
+	metadata := Metadata{}
+	metadata.SetInstallRequests([]InstallRequest{
+		{ID: "2", AccountLogin: "octo", RequesterLogin: "member"},
+		{ID: "1", AccountLogin: "acme", RequesterLogin: "member"},
+		{ID: "1", AccountLogin: "acme", RequesterLogin: "member"},
+	})
+
+	assert.True(t, metadata.InstallRequested)
+	assert.Empty(t, metadata.InstallRequestedAccount)
+	assert.Len(t, metadata.InstallRequests, 2)
+}
+
+func Test__Metadata_CurrentInstallRequestsReadsLegacyFields(t *testing.T) {
+	requests := (Metadata{
+		InstallRequested:        true,
+		InstallRequestedAccount: "acme",
+		StartedByGitHubLogin:    "member",
+	}).CurrentInstallRequests()
+
+	assert.Equal(t, []InstallRequest{{AccountLogin: "acme", RequesterLogin: "member"}}, requests)
+}
+
+func Test__Metadata_SetPendingInstallationsDeduplicatesByID(t *testing.T) {
+	metadata := Metadata{}
+	metadata.SetPendingInstallations([]PendingInstallation{
+		{ID: "11", AccountLogin: "acme"},
+		{ID: "11", AccountLogin: "acme-copy"},
+		{ID: "22", AccountLogin: "octo"},
+	})
+
+	assert.Equal(t, []PendingInstallation{
+		{ID: "11", AccountLogin: "acme"},
+		{ID: "22", AccountLogin: "octo"},
+	}, metadata.PendingInstallations)
+}

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -461,11 +462,27 @@ func (g *GitHub) handleInstallationDeletion(ctx core.HTTPRequestContext, install
 		metadata.InstallationID = ""
 		metadata.Repositories = []common.Repository{}
 		metadata.State = state
+		metadata.PendingInstallations = slices.DeleteFunc(metadata.PendingInstallations, func(installation common.PendingInstallation) bool {
+			return installation.ID == installationID
+		})
+		metadata.AuthorizeURL = ""
+
+		actionURL := common.HostedAppInstallURL(metadata.GitHubApp.Slug, state)
+		actionDescription := appInstallationDescription
+		if app, ok := common.HostedAppFromEnv(); metadata.HostedApp && ok && app.UserOAuthEnabled() && ctx.BaseURL != "" {
+			metadata.AuthorizeURL = common.HostedAppAuthorizeURL(
+				app.ClientID,
+				common.HostedAppOAuthCallbackURL(ctx.BaseURL),
+				state,
+			)
+			actionURL = metadata.AuthorizeURL
+			actionDescription = hostedOAuthDescription
+		}
 
 		ctx.Integration.SetMetadata(metadata)
 		ctx.Integration.NewBrowserAction(core.BrowserAction{
-			Description: appInstallationDescription,
-			URL:         fmt.Sprintf("https://github.com/apps/%s/installations/new?state=%s", metadata.GitHubApp.Slug, state),
+			Description: actionDescription,
+			URL:         actionURL,
 			Method:      "GET",
 		})
 

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v84/github"
@@ -177,15 +178,15 @@ func (g *GitHub) Sync(ctx core.SyncContext) error {
 		return fmt.Errorf("Failed to decode metadata: %v", err)
 	}
 
+	if UseHostedApp(ctx.OrganizationID) && !config.PrivateApp {
+		return g.syncHostedApp(ctx, config)
+	}
+
 	//
 	// App is already installed - do not do anything.
 	//
 	if metadata.InstallationID != "" {
 		return nil
-	}
-
-	if UseHostedApp(ctx.OrganizationID) && !config.PrivateApp {
-		return g.syncHostedApp(ctx, config)
 	}
 
 	state, err := crypto.Base64String(32)
@@ -220,9 +221,9 @@ func (g *GitHub) syncHostedApp(ctx core.SyncContext, config Configuration) error
 	var existing common.Metadata
 	_ = mapstructure.Decode(ctx.Integration.GetMetadata(), &existing)
 	returnPath := firstSafeSetupReturnPath(config.SetupReturnPath, existing.SetupReturnPath)
-	if existing.HostedApp && existing.InstallationID == "" && existing.State != "" {
+	if existing.HostedApp && existing.State != "" {
 		existing.SetupReturnPath = returnPath
-		if existing.InstallRequested {
+		if existing.HasInstallRequests() {
 			// Adopt records the requested account it found on GitHub and
 			// moves an approved installation into the account picker;
 			// refreshHostedPendingAction below persists both.
@@ -266,6 +267,10 @@ func (g *GitHub) refreshHostedPendingAction(ctx core.SyncContext, app common.Hos
 	oauthEnabled := app.UserOAuthEnabled() && ctx.BaseURL != ""
 	if oauthEnabled {
 		metadata.AuthorizeURL = common.HostedAppAuthorizeURL(app.ClientID, common.HostedAppOAuthCallbackURL(ctx.BaseURL), metadata.State)
+	}
+	if metadata.InstallationID != "" {
+		ctx.Integration.SetMetadata(metadata)
+		return
 	}
 
 	if len(metadata.PendingInstallations) >= 1 {
@@ -1080,10 +1085,13 @@ func isInstallationRequestSetupAction(setupAction string) bool {
 func persistInstallRequested(ctx core.HTTPRequestContext) {
 	metadata := common.Metadata{}
 	_ = mapstructure.Decode(ctx.Integration.GetMetadata(), &metadata)
-	metadata.InstallRequested = true
-	if account := requestedInstallAccount(ctx); account != "" {
-		metadata.InstallRequestedAccount = account
-	}
+	requests := metadata.CurrentInstallRequests()
+	requests = append(requests, common.InstallRequest{
+		AccountLogin:   requestedInstallAccount(ctx),
+		RequesterLogin: metadata.StartedByGitHubLogin,
+		CreatedAt:      time.Now().UTC().Format(time.RFC3339Nano),
+	})
+	metadata.SetInstallRequests(requests)
 	ctx.Integration.SetMetadata(metadata)
 }
 
@@ -1092,11 +1100,10 @@ func clearInstallRequested(ctx core.HTTPRequestContext) {
 	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &metadata); err != nil {
 		return
 	}
-	if !metadata.InstallRequested && metadata.InstallRequestedAccount == "" {
+	if !metadata.HasInstallRequests() && metadata.InstallRequestedAccount == "" {
 		return
 	}
-	metadata.InstallRequested = false
-	metadata.InstallRequestedAccount = ""
+	metadata.SetInstallRequests(nil)
 	ctx.Integration.SetMetadata(metadata)
 }
 
@@ -1112,10 +1119,6 @@ func requestedInstallAccount(ctx core.HTTPRequestContext) string {
 	if metadata.InstallRequestedAccount != "" {
 		return metadata.InstallRequestedAccount
 	}
-	if metadata.Owner != "" {
-		return metadata.Owner
-	}
-
 	return ""
 }
 
@@ -1124,7 +1127,7 @@ func redirectToIntegrationSettings(ctx core.HTTPRequestContext) {
 }
 
 func redirectToIntegrationSettingsRequested(ctx core.HTTPRequestContext) {
-	query := "githubSetup=request"
+	query := "githubSetup=request&githubIntegrationId=" + url.QueryEscape(ctx.Integration.ID().String())
 	metadata := common.Metadata{}
 	_ = mapstructure.Decode(ctx.Integration.GetMetadata(), &metadata)
 	if metadata.InstallRequestedAccount != "" {

--- a/pkg/integrations/github/github_test.go
+++ b/pkg/integrations/github/github_test.go
@@ -185,6 +185,35 @@ func Test__isInstallationRequestSetupAction(t *testing.T) {
 	assert.False(t, isInstallationRequestSetupAction(""))
 }
 
+func Test__handleInstallationDeletion_refreshesHostedOAuthState(t *testing.T) {
+	setHostedAppOAuthEnv(t)
+	integration := &contexts.IntegrationContext{
+		Metadata: common.Metadata{
+			State:          "old-state",
+			HostedApp:      true,
+			AuthorizeURL:   common.HostedAppAuthorizeURL("Iv1.abc", common.HostedAppOAuthCallbackURL("https://app.example"), "old-state"),
+			InstallationID: "11",
+			GitHubApp:      common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+			PendingInstallations: []common.PendingInstallation{
+				{ID: "11", AccountLogin: "acme"},
+				{ID: "22", AccountLogin: "octo"},
+			},
+		},
+	}
+	ctx, _ := hostedRequestContext(integration, "/api/v1/github/app/webhook", nil)
+
+	(&GitHub{}).handleInstallationDeletion(ctx, "11")
+
+	metadata := integration.Metadata.(common.Metadata)
+	assert.NotEqual(t, "old-state", metadata.State)
+	assert.Contains(t, metadata.AuthorizeURL, "state="+url.QueryEscape(metadata.State))
+	assert.NotContains(t, metadata.AuthorizeURL, "state=old-state")
+	require.NotNil(t, integration.BrowserAction)
+	assert.Equal(t, metadata.AuthorizeURL, integration.BrowserAction.URL)
+	assert.Equal(t, hostedOAuthDescription, integration.BrowserAction.Description)
+	assert.Equal(t, []common.PendingInstallation{{ID: "22", AccountLogin: "octo"}}, metadata.PendingInstallations)
+}
+
 func Test__afterAppInstallation_installRequest(t *testing.T) {
 	integration := &contexts.IntegrationContext{
 		NewSetupFlow:  true,

--- a/pkg/integrations/github/github_test.go
+++ b/pkg/integrations/github/github_test.go
@@ -204,7 +204,7 @@ func Test__afterAppInstallation_installRequest(t *testing.T) {
 	assert.Equal(t, http.StatusSeeOther, rec.Code)
 	assert.Equal(
 		t,
-		"https://app.example/org-1/settings/integrations/11111111-1111-1111-1111-111111111111?githubSetup=request",
+		"https://app.example/org-1/settings/integrations/11111111-1111-1111-1111-111111111111?githubSetup=request&githubIntegrationId=11111111-1111-1111-1111-111111111111",
 		rec.Header().Get("Location"),
 	)
 	require.NotNil(t, integration.Metadata)
@@ -231,7 +231,7 @@ func Test__afterAppInstallation_installRequest_persistsAccount(t *testing.T) {
 	assert.Equal(t, http.StatusSeeOther, rec.Code)
 	assert.Equal(
 		t,
-		"https://app.example/org-1/settings/integrations/11111111-1111-1111-1111-111111111111?githubSetup=request&githubOrg=acme",
+		"https://app.example/org-1/settings/integrations/11111111-1111-1111-1111-111111111111?githubSetup=request&githubIntegrationId=11111111-1111-1111-1111-111111111111&githubOrg=acme",
 		rec.Header().Get("Location"),
 	)
 	require.NotNil(t, integration.Metadata)

--- a/pkg/integrations/github/hosted_bind.go
+++ b/pkg/integrations/github/hosted_bind.go
@@ -3,8 +3,10 @@ package github
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v84/github"
 	"github.com/sirupsen/logrus"
@@ -71,8 +73,10 @@ func (g *GitHub) bindHostedInstallationWith(
 	// account picker with them, so the member can move the connection to
 	// another GitHub account.
 	metadata.Repositories = repos
-	metadata.InstallRequested = false
-	metadata.InstallRequestedAccount = ""
+	remainingRequests := slices.DeleteFunc(metadata.CurrentInstallRequests(), func(request common.InstallRequest) bool {
+		return request.AccountLogin == "" || strings.EqualFold(request.AccountLogin, metadata.Owner)
+	})
+	metadata.SetInstallRequests(remainingRequests)
 
 	integration.SetMetadata(metadata)
 	integration.RemoveBrowserAction()
@@ -100,84 +104,123 @@ func (g *GitHub) adoptRequestedInstallation(ctx core.SyncContext, app common.Hos
 		return fmt.Errorf("failed to create app client: %w", err)
 	}
 
-	account := strings.TrimSpace(metadata.InstallRequestedAccount)
-	if account == "" {
-		account, err = listAppInstallationRequests(context.Background(), client, metadata.StartedByGitHubLogin)
+	trackedRequests := metadata.CurrentInstallRequests()
+	if requester := strings.TrimSpace(metadata.StartedByGitHubLogin); requester != "" {
+		trackedRequests = slices.DeleteFunc(trackedRequests, func(request common.InstallRequest) bool {
+			return request.RequesterLogin != "" && !strings.EqualFold(request.RequesterLogin, requester)
+		})
+	}
+	openRequests := trackedRequests
+	if strings.TrimSpace(metadata.StartedByGitHubLogin) != "" {
+		openRequests, err = listAppInstallationRequests(context.Background(), client, metadata.StartedByGitHubLogin)
 		if err != nil {
 			return fmt.Errorf("failed to list app installation requests: %w", err)
 		}
-		if account == "" {
-			return nil
-		}
-		metadata.InstallRequestedAccount = account
 	}
 
-	installation, found, err := listAppInstallations(context.Background(), client, account)
+	installations, err := listAppInstallations(context.Background(), client)
 	if err != nil {
 		return fmt.Errorf("failed to list app installations: %w", err)
 	}
-	if !found {
-		return nil
-	}
 
-	if !metadata.AllowsPendingInstallation(installation.ID) {
-		metadata.PendingInstallations = append(metadata.PendingInstallations, installation)
+	// Put GitHub's current records first so their request IDs and timestamps
+	// replace callback placeholders for the same account during deduplication.
+	candidates := append(slices.Clone(openRequests), trackedRequests...)
+	metadata.SetPendingInstallations(metadata.PendingInstallations)
+	unresolved := make([]common.InstallRequest, 0, len(openRequests))
+	for _, request := range candidates {
+		installation, installed := installationForAccount(installations, request.AccountLogin)
+		if installed {
+			if !metadata.AllowsPendingInstallation(installation.ID) {
+				metadata.PendingInstallations = append(metadata.PendingInstallations, installation)
+			}
+			continue
+		}
+		if installRequestIsOpen(request, openRequests) {
+			unresolved = append(unresolved, request)
+		}
 	}
-	metadata.InstallRequested = false
-	metadata.InstallRequestedAccount = ""
+	metadata.SetInstallRequests(unresolved)
 	return nil
 }
 
-// listAppInstallationRequestsFromGitHub returns the account login of the open
-// App install request made by the requester, or an empty string when the
-// requester has no open request.
-func listAppInstallationRequestsFromGitHub(ctx context.Context, client *github.Client, requesterLogin string) (string, error) {
+func installationForAccount(installations []common.PendingInstallation, account string) (common.PendingInstallation, bool) {
+	if strings.TrimSpace(account) == "" {
+		return common.PendingInstallation{}, false
+	}
+	for _, installation := range installations {
+		if strings.EqualFold(installation.AccountLogin, account) {
+			return installation, true
+		}
+	}
+	return common.PendingInstallation{}, false
+}
+
+func installRequestIsOpen(request common.InstallRequest, open []common.InstallRequest) bool {
+	return slices.ContainsFunc(open, func(candidate common.InstallRequest) bool {
+		if request.ID != "" && candidate.ID != "" {
+			return request.ID == candidate.ID
+		}
+		return request.AccountLogin != "" && strings.EqualFold(request.AccountLogin, candidate.AccountLogin)
+	})
+}
+
+// listAppInstallationRequestsFromGitHub returns every open App install request
+// made by the requester.
+func listAppInstallationRequestsFromGitHub(ctx context.Context, client *github.Client, requesterLogin string) ([]common.InstallRequest, error) {
 	if strings.TrimSpace(requesterLogin) == "" {
-		return "", nil
+		return nil, nil
 	}
 
+	result := []common.InstallRequest{}
 	opts := &github.ListOptions{PerPage: 100}
 	for {
 		requests, response, err := client.Apps.ListInstallationRequests(ctx, opts)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		for _, request := range requests {
 			if strings.EqualFold(request.GetRequester().GetLogin(), requesterLogin) {
-				return request.GetAccount().GetLogin(), nil
+				createdAt := ""
+				if request.CreatedAt != nil {
+					createdAt = request.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
+				}
+				result = append(result, common.InstallRequest{
+					ID:             strconv.FormatInt(request.GetID(), 10),
+					AccountLogin:   request.GetAccount().GetLogin(),
+					RequesterLogin: request.GetRequester().GetLogin(),
+					CreatedAt:      createdAt,
+				})
 			}
 		}
 
 		if response == nil || response.NextPage == 0 {
-			return "", nil
+			return result, nil
 		}
 		opts.Page = response.NextPage
 	}
 }
 
-// listAppInstallationsFromGitHub returns the App installation owned by the
-// account, or found=false when the account has no installation.
-func listAppInstallationsFromGitHub(ctx context.Context, client *github.Client, account string) (common.PendingInstallation, bool, error) {
+func listAppInstallationsFromGitHub(ctx context.Context, client *github.Client) ([]common.PendingInstallation, error) {
+	result := []common.PendingInstallation{}
 	opts := &github.ListOptions{PerPage: 100}
 	for {
 		installations, response, err := client.Apps.ListInstallations(ctx, opts)
 		if err != nil {
-			return common.PendingInstallation{}, false, err
+			return nil, err
 		}
 
 		for _, installation := range installations {
-			if strings.EqualFold(installation.GetAccount().GetLogin(), account) {
-				return common.PendingInstallation{
-					ID:           strconv.FormatInt(installation.GetID(), 10),
-					AccountLogin: installation.GetAccount().GetLogin(),
-					AccountType:  installation.GetAccount().GetType(),
-				}, true, nil
-			}
+			result = append(result, common.PendingInstallation{
+				ID:           strconv.FormatInt(installation.GetID(), 10),
+				AccountLogin: installation.GetAccount().GetLogin(),
+				AccountType:  installation.GetAccount().GetType(),
+			})
 		}
 
 		if response == nil || response.NextPage == 0 {
-			return common.PendingInstallation{}, false, nil
+			return result, nil
 		}
 		opts.Page = response.NextPage
 	}

--- a/pkg/integrations/github/hosted_oauth.go
+++ b/pkg/integrations/github/hosted_oauth.go
@@ -124,14 +124,17 @@ func (g *GitHub) afterHostedAppOAuth(ctx core.HTTPRequestContext) {
 	// Even a single installation goes through the account picker. A silent
 	// bind would lock the connection to that account (often the user's
 	// personal one) with no way to install the App on an organization.
-	metadata.PendingInstallations = installations
+	metadata.SetPendingInstallations(installations)
 
-	// The picker now offers the requested account, so the install request is
-	// approved and the waiting state must not show next to the picker.
-	if installationsIncludeAccount(installations, metadata.InstallRequestedAccount) {
-		metadata.InstallRequested = false
-		metadata.InstallRequestedAccount = ""
+	// Remove only the requests that the refreshed picker can now offer. Other
+	// organization requests can continue to wait on the same connection.
+	unresolved := []common.InstallRequest{}
+	for _, request := range metadata.CurrentInstallRequests() {
+		if !installationsIncludeAccount(installations, request.AccountLogin) {
+			unresolved = append(unresolved, request)
+		}
 	}
+	metadata.SetInstallRequests(unresolved)
 
 	ctx.Integration.SetMetadata(metadata)
 	ctx.Integration.RemoveBrowserAction()

--- a/pkg/integrations/github/hosted_oauth_test.go
+++ b/pkg/integrations/github/hosted_oauth_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -290,8 +291,8 @@ func Test__afterHostedAppBind(t *testing.T) {
 		newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
 			return gh.NewClient(nil), nil
 		}
-		listAppInstallations = func(context.Context, *gh.Client, string) (common.PendingInstallation, bool, error) {
-			return common.PendingInstallation{}, false, nil
+		listAppInstallations = func(context.Context, *gh.Client) ([]common.PendingInstallation, error) {
+			return nil, nil
 		}
 
 		integration := pendingHostedIntegration("csrf")
@@ -315,6 +316,36 @@ func Test__afterHostedAppBind(t *testing.T) {
 		metadata := integration.Metadata.(common.Metadata)
 		assert.Equal(t, "22", metadata.InstallationID)
 		assert.Equal(t, "octo", metadata.Owner)
+	})
+
+	t.Run("keeps requests for other accounts after binding", func(t *testing.T) {
+		t.Cleanup(resetBindClientHooks)
+		listInstallationRepos = func(context.Context, *gh.Client) ([]common.Repository, error) {
+			return []common.Repository{{ID: 1, Name: "repo", URL: "https://github.com/acme/repo"}}, nil
+		}
+		newInstallationClient = func(core.IntegrationContext, int64, string) (*gh.Client, error) {
+			return gh.NewClient(nil), nil
+		}
+
+		integration := pendingHostedIntegration("csrf")
+		integration.Metadata = common.Metadata{
+			State:     "csrf",
+			HostedApp: true,
+			GitHubApp: common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+			InstallRequests: []common.InstallRequest{
+				{ID: "1", AccountLogin: "acme", RequesterLogin: "member"},
+				{ID: "2", AccountLogin: "octo", RequesterLogin: "member"},
+			},
+			PendingInstallations: []common.PendingInstallation{{ID: "11", AccountLogin: "acme"}},
+		}
+		ctx, rec := hostedRequestContext(integration, "/api/v1/github/app/bind?state=csrf&installation_id=11", nil)
+
+		g.afterHostedAppBind(ctx)
+
+		assert.Equal(t, http.StatusSeeOther, rec.Code)
+		metadata := integration.Metadata.(common.Metadata)
+		assert.Equal(t, []common.InstallRequest{{ID: "2", AccountLogin: "octo", RequesterLogin: "member"}}, metadata.InstallRequests)
+		assert.Equal(t, "octo", metadata.InstallRequestedAccount)
 	})
 
 	t.Run("redirects a bound connection when the state does not match", func(t *testing.T) {
@@ -355,12 +386,13 @@ func Test__afterAppInstallationLegacy_installRequest(t *testing.T) {
 		assert.Equal(t, http.StatusSeeOther, rec.Code)
 		assert.Equal(
 			t,
-			"https://app.example/org-1/settings/integrations/11111111-1111-1111-1111-111111111111?githubSetup=request",
+			"https://app.example/org-1/settings/integrations/11111111-1111-1111-1111-111111111111?githubSetup=request&githubIntegrationId=11111111-1111-1111-1111-111111111111",
 			rec.Header().Get("Location"),
 		)
 		assert.Equal(t, "pending", integration.State)
 		assert.Empty(t, integration.Metadata.(common.Metadata).InstallationID)
 		assert.True(t, integration.Metadata.(common.Metadata).InstallRequested)
+		assert.NotEmpty(t, integration.Metadata.(common.Metadata).InstallRequests[0].CreatedAt)
 	})
 
 	t.Run("persists the requested GitHub organization", func(t *testing.T) {
@@ -376,10 +408,31 @@ func Test__afterAppInstallationLegacy_installRequest(t *testing.T) {
 		assert.Equal(t, http.StatusSeeOther, rec.Code)
 		assert.Equal(
 			t,
-			"https://app.example/org-1/settings/integrations/11111111-1111-1111-1111-111111111111?githubSetup=request&githubOrg=acme",
+			"https://app.example/org-1/settings/integrations/11111111-1111-1111-1111-111111111111?githubSetup=request&githubIntegrationId=11111111-1111-1111-1111-111111111111&githubOrg=acme",
 			rec.Header().Get("Location"),
 		)
 		assert.Equal(t, "acme", integration.Metadata.(common.Metadata).InstallRequestedAccount)
+	})
+
+	t.Run("persists multiple requested GitHub organizations without choosing one", func(t *testing.T) {
+		integration := pendingHostedIntegration("csrf")
+		firstContext, _ := hostedRequestContext(
+			integration,
+			"/api/v1/github/app/setup?state=csrf&setup_action=request&account=acme",
+			nil,
+		)
+		(&GitHub{}).afterAppInstallationLegacy(firstContext)
+
+		secondContext, _ := hostedRequestContext(
+			integration,
+			"/api/v1/github/app/setup?state=csrf&setup_action=request&account=octo",
+			nil,
+		)
+		(&GitHub{}).afterAppInstallationLegacy(secondContext)
+
+		metadata := integration.Metadata.(common.Metadata)
+		require.Len(t, metadata.InstallRequests, 2)
+		assert.Empty(t, metadata.InstallRequestedAccount)
 	})
 
 	t.Run("returns to the stored onboarding path instead of settings", func(t *testing.T) {
@@ -566,11 +619,8 @@ func Test__Sync_hostedAppOffersApprovedInstallInPicker(t *testing.T) {
 	t.Cleanup(restore)
 	t.Cleanup(resetBindClientHooks)
 
-	listAppInstallations = func(_ context.Context, _ *gh.Client, account string) (common.PendingInstallation, bool, error) {
-		if account == "acme" {
-			return common.PendingInstallation{ID: "11", AccountLogin: "acme", AccountType: "Organization"}, true, nil
-		}
-		return common.PendingInstallation{}, false, nil
+	listAppInstallations = func(context.Context, *gh.Client) ([]common.PendingInstallation, error) {
+		return []common.PendingInstallation{{ID: "11", AccountLogin: "acme", AccountType: "Organization"}}, nil
 	}
 	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
 		return gh.NewClient(nil), nil
@@ -616,8 +666,8 @@ func Test__Sync_hostedAppDoesNotDuplicatePickerEntry(t *testing.T) {
 	t.Cleanup(restore)
 	t.Cleanup(resetBindClientHooks)
 
-	listAppInstallations = func(context.Context, *gh.Client, string) (common.PendingInstallation, bool, error) {
-		return common.PendingInstallation{ID: "11", AccountLogin: "acme", AccountType: "Organization"}, true, nil
+	listAppInstallations = func(context.Context, *gh.Client) ([]common.PendingInstallation, error) {
+		return []common.PendingInstallation{{ID: "11", AccountLogin: "acme", AccountType: "Organization"}}, nil
 	}
 	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
 		return gh.NewClient(nil), nil
@@ -649,6 +699,157 @@ func Test__Sync_hostedAppDoesNotDuplicatePickerEntry(t *testing.T) {
 	assert.False(t, metadata.InstallRequested)
 }
 
+func Test__Sync_hostedAppReconcilesMultipleRequestsWithoutDependingOnOrder(t *testing.T) {
+	setHostedAppOAuthEnv(t)
+	restore := withFactoriesEnabledForTest(func(string) bool { return true })
+	t.Cleanup(restore)
+	t.Cleanup(resetBindClientHooks)
+
+	listAppInstallationRequests = func(context.Context, *gh.Client, string) ([]common.InstallRequest, error) {
+		return []common.InstallRequest{
+			{ID: "2", AccountLogin: "octo", RequesterLogin: "member"},
+		}, nil
+	}
+	listAppInstallations = func(context.Context, *gh.Client) ([]common.PendingInstallation, error) {
+		return []common.PendingInstallation{{ID: "11", AccountLogin: "acme", AccountType: "Organization"}}, nil
+	}
+	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) { return gh.NewClient(nil), nil }
+
+	integrationCtx := &contexts.IntegrationContext{
+		State: "pending",
+		Metadata: common.Metadata{
+			State:                "csrf",
+			HostedApp:            true,
+			StartedByGitHubLogin: "member",
+			InstallRequests: []common.InstallRequest{
+				{ID: "1", AccountLogin: "acme", RequesterLogin: "member"},
+				{ID: "2", AccountLogin: "octo", RequesterLogin: "member"},
+			},
+			InstallRequested: true,
+			GitHubApp:        common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+		},
+	}
+
+	require.NoError(t, (&GitHub{}).Sync(core.SyncContext{
+		Logger:         logrus.NewEntry(logrus.New()),
+		OrganizationID: "11111111-1111-1111-1111-111111111111",
+		BaseURL:        "https://app.example",
+		Integration:    integrationCtx,
+	}))
+
+	metadata := integrationCtx.Metadata.(common.Metadata)
+	require.Equal(t, []common.InstallRequest{{ID: "2", AccountLogin: "octo", RequesterLogin: "member"}}, metadata.InstallRequests)
+	assert.Equal(t, "octo", metadata.InstallRequestedAccount)
+	require.Len(t, metadata.PendingInstallations, 1)
+	assert.Equal(t, "acme", metadata.PendingInstallations[0].AccountLogin)
+}
+
+func Test__Sync_hostedReadyAppReconcilesApprovedRequest(t *testing.T) {
+	setHostedAppOAuthEnv(t)
+	restore := withFactoriesEnabledForTest(func(string) bool { return true })
+	t.Cleanup(restore)
+	t.Cleanup(resetBindClientHooks)
+
+	listAppInstallationRequests = func(context.Context, *gh.Client, string) ([]common.InstallRequest, error) {
+		return nil, nil
+	}
+	listAppInstallations = func(context.Context, *gh.Client) ([]common.PendingInstallation, error) {
+		return []common.PendingInstallation{{ID: "22", AccountLogin: "octo", AccountType: "Organization"}}, nil
+	}
+	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) { return gh.NewClient(nil), nil }
+
+	integrationCtx := &contexts.IntegrationContext{
+		State: "ready",
+		Metadata: common.Metadata{
+			State:                "csrf",
+			HostedApp:            true,
+			InstallationID:       "11",
+			Owner:                "acme",
+			StartedByGitHubLogin: "member",
+			InstallRequested:     true,
+			InstallRequests: []common.InstallRequest{
+				{ID: "2", AccountLogin: "octo", RequesterLogin: "member"},
+			},
+			GitHubApp: common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+		},
+	}
+
+	require.NoError(t, (&GitHub{}).Sync(core.SyncContext{
+		Logger:         logrus.NewEntry(logrus.New()),
+		OrganizationID: "11111111-1111-1111-1111-111111111111",
+		BaseURL:        "https://app.example",
+		Integration:    integrationCtx,
+	}))
+
+	metadata := integrationCtx.Metadata.(common.Metadata)
+	assert.Equal(t, "11", metadata.InstallationID)
+	assert.False(t, metadata.InstallRequested)
+	require.Len(t, metadata.PendingInstallations, 1)
+	assert.Equal(t, "octo", metadata.PendingInstallations[0].AccountLogin)
+}
+
+func Test__listAppInstallationRequestsFromGitHubReturnsAllRequestsForRequester(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, "/app/installation-requests", request.URL.Path)
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`[
+			{"id":2,"account":{"login":"octo"},"requester":{"login":"member"},"created_at":"2026-09-08T12:00:00Z"},
+			{"id":1,"account":{"login":"acme"},"requester":{"login":"member"},"created_at":"2026-09-08T11:00:00Z"},
+			{"id":3,"account":{"login":"other"},"requester":{"login":"another-user"}}
+		]`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(server.Client())
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+	client.BaseURL = baseURL
+
+	requests, err := listAppInstallationRequestsFromGitHub(context.Background(), client, "member")
+	require.NoError(t, err)
+	require.Len(t, requests, 2)
+	assert.Equal(t, "2", requests[0].ID)
+	assert.Equal(t, "octo", requests[0].AccountLogin)
+	assert.Equal(t, "1", requests[1].ID)
+	assert.Equal(t, "acme", requests[1].AccountLogin)
+}
+
+func Test__Sync_hostedAppPreservesRequestsWhenGitHubLookupFails(t *testing.T) {
+	setHostedAppOAuthEnv(t)
+	restore := withFactoriesEnabledForTest(func(string) bool { return true })
+	t.Cleanup(restore)
+	t.Cleanup(resetBindClientHooks)
+
+	listAppInstallationRequests = func(context.Context, *gh.Client, string) ([]common.InstallRequest, error) {
+		return nil, errors.New("GitHub unavailable")
+	}
+	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) { return gh.NewClient(nil), nil }
+
+	existingRequest := common.InstallRequest{ID: "1", AccountLogin: "acme", RequesterLogin: "member"}
+	integrationCtx := &contexts.IntegrationContext{
+		State: "pending",
+		Metadata: common.Metadata{
+			State:                "csrf",
+			HostedApp:            true,
+			StartedByGitHubLogin: "member",
+			InstallRequested:     true,
+			InstallRequests:      []common.InstallRequest{existingRequest},
+			GitHubApp:            common.GitHubAppMetadata{ID: 99, Slug: "superplane"},
+		},
+	}
+
+	require.NoError(t, (&GitHub{}).Sync(core.SyncContext{
+		Logger:         logrus.NewEntry(logrus.New()),
+		OrganizationID: "11111111-1111-1111-1111-111111111111",
+		BaseURL:        "https://app.example",
+		Integration:    integrationCtx,
+	}))
+
+	metadata := integrationCtx.Metadata.(common.Metadata)
+	assert.Equal(t, []common.InstallRequest{existingRequest}, metadata.InstallRequests)
+	assert.True(t, metadata.InstallRequested)
+}
+
 func Test__Sync_hostedAppFindsRequestedAccountOnGitHub(t *testing.T) {
 	setHostedAppOAuthEnv(t)
 	restore := withFactoriesEnabledForTest(func(string) bool { return true })
@@ -658,14 +859,14 @@ func Test__Sync_hostedAppFindsRequestedAccountOnGitHub(t *testing.T) {
 	// GitHub's request callback does not name the requested account, so the
 	// connection stored only the requester's login. Sync finds the open
 	// install request on GitHub and records the account.
-	listAppInstallationRequests = func(_ context.Context, _ *gh.Client, requesterLogin string) (string, error) {
+	listAppInstallationRequests = func(_ context.Context, _ *gh.Client, requesterLogin string) ([]common.InstallRequest, error) {
 		if requesterLogin == "member" {
-			return "acme", nil
+			return []common.InstallRequest{{ID: "1", AccountLogin: "acme", RequesterLogin: "member"}}, nil
 		}
-		return "", nil
+		return nil, nil
 	}
-	listAppInstallations = func(context.Context, *gh.Client, string) (common.PendingInstallation, bool, error) {
-		return common.PendingInstallation{}, false, nil // The request is still waiting for an approval.
+	listAppInstallations = func(context.Context, *gh.Client) ([]common.PendingInstallation, error) {
+		return nil, nil // The request is still waiting for an approval.
 	}
 	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
 		return gh.NewClient(nil), nil
@@ -693,6 +894,8 @@ func Test__Sync_hostedAppFindsRequestedAccountOnGitHub(t *testing.T) {
 	metadata := integrationCtx.Metadata.(common.Metadata)
 	assert.Equal(t, "acme", metadata.InstallRequestedAccount)
 	assert.True(t, metadata.InstallRequested)
+	require.Len(t, metadata.InstallRequests, 1)
+	assert.Equal(t, "1", metadata.InstallRequests[0].ID)
 }
 
 func Test__Sync_hostedAppOffersRequestWithoutStoredAccountInPicker(t *testing.T) {
@@ -701,17 +904,14 @@ func Test__Sync_hostedAppOffersRequestWithoutStoredAccountInPicker(t *testing.T)
 	t.Cleanup(restore)
 	t.Cleanup(resetBindClientHooks)
 
-	listAppInstallationRequests = func(_ context.Context, _ *gh.Client, requesterLogin string) (string, error) {
+	listAppInstallationRequests = func(_ context.Context, _ *gh.Client, requesterLogin string) ([]common.InstallRequest, error) {
 		if requesterLogin == "member" {
-			return "acme", nil
+			return []common.InstallRequest{{ID: "1", AccountLogin: "acme", RequesterLogin: "member"}}, nil
 		}
-		return "", nil
+		return nil, nil
 	}
-	listAppInstallations = func(_ context.Context, _ *gh.Client, account string) (common.PendingInstallation, bool, error) {
-		if account == "acme" {
-			return common.PendingInstallation{ID: "11", AccountLogin: "acme", AccountType: "Organization"}, true, nil
-		}
-		return common.PendingInstallation{}, false, nil
+	listAppInstallations = func(context.Context, *gh.Client) ([]common.PendingInstallation, error) {
+		return []common.PendingInstallation{{ID: "11", AccountLogin: "acme", AccountType: "Organization"}}, nil
 	}
 	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
 		return gh.NewClient(nil), nil
@@ -750,8 +950,8 @@ func Test__Sync_hostedAppKeepsWaitingWhenRequestNotApproved(t *testing.T) {
 	t.Cleanup(restore)
 	t.Cleanup(resetBindClientHooks)
 
-	listAppInstallations = func(context.Context, *gh.Client, string) (common.PendingInstallation, bool, error) {
-		return common.PendingInstallation{}, false, nil
+	listAppInstallations = func(context.Context, *gh.Client) ([]common.PendingInstallation, error) {
+		return nil, nil
 	}
 	newAppJWTClient = func(core.IntegrationContext, int64) (*gh.Client, error) {
 		return gh.NewClient(nil), nil

--- a/test/e2e/github_install_request_test.go
+++ b/test/e2e/github_install_request_test.go
@@ -177,5 +177,6 @@ func (s *githubInstallRequestSteps) assertTheOwnerApprovalIsExplained() {
 	require.NotContains(s.t, s.session.Page().URL(), "missing state")
 	s.session.AssertVisible(q.TestID("github-install-approved"))
 	s.session.AssertText("Request approved")
-	s.session.AssertText("The SuperPlane GitHub App is approved. The person who asked can click Connect GitHub again.")
+	s.session.AssertText("The SuperPlane GitHub App is approved.")
+	s.session.AssertVisible(q.TestID("github-install-approved-open"))
 }

--- a/test/e2e/github_install_request_test.go
+++ b/test/e2e/github_install_request_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"encoding/json"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,12 +30,12 @@ func TestGitHubInstallRequest(t *testing.T) {
 		steps.assertThePendingRequestIsExplained()
 	})
 
-	t.Run("connect screen explains a pending GitHub request from the return query", func(t *testing.T) {
+	t.Run("connect screen ignores a stale pending GitHub request from the return query", func(t *testing.T) {
 		steps := &githubInstallRequestSteps{t: t}
 		steps.start()
 		factory := steps.givenAnIncompleteWorkspaceExists()
 		steps.visitWorkspaceSetupWithInstallRequest(factory)
-		steps.assertTheConnectScreenExplainsThePendingRequest()
+		steps.assertTheConnectScreenIgnoresTheStalePendingRequest()
 	})
 
 	t.Run("owner approval without state opens the approved page", func(t *testing.T) {
@@ -146,11 +147,13 @@ func (s *githubInstallRequestSteps) visitWorkspaceSetupWithInstallRequest(factor
 	s.session.Visit("/" + s.session.OrgSlug + "/workspaces/" + factory.Key + "/setup?step=vcs&githubSetup=request")
 }
 
-func (s *githubInstallRequestSteps) assertTheConnectScreenExplainsThePendingRequest() {
+func (s *githubInstallRequestSteps) assertTheConnectScreenIgnoresTheStalePendingRequest() {
 	s.session.AssertVisible(q.TestID("first-run-connect"))
-	s.session.AssertVisible(q.TestID("first-run-github-install-requested"))
 	s.session.AssertVisible(q.TestID("first-run-connect-github"))
-	s.assertPendingRequestCopy()
+	s.session.AssertHidden(q.TestID("first-run-github-install-requested"))
+	require.Eventually(s.t, func() bool {
+		return !strings.Contains(s.session.Page().URL(), "githubSetup=request")
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
 func (s *githubInstallRequestSteps) assertThePendingRequestIsExplained() {

--- a/web_src/src/hooks/useRecheckGitHubInstallRequest.spec.tsx
+++ b/web_src/src/hooks/useRecheckGitHubInstallRequest.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -28,18 +28,46 @@ const readyInstance: OrganizationsIntegration = {
 
 describe("pendingGitHubInstallRequestId", () => {
   it("finds the pending GitHub connection with an install request", () => {
-    expect(pendingGitHubInstallRequestId([readyInstance, waitingInstance])).toBe("int-1");
-    expect(pendingGitHubInstallRequestId([readyInstance])).toBeUndefined();
+    expect(pendingGitHubInstallRequestId([readyInstance, waitingInstance], "user-1")).toBe("int-1");
+    expect(pendingGitHubInstallRequestId([readyInstance], "user-1")).toBeUndefined();
+  });
+
+  it("selects the current user's request instead of another member's request", () => {
+    const theirs: OrganizationsIntegration = {
+      ...waitingInstance,
+      metadata: { ...waitingInstance.metadata, id: "int-theirs" },
+      status: { ...waitingInstance.status, metadata: { installRequested: true, startedByUserID: "user-2" } },
+    };
+    const mine: OrganizationsIntegration = {
+      ...waitingInstance,
+      metadata: { ...waitingInstance.metadata, id: "int-mine" },
+      status: { ...waitingInstance.status, metadata: { installRequested: true, startedByUserID: "user-1" } },
+    };
+
+    expect(pendingGitHubInstallRequestId([theirs, mine], "user-1")).toBe("int-mine");
+  });
+
+  it("finds an install request on a ready connection", () => {
+    const readyWithRequest: OrganizationsIntegration = {
+      ...readyInstance,
+      status: {
+        ...readyInstance.status,
+        metadata: { installRequested: true, startedByUserID: "user-1", installRequestedAccount: "octo" },
+      },
+    };
+
+    expect(pendingGitHubInstallRequestId([readyWithRequest], "user-1")).toBe("int-2");
   });
 });
 
 describe("useRecheckGitHubInstallRequest", () => {
   afterEach(() => {
-    updateIntegration.mockClear();
+    vi.useRealTimers();
+    updateIntegration.mockReset().mockResolvedValue({});
   });
 
   it("rechecks the pending install request on page access", async () => {
-    renderHook(() => useRecheckGitHubInstallRequest("org-1", [waitingInstance]), { wrapper });
+    renderHook(() => useRecheckGitHubInstallRequest("org-1", "int-1"), { wrapper });
 
     await waitFor(() => expect(updateIntegration).toHaveBeenCalledTimes(1));
     const args = updateIntegration.mock.calls[0][0] as { path: { id: string; integrationId: string } };
@@ -47,8 +75,45 @@ describe("useRecheckGitHubInstallRequest", () => {
   });
 
   it("does nothing without a pending install request", () => {
-    renderHook(() => useRecheckGitHubInstallRequest("org-1", [readyInstance]), { wrapper });
+    renderHook(() => useRecheckGitHubInstallRequest("org-1", undefined), { wrapper });
 
     expect(updateIntegration).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when polling is disabled", () => {
+    renderHook(() => useRecheckGitHubInstallRequest("org-1", "int-1", false), { wrapper });
+
+    expect(updateIntegration).not.toHaveBeenCalled();
+  });
+
+  it("waits for each recheck before scheduling the next one and stops on cleanup", async () => {
+    vi.useFakeTimers();
+    let finishFirst!: () => void;
+    updateIntegration.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishFirst = () => resolve({});
+        }),
+    );
+
+    const { unmount } = renderHook(() => useRecheckGitHubInstallRequest("org-1", "int-1"), { wrapper });
+    await act(async () => Promise.resolve());
+    expect(updateIntegration).toHaveBeenCalledTimes(1);
+
+    await act(async () => vi.advanceTimersByTimeAsync(10_000));
+    expect(updateIntegration).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      finishFirst();
+      await Promise.resolve();
+    });
+    await act(async () => vi.advanceTimersByTimeAsync(4_999));
+    expect(updateIntegration).toHaveBeenCalledTimes(1);
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(updateIntegration).toHaveBeenCalledTimes(2);
+
+    unmount();
+    await act(async () => vi.advanceTimersByTimeAsync(5_000));
+    expect(updateIntegration).toHaveBeenCalledTimes(2);
   });
 });

--- a/web_src/src/hooks/useRecheckGitHubInstallRequest.ts
+++ b/web_src/src/hooks/useRecheckGitHubInstallRequest.ts
@@ -4,19 +4,17 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { OrganizationsIntegration } from "@/api-client";
 import { organizationsUpdateIntegration } from "@/api-client/sdk.gen";
 import { integrationKeys } from "@/hooks/useIntegrations";
-import { hostedGitHubInstallRequested } from "@/lib/hostedGitHubInstall";
+import { pendingGitHubRequestConnection } from "@/lib/startDirectGitHubConnect";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 
 const RECHECK_INTERVAL_MS = 5_000;
 
-export function pendingGitHubInstallRequestId(instances: OrganizationsIntegration[]): string | undefined {
-  const pending = instances.find(
-    (instance) =>
-      instance.metadata?.integrationName === "github" &&
-      instance.status?.state !== "ready" &&
-      hostedGitHubInstallRequested(instance.status?.metadata),
-  );
-  return pending?.metadata?.id;
+export function pendingGitHubInstallRequestId(
+  instances: OrganizationsIntegration[],
+  currentUserId?: string,
+  preferredIntegrationId?: string,
+): string | undefined {
+  return pendingGitHubRequestConnection(instances, currentUserId, preferredIntegrationId)?.id;
 }
 
 /**
@@ -26,17 +24,17 @@ export function pendingGitHubInstallRequestId(instances: OrganizationsIntegratio
  * webhook cannot find a connection without an installation id, so the server
  * only learns about an approval during a connection sync. An empty update
  * runs that sync: an approved installation joins the account picker, where
- * the user picks it. Runs on page access and then every 10 seconds until the
+ * the user picks it. Runs on page access and then every five seconds until the
  * request resolves or the page closes.
  */
-export function useRecheckGitHubInstallRequest(organizationId: string, instances: OrganizationsIntegration[]) {
+export function useRecheckGitHubInstallRequest(organizationId: string, integrationId?: string, enabled = true) {
   const queryClient = useQueryClient();
-  const integrationId = pendingGitHubInstallRequestId(instances);
 
   useEffect(() => {
-    if (!organizationId || !integrationId) return;
+    if (!organizationId || !integrationId || !enabled) return;
 
     let cancelled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     const recheck = async () => {
       try {
         await organizationsUpdateIntegration(
@@ -51,13 +49,13 @@ export function useRecheckGitHubInstallRequest(organizationId: string, instances
       }
       if (cancelled) return;
       await queryClient.invalidateQueries({ queryKey: integrationKeys.connected(organizationId) });
+      if (!cancelled) timeout = setTimeout(() => void recheck(), RECHECK_INTERVAL_MS);
     };
 
     void recheck();
-    const interval = setInterval(() => void recheck(), RECHECK_INTERVAL_MS);
     return () => {
       cancelled = true;
-      clearInterval(interval);
+      if (timeout) clearTimeout(timeout);
     };
-  }, [organizationId, integrationId, queryClient]);
+  }, [enabled, organizationId, integrationId, queryClient]);
 }

--- a/web_src/src/lib/githubInstallRequestCopy.spec.ts
+++ b/web_src/src/lib/githubInstallRequestCopy.spec.ts
@@ -18,13 +18,13 @@ describe("githubInstallRequestCopy", () => {
   it("falls back when the organization is unknown", () => {
     expect(githubInstallRequestBody()).toBe("Ask a GitHub organization admin to approve the SuperPlane GitHub App.");
     expect(githubInstallRequestSettingsTitle()).toBe("Waiting for GitHub approval");
-    expect(GITHUB_INSTALL_REQUEST_NEXT).toBe("After they approve, click Connect GitHub again.");
+    expect(GITHUB_INSTALL_REQUEST_NEXT).toBe("SuperPlane checks for approval automatically.");
   });
 
   it("tells a GitHub admin the request is approved", () => {
     expect(GITHUB_INSTALL_APPROVED_TITLE).toBe("Request approved");
     expect(GITHUB_INSTALL_APPROVED_BODY).toBe(
-      "The SuperPlane GitHub App is approved. The person who asked can click Connect GitHub again.",
+      "The SuperPlane GitHub App is approved. The person who asked can continue in SuperPlane.",
     );
     expect(GITHUB_INSTALL_APPROVED_ACTION).toBe("Open SuperPlane");
   });

--- a/web_src/src/lib/githubInstallRequestCopy.ts
+++ b/web_src/src/lib/githubInstallRequestCopy.ts
@@ -1,11 +1,11 @@
 export const GITHUB_INSTALL_REQUEST_TITLE = "Waiting for approval";
 
-export const GITHUB_INSTALL_REQUEST_NEXT = "After they approve, click Connect GitHub again.";
+export const GITHUB_INSTALL_REQUEST_NEXT = "SuperPlane checks for approval automatically.";
 
 export const GITHUB_INSTALL_APPROVED_TITLE = "Request approved";
 
 export const GITHUB_INSTALL_APPROVED_BODY =
-  "The SuperPlane GitHub App is approved. The person who asked can click Connect GitHub again.";
+  "The SuperPlane GitHub App is approved. The person who asked can continue in SuperPlane.";
 
 export const GITHUB_INSTALL_APPROVED_ACTION = "Open SuperPlane";
 

--- a/web_src/src/lib/hostedGitHubInstall.spec.ts
+++ b/web_src/src/lib/hostedGitHubInstall.spec.ts
@@ -9,6 +9,7 @@ import {
   hostedGitHubInstallURL,
   hostedGitHubStartedByLogin,
   hostedGitHubState,
+  pendingGitHubInstallRequests,
   pendingGitHubInstallations,
 } from "./hostedGitHubInstall";
 
@@ -67,6 +68,25 @@ describe("pendingGitHubInstallations", () => {
   });
 });
 
+describe("pendingGitHubInstallRequests", () => {
+  it("reads every request and keeps legacy metadata compatible", () => {
+    expect(
+      pendingGitHubInstallRequests({
+        installRequests: [
+          { id: 1, accountLogin: "acme", requesterLogin: "member", createdAt: "2026-09-08T12:00:00Z" },
+          { id: "2", accountLogin: "octo", requesterLogin: "member" },
+        ],
+      }),
+    ).toEqual([
+      { id: "1", accountLogin: "acme", requesterLogin: "member", createdAt: "2026-09-08T12:00:00Z" },
+      { id: "2", accountLogin: "octo", requesterLogin: "member" },
+    ]);
+    expect(pendingGitHubInstallRequests({ installRequested: true, installRequestedAccount: "legacy" })).toEqual([
+      { accountLogin: "legacy" },
+    ]);
+  });
+});
+
 describe("hosted GitHub URLs", () => {
   it("builds the public bind path", () => {
     expect(hostedGitHubBindPath("csrf", "11")).toBe("/api/v1/github/app/bind?state=csrf&installation_id=11");
@@ -98,7 +118,7 @@ describe("hosted GitHub URLs", () => {
 
   it("reads the organization waiting for approval", () => {
     expect(hostedGitHubInstallRequestedAccount({ installRequestedAccount: "acme" })).toBe("acme");
-    expect(hostedGitHubInstallRequestedAccount({ owner: "acme" })).toBe("acme");
+    expect(hostedGitHubInstallRequestedAccount({ owner: "acme" })).toBe("");
     expect(hostedGitHubInstallRequestedAccount({ installRequestedAccount: "acme", owner: "other" })).toBe("acme");
     expect(hostedGitHubInstallRequestedAccount({})).toBe("");
   });

--- a/web_src/src/lib/hostedGitHubInstall.ts
+++ b/web_src/src/lib/hostedGitHubInstall.ts
@@ -4,6 +4,44 @@ export type PendingGitHubInstallation = {
   accountType?: string;
 };
 
+export type PendingGitHubInstallRequest = {
+  id?: string;
+  accountLogin: string;
+  requesterLogin?: string;
+  createdAt?: string;
+};
+
+export function pendingGitHubInstallRequests(metadata: unknown): PendingGitHubInstallRequest[] {
+  if (!metadata || typeof metadata !== "object") return [];
+
+  const raw = (metadata as { installRequests?: unknown }).installRequests;
+  if (Array.isArray(raw)) {
+    return raw.flatMap((item) => {
+      if (!item || typeof item !== "object") return [];
+      const row = item as {
+        id?: unknown;
+        accountLogin?: unknown;
+        requesterLogin?: unknown;
+        createdAt?: unknown;
+      };
+      const id = typeof row.id === "number" ? String(row.id) : row.id;
+      return [
+        {
+          ...(typeof id === "string" && id !== "" ? { id } : {}),
+          accountLogin: typeof row.accountLogin === "string" ? row.accountLogin.trim() : "",
+          ...(typeof row.requesterLogin === "string" && row.requesterLogin !== ""
+            ? { requesterLogin: row.requesterLogin }
+            : {}),
+          ...(typeof row.createdAt === "string" && row.createdAt !== "" ? { createdAt: row.createdAt } : {}),
+        },
+      ];
+    });
+  }
+
+  if ((metadata as { installRequested?: unknown }).installRequested !== true) return [];
+  return [{ accountLogin: hostedGitHubInstallRequestedAccount(metadata) }];
+}
+
 export function pendingGitHubInstallations(metadata: unknown): PendingGitHubInstallation[] {
   if (!metadata || typeof metadata !== "object") {
     return [];
@@ -40,7 +78,10 @@ export function hostedGitHubInstallRequested(metadata: unknown): boolean {
     return false;
   }
 
-  return (metadata as { installRequested?: unknown }).installRequested === true;
+  return (
+    (metadata as { installRequested?: unknown }).installRequested === true ||
+    pendingGitHubInstallRequests(metadata).length > 0
+  );
 }
 
 export function hostedGitHubInstallRequestedAccount(metadata: unknown): string {
@@ -53,8 +94,7 @@ export function hostedGitHubInstallRequestedAccount(metadata: unknown): string {
     return requested;
   }
 
-  const owner = (metadata as { owner?: unknown }).owner;
-  return typeof owner === "string" ? owner : "";
+  return "";
 }
 
 export function hostedGitHubState(metadata: unknown): string {

--- a/web_src/src/lib/integrationSetupReturn.spec.ts
+++ b/web_src/src/lib/integrationSetupReturn.spec.ts
@@ -71,6 +71,12 @@ describe("integration setup return", () => {
     expect(withGitHubSetupRequest("/org-1/workspaces/APP/setup?step=vcs", "githubSetup=request&githubOrg=acme")).toBe(
       "/org-1/workspaces/APP/setup?step=vcs&githubSetup=request&githubOrg=acme",
     );
+    expect(
+      withGitHubSetupRequest(
+        "/org-1/workspaces/APP/setup?step=vcs",
+        "githubSetup=request&githubOrg=acme&githubIntegrationId=int-1",
+      ),
+    ).toBe("/org-1/workspaces/APP/setup?step=vcs&githubSetup=request&githubOrg=acme&githubIntegrationId=int-1");
   });
 
   it("returns the path regardless of the integration the provider redirects to", () => {

--- a/web_src/src/lib/integrationSetupReturn.ts
+++ b/web_src/src/lib/integrationSetupReturn.ts
@@ -12,6 +12,8 @@ export const GITHUB_SETUP_REQUEST_PARAM = "githubSetup";
 export const GITHUB_SETUP_REQUEST_VALUE = "request";
 /** GitHub organization the member asked an admin to approve. */
 export const GITHUB_SETUP_ORG_PARAM = "githubOrg";
+/** GitHub connection that received the installation request callback. */
+export const GITHUB_SETUP_INTEGRATION_PARAM = "githubIntegrationId";
 
 interface StoredReturn {
   path: string;
@@ -105,6 +107,11 @@ export function githubSetupRequestedOrganization(search: string): string {
   return new URLSearchParams(query).get(GITHUB_SETUP_ORG_PARAM)?.trim() ?? "";
 }
 
+export function githubSetupRequestedIntegration(search: string): string {
+  const query = search.startsWith("?") ? search.slice(1) : search;
+  return new URLSearchParams(query).get(GITHUB_SETUP_INTEGRATION_PARAM)?.trim() ?? "";
+}
+
 /** Copies githubSetup=request from the provider callback onto the stored return path. */
 export function withGitHubSetupRequest(path: string, search: string): string {
   if (!hasGitHubSetupRequest(search)) return path;
@@ -115,6 +122,10 @@ export function withGitHubSetupRequest(path: string, search: string): string {
   const organization = githubSetupRequestedOrganization(search);
   if (organization !== "") {
     params.set(GITHUB_SETUP_ORG_PARAM, organization);
+  }
+  const integrationId = githubSetupRequestedIntegration(search);
+  if (integrationId !== "") {
+    params.set(GITHUB_SETUP_INTEGRATION_PARAM, integrationId);
   }
   return `${pathname}?${params.toString()}`;
 }

--- a/web_src/src/lib/startDirectGitHubConnect.requests.spec.ts
+++ b/web_src/src/lib/startDirectGitHubConnect.requests.spec.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { startDirectGitHubConnect } from "./startDirectGitHubConnect";
+
+const follow = vi.hoisted(() => vi.fn(() => true));
+
+vi.mock("@/lib/integrationSetupReturn", () => ({
+  rememberIntegrationSetupReturn: vi.fn(),
+  INTEGRATION_SETUP_STAY_PARAM: "setupStay",
+}));
+vi.mock("@/lib/browserAction", () => ({ followBrowserAction: follow }));
+
+describe("startDirectGitHubConnect request selection", () => {
+  beforeEach(() => follow.mockClear());
+
+  it("reuses the exact requested connection when the user has two pending connections", async () => {
+    const firstAction = { method: "GET", url: "https://github.com/apps/superplane/installations/new?state=1" };
+    const requestedAction = { method: "GET", url: "https://github.com/apps/superplane/installations/new?state=2" };
+    const create = vi.fn();
+    const update = vi.fn().mockResolvedValue(undefined);
+
+    await startDirectGitHubConnect({
+      organizationId: "org-1",
+      returnTo: "/org-1/workspaces/ws/setup?step=vcs",
+      existingNames: new Set(),
+      connected: [
+        {
+          metadata: { id: "int-1", integrationName: "github" },
+          status: { state: "pending", browserAction: firstAction, metadata: { startedByUserID: "user-1" } },
+        },
+        {
+          metadata: { id: "int-2", integrationName: "github" },
+          status: { state: "pending", browserAction: requestedAction, metadata: { startedByUserID: "user-1" } },
+        },
+      ],
+      currentUserId: "user-1",
+      preferredIntegrationId: "int-2",
+      create,
+      update,
+    });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith({
+      id: "int-2",
+      configuration: { setupReturnPath: "/org-1/workspaces/ws/setup?step=vcs" },
+    });
+    expect(follow).toHaveBeenCalledWith(requestedAction);
+  });
+
+  it("reuses an exact ready connection that has another installation request", async () => {
+    const authorizeAction = "https://github.com/login/oauth/authorize?state=ready";
+    const create = vi.fn();
+
+    await startDirectGitHubConnect({
+      organizationId: "org-1",
+      returnTo: "/org-1/workspaces/ws/setup?step=vcs",
+      existingNames: new Set(),
+      connected: [
+        {
+          metadata: { id: "int-ready", integrationName: "github" },
+          status: {
+            state: "ready",
+            metadata: {
+              startedByUserID: "user-1",
+              state: "csrf",
+              authorizeURL: authorizeAction,
+              installRequested: true,
+              pendingInstallations: [{ id: "11", accountLogin: "acme" }],
+            },
+          },
+        },
+      ],
+      currentUserId: "user-1",
+      preferredIntegrationId: "int-ready",
+      create,
+    });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(follow).toHaveBeenCalledWith({ method: "GET", url: authorizeAction });
+  });
+});

--- a/web_src/src/lib/startDirectGitHubConnect.requests.spec.ts
+++ b/web_src/src/lib/startDirectGitHubConnect.requests.spec.ts
@@ -48,7 +48,7 @@ describe("startDirectGitHubConnect request selection", () => {
   });
 
   it("reuses an exact ready connection that has another installation request", async () => {
-    const authorizeAction = "https://github.com/login/oauth/authorize?state=ready";
+    const authorizeAction = "https://github.com/login/oauth/authorize?state=csrf";
     const create = vi.fn();
 
     await startDirectGitHubConnect({
@@ -77,5 +77,42 @@ describe("startDirectGitHubConnect request selection", () => {
 
     expect(create).not.toHaveBeenCalled();
     expect(follow).toHaveBeenCalledWith({ method: "GET", url: authorizeAction });
+  });
+
+  it("repairs a stale authorize URL after GitHub access is revoked", async () => {
+    const create = vi.fn();
+
+    const started = await startDirectGitHubConnect({
+      organizationId: "org-1",
+      returnTo: "/onboarding?attempt=1&step=vcs",
+      existingNames: new Set(),
+      connected: [
+        {
+          metadata: { id: "int-1", integrationName: "github" },
+          status: {
+            state: "error",
+            browserAction: {
+              method: "GET",
+              url: "https://github.com/apps/superplane/installations/new?state=current-state",
+            },
+            metadata: {
+              state: "current-state",
+              startedByUserID: "user-1",
+              authorizeURL: "https://github.com/login/oauth/authorize?client_id=abc&state=revoked-state",
+              pendingInstallations: [{ id: "11", accountLogin: "acme" }],
+            },
+          },
+        },
+      ],
+      currentUserId: "user-1",
+      create,
+    });
+
+    expect(started).toBe(true);
+    expect(create).not.toHaveBeenCalled();
+    expect(follow).toHaveBeenCalledWith({
+      method: "GET",
+      url: "https://github.com/login/oauth/authorize?client_id=abc&state=current-state",
+    });
   });
 });

--- a/web_src/src/lib/startDirectGitHubConnect.spec.ts
+++ b/web_src/src/lib/startDirectGitHubConnect.spec.ts
@@ -76,6 +76,16 @@ describe("pendingGitHubBrowserAction", () => {
       ]),
     ).toBeUndefined();
   });
+
+  it("does not guess between two legacy pending connections", () => {
+    const action = { method: "GET", url: "https://github.com/apps/superplane/installations/new" };
+    const legacy = (id: string) => ({
+      metadata: { id, integrationName: "github" },
+      status: { state: "pending", browserAction: action, metadata: {} },
+    });
+
+    expect(pendingGitHubBrowserAction([legacy("int-1"), legacy("int-2")], "user-1")).toBeUndefined();
+  });
 });
 
 describe("pendingGitHubInstallPicker", () => {

--- a/web_src/src/lib/startDirectGitHubConnect.ts
+++ b/web_src/src/lib/startDirectGitHubConnect.ts
@@ -46,14 +46,30 @@ function accountPickerFromItem(item: OrganizationsIntegration | undefined): Pend
     return undefined;
   }
 
+  const state = hostedGitHubState(item.status?.metadata);
+
   return {
     id: item.metadata.id,
     installations: pendingGitHubInstallations(item.status?.metadata),
-    state: hostedGitHubState(item.status?.metadata),
+    state,
     appSlug: hostedGitHubAppSlug(item.status?.metadata),
-    authorizeUrl: hostedGitHubAuthorizeURL(item.status?.metadata),
+    authorizeUrl: authorizeURLWithState(hostedGitHubAuthorizeURL(item.status?.metadata), state),
     githubLogin: hostedGitHubStartedByLogin(item.status?.metadata),
   };
+}
+
+function authorizeURLWithState(authorizeURL: string, state: string): string {
+  if (!authorizeURL || !state) return authorizeURL;
+
+  try {
+    const url = new URL(authorizeURL);
+    if (url.searchParams.get("state") === state) return authorizeURL;
+
+    url.searchParams.set("state", state);
+    return url.toString();
+  } catch {
+    return authorizeURL;
+  }
 }
 
 function startedByUserID(item: OrganizationsIntegration): string {

--- a/web_src/src/lib/startDirectGitHubConnect.ts
+++ b/web_src/src/lib/startDirectGitHubConnect.ts
@@ -10,9 +10,12 @@ import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import {
   hostedGitHubAppSlug,
   hostedGitHubAuthorizeURL,
+  hostedGitHubInstallRequested,
   hostedGitHubStartedByLogin,
   hostedGitHubState,
+  pendingGitHubInstallRequests,
   pendingGitHubInstallations,
+  type PendingGitHubInstallRequest,
   type PendingGitHubInstallation,
 } from "@/lib/hostedGitHubInstall";
 import { integrationDetailPath, legacySettingsIntegrationsPath } from "@/lib/integrationSettingsPaths";
@@ -30,6 +33,12 @@ export type PendingGitHubAccountPicker = {
   authorizeUrl: string;
   /** GitHub login that authorized this connect. Empty when the field is absent. */
   githubLogin: string;
+};
+
+export type PendingGitHubRequestConnection = {
+  id: string;
+  connection: OrganizationsIntegration;
+  requests: PendingGitHubInstallRequest[];
 };
 
 function accountPickerFromItem(item: OrganizationsIntegration | undefined): PendingGitHubAccountPicker | undefined {
@@ -61,12 +70,28 @@ function isOwnPendingGitHub(item: OrganizationsIntegration, currentUserId?: stri
   return startedBy === "" || startedBy === currentUserId;
 }
 
-function isOwnPendingGitHubItem(item: OrganizationsIntegration, currentUserId?: string): boolean {
-  return (
-    item.metadata?.integrationName === "github" &&
-    item.status?.state !== "ready" &&
-    isOwnPendingGitHub(item, currentUserId)
+function isGitHubInstallRequest(item: OrganizationsIntegration): boolean {
+  return item.metadata?.integrationName === "github" && hostedGitHubInstallRequested(item.status?.metadata);
+}
+
+/** Selects one request connection without combining metadata from different integrations. */
+export function pendingGitHubRequestConnection(
+  connected: OrganizationsIntegration[],
+  currentUserId?: string,
+  preferredIntegrationId?: string,
+): PendingGitHubRequestConnection | undefined {
+  if (!currentUserId) return undefined;
+
+  const requested = connected.filter(isGitHubInstallRequest);
+  const preferred = requested.find(
+    (item) => item.metadata?.id === preferredIntegrationId && isOwnPendingGitHub(item, currentUserId),
   );
+  const owned = preferred ?? requested.find((item) => startedByUserID(item) === currentUserId);
+  const legacy = owned ?? (requested.length === 1 && startedByUserID(requested[0]) === "" ? requested[0] : undefined);
+  const id = legacy?.metadata?.id;
+  if (!legacy || !id) return undefined;
+
+  return { id, connection: legacy, requests: pendingGitHubInstallRequests(legacy.status?.metadata) };
 }
 
 export function pendingGitHubBrowserAction(
@@ -79,10 +104,24 @@ export function pendingGitHubBrowserAction(
 function pendingOwnGitHubWithAction(
   connected: OrganizationsIntegration[],
   currentUserId?: string,
+  preferredIntegrationId?: string,
 ): OrganizationsIntegration | undefined {
-  return connected.find(
-    (item) => isOwnPendingGitHubItem(item, currentUserId) && Boolean(item.status?.browserAction?.url),
+  const candidates = connected.filter(
+    (item) =>
+      item.metadata?.integrationName === "github" &&
+      item.status?.state !== "ready" &&
+      Boolean(item.status?.browserAction?.url),
   );
+  const preferred = candidates.find(
+    (item) => item.metadata?.id === preferredIntegrationId && isOwnPendingGitHub(item, currentUserId),
+  );
+  if (preferred) return preferred;
+
+  const owned = candidates.find((item) => startedByUserID(item) === currentUserId);
+  if (owned) return owned;
+
+  const legacy = candidates.filter((item) => startedByUserID(item) === "");
+  return legacy.length === 1 ? legacy[0] : undefined;
 }
 
 export function pendingGitHubInstallPicker(
@@ -96,17 +135,30 @@ export function pendingGitHubInstallPicker(
 export function pendingGitHubAccountPicker(
   connected: OrganizationsIntegration[],
   currentUserId?: string,
+  preferredIntegrationId?: string,
 ): PendingGitHubAccountPicker | undefined {
   if (!currentUserId) {
     return undefined;
   }
 
-  const pending = connected.find((item) => {
-    if (!isOwnPendingGitHubItem(item, currentUserId) || !item.metadata?.id) {
+  const preferredConnection = connected.find((item) => item.metadata?.id === preferredIntegrationId);
+  const preferredPicker = githubAccountPickerFromConnection(preferredConnection, currentUserId);
+  if (preferredPicker) return preferredPicker;
+
+  const candidates = connected.filter((item) => {
+    if (
+      item.metadata?.integrationName !== "github" ||
+      item.status?.state === "ready" ||
+      !item.metadata?.id ||
+      !isOwnPendingGitHub(item, currentUserId)
+    ) {
       return false;
     }
     return pendingGitHubInstallations(item.status?.metadata).length >= 1;
   });
+  const owned = candidates.find((item) => startedByUserID(item) === currentUserId);
+  const legacyCandidates = candidates.filter((item) => startedByUserID(item) === "");
+  const pending = owned ?? (legacyCandidates.length === 1 ? legacyCandidates[0] : undefined);
   return accountPickerFromItem(pending);
 }
 
@@ -189,6 +241,7 @@ type StartDirectGitHubConnectArgs = {
   connected: OrganizationsIntegration[];
   currentUserId?: string;
   forceNew?: boolean;
+  preferredIntegrationId?: string;
   create: (payload: {
     integrationName: string;
     name: string;
@@ -199,7 +252,7 @@ type StartDirectGitHubConnectArgs = {
 };
 
 async function resumePendingGitHubConnect(args: StartDirectGitHubConnectArgs): Promise<boolean> {
-  const picker = pendingGitHubAccountPicker(args.connected, args.currentUserId);
+  const picker = pendingGitHubAccountPicker(args.connected, args.currentUserId, args.preferredIntegrationId);
   if (picker) {
     rememberIntegrationSetupReturn(args.organizationId, args.returnTo);
     if (isOnboardingSetupReturnPath(args.returnTo)) {
@@ -222,7 +275,7 @@ async function resumePendingGitHubConnect(args: StartDirectGitHubConnectArgs): P
     return true;
   }
 
-  const pending = pendingOwnGitHubWithAction(args.connected, args.currentUserId);
+  const pending = pendingOwnGitHubWithAction(args.connected, args.currentUserId, args.preferredIntegrationId);
   const pendingAction = pending?.status?.browserAction;
   if (!pendingAction) {
     return false;

--- a/web_src/src/pages/auth/OrganizationOnboardingRedirect.component.spec.tsx
+++ b/web_src/src/pages/auth/OrganizationOnboardingRedirect.component.spec.tsx
@@ -1,8 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AccountContextType } from "@/contexts/accountContextState";
+import { factoryQueryKeys } from "@/hooks/useFactoryData";
+import { meKeys } from "@/hooks/useMe";
 
 import { OrganizationOnboardingRedirect } from "./OrganizationOnboardingRedirect";
 
@@ -134,7 +136,7 @@ describe("OrganizationOnboardingRedirect", () => {
       json: () => Promise.resolve({ organizationSlug: "dev-user-x1y2z3", workspaceKey: "NEWWO" }),
     });
 
-    await reresolve();
+    await act(reresolve);
 
     await waitFor(() => expect(screen.getByTestId("internal-workspace-slug")).toHaveTextContent("dev-user-x1y2z3"));
     expect(location.replace).not.toHaveBeenCalled();
@@ -165,9 +167,41 @@ describe("OrganizationOnboardingRedirect", () => {
     // Cache written by the wizard itself after the workspace was adopted.
     queryClient.setQueryData(["factories", "dev-user"], [{ id: "current-factory" }]);
 
-    await reresolve();
+    await act(reresolve);
 
     expect(queryClient.getQueryData(["factories", "dev-user"])).toBeDefined();
+  });
+
+  it("keeps seeded workspace queries when a re-resolve adopts a new slug", async () => {
+    const queryClient = new QueryClient();
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ organizationSlug: "dev-user", workspaceKey: "NEWWO" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { reresolve } = renderOnboardingWithReresolve(queryClient);
+
+    await screen.findByText("dev-user");
+
+    const seededFactory = { id: "current-factory", key: "NEWWO" };
+    const currentUser = { id: "account-1", permissions: [{ resource: "factories", action: "update" }] };
+    queryClient.setQueryData(factoryQueryKeys.list("github-owner"), [seededFactory]);
+    queryClient.setQueryData(factoryQueryKeys.detail("github-owner", seededFactory.id), seededFactory);
+    queryClient.setQueryData(meKeys.me("dev-user"), currentUser);
+    queryClient.setQueryData(meKeys.me("github-owner"), { id: "stale-user", permissions: [] });
+    queryClient.setQueryData(["integrations", "connected", "github-owner"], [{ id: "stale-integration" }]);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ organizationSlug: "github-owner", workspaceKey: "NEWWO" }),
+    });
+
+    await act(reresolve);
+
+    await waitFor(() => expect(screen.getByTestId("internal-workspace-slug")).toHaveTextContent("github-owner"));
+    expect(queryClient.getQueryData(factoryQueryKeys.list("github-owner"))).toEqual([seededFactory]);
+    expect(queryClient.getQueryData(factoryQueryKeys.detail("github-owner", seededFactory.id))).toEqual(seededFactory);
+    expect(queryClient.getQueryData(meKeys.me("github-owner"))).toEqual(currentUser);
+    expect(queryClient.getQueryData(["integrations", "connected", "github-owner"])).toBeUndefined();
   });
 
   it("starts workspace setup without GitHub authorization", async () => {

--- a/web_src/src/pages/auth/OrganizationOnboardingRedirect.tsx
+++ b/web_src/src/pages/auth/OrganizationOnboardingRedirect.tsx
@@ -1,5 +1,6 @@
 import { useAccount } from "@/contexts/useAccount";
-import { useQueryClient } from "@tanstack/react-query";
+import { meKeys } from "@/hooks/useMe";
+import { useQueryClient, type QueryClient, type QueryKey } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 
 import type { OnboardingWorkspaceResolution } from "../factories/pages/onboarding/onboardingWorkspaceResolutionContext";
@@ -9,6 +10,23 @@ export type ProvisionedWorkspace = {
   organizationSlug: string;
   workspaceKey: string;
 };
+
+function isWorkspaceResolutionQuery(queryKey: readonly unknown[], organizationSlug: string): boolean {
+  return queryKey[0] === "factories" && queryKey[1] === organizationSlug && queryKey.length <= 3;
+}
+
+function workspaceResolutionQueries(
+  queryClient: QueryClient,
+  currentSlug: string,
+  nextSlug: string,
+): [QueryKey, unknown][] {
+  const queries = queryClient.getQueriesData({
+    predicate: (query) => isWorkspaceResolutionQuery(query.queryKey, nextSlug),
+  });
+  const currentUser = queryClient.getQueryData(meKeys.me(currentSlug));
+  if (currentUser !== undefined) queries.push([meKeys.me(nextSlug), currentUser]);
+  return queries;
+}
 
 interface OrganizationOnboardingRedirectProps {
   renderWorkspace: (
@@ -30,16 +48,22 @@ export function OrganizationOnboardingRedirect({ renderWorkspace }: Organization
   const onboardingAttempt = useRef(getOnboardingAttempt());
 
   // A new organization can receive the slug of an earlier onboarding
-  // organization that was later renamed (for example, to the GitHub owner).
-  // Cached queries under that slug still hold the old organization's factory
-  // and connections, which would open the wizard mid-way, so the slug starts
-  // with a clean cache whenever the wizard adopts a different slug.
+  // organization that was later renamed. Clear that organization's cached
+  // data, but retain the seeded factory data and current permissions. These
+  // queries keep the repository step mounted while the new slug resolves;
+  // all other organization data must load again.
   const adoptWorkspace = useCallback(
     (provisioned: ProvisionedWorkspace) => {
       if (workspaceRef.current?.organizationSlug !== provisioned.organizationSlug) {
+        const resolutionQueries = workspaceRef.current
+          ? workspaceResolutionQueries(queryClient, workspaceRef.current.organizationSlug, provisioned.organizationSlug)
+          : [];
         queryClient.removeQueries({
           predicate: (query) => query.queryKey.includes(provisioned.organizationSlug),
         });
+        for (const [queryKey, data] of resolutionQueries) {
+          if (data !== undefined) queryClient.setQueryData(queryKey, data);
+        }
       }
       workspaceRef.current = provisioned;
       setWorkspace(provisioned);

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.chrome.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.chrome.spec.tsx
@@ -40,7 +40,7 @@ vi.mock("@/hooks/useRecheckGitHubInstallRequest", () => ({
 }));
 
 vi.mock("@/hooks/useBindGitHubInstallation", () => ({
-  useBindGitHubInstallation: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+  useBindGitHubInstallation: () => ({ mutateAsync: vi.fn() }),
 }));
 
 const navigateSpy = vi.fn();
@@ -72,6 +72,7 @@ function pageModel(overrides: Partial<OnboardingPageModel> = {}): OnboardingPage
   return {
     setup: setupState(),
     hostedAgentReady: false,
+    agentLoading: false,
     openSection: "issues",
     setOpenSection: vi.fn(),
     requestConnect: vi.fn(),

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.reliability.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.reliability.spec.tsx
@@ -1,0 +1,283 @@
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import type { FactoriesFactory, OrganizationsIntegration } from "@/api-client";
+
+import { FIRST_RUN_COPY } from "./first-run/firstRunCopy";
+import { FirstRunSetup } from "./FirstRunSetup";
+import { useOnboardingSetupState, type OnboardingSetupApi } from "./useOnboardingSetupState";
+import type { useOnboardingPageModel } from "./useOnboardingPageModel";
+
+type OnboardingPageModel = ReturnType<typeof useOnboardingPageModel>;
+const factory: FactoriesFactory = {
+  id: "factory-1",
+  key: "PAY",
+  name: "New workspace",
+  onboarding: { vcsIntegrationId: "github-1" },
+};
+
+vi.mock("../../layout/factoriesLayoutContext", () => ({
+  useFactoriesLayout: () => ({
+    organizationId: "org-1",
+    factoryId: "factory-1",
+    factoryKey: "PAY",
+    factory,
+    factories: [factory],
+  }),
+}));
+vi.mock("@/contexts/useAccount", () => ({
+  useAccount: () => ({ account: { id: "account-1", name: "Ada Lovelace", email: "ada@example.com" } }),
+}));
+vi.mock("@/hooks/useMe", () => ({ useMe: () => ({ data: { id: "user-1" } }) }));
+vi.mock("@/hooks/useAccountOrganizations", () => ({
+  useAccountOrganizations: () => ({ data: [{ id: "org-1", name: "Acme" }] }),
+}));
+vi.mock("@/hooks/useRecheckGitHubInstallRequest", () => ({ useRecheckGitHubInstallRequest: vi.fn() }));
+vi.mock("@/hooks/useBindGitHubInstallation", () => ({
+  useBindGitHubInstallation: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+}));
+vi.mock("@/posthog", () => ({ posthog: { reset: vi.fn() } }));
+vi.mock("./AgentStep", () => ({ AgentStep: () => <div data-testid="agent-step" /> }));
+
+function setupState(): OnboardingSetupApi {
+  return renderHook(() => useOnboardingSetupState("Payments Service", { simulateDiscovery: false })).result.current;
+}
+
+function pageModel(overrides: Partial<OnboardingPageModel> = {}): OnboardingPageModel {
+  return {
+    setup: setupState(),
+    hostedAgentReady: false,
+    agentLoading: false,
+    openSection: "issues",
+    setOpenSection: vi.fn(),
+    requestConnect: vi.fn(),
+    refreshGithubConnections: vi.fn().mockResolvedValue(undefined),
+    githubConnectionsLoading: false,
+    requestPrivateGitHubConnect: vi.fn(),
+    offersPrivateGitHubAppSetup: false,
+    createVcsConnection: vi.fn(),
+    selectVcsConnection: vi.fn().mockResolvedValue(true),
+    githubConnections: { name: "github", allInstances: [], readyInstances: [] },
+    selectedVcsConnectionId: "github-1",
+    requestConfigure: vi.fn(),
+    integrationDialogs: <></>,
+    repositories: ["acme/payments-service"],
+    repositoriesLoading: false,
+    repositoriesError: null,
+    canConfigureWorkspace: true,
+    saving: false,
+    saveName: vi.fn().mockResolvedValue(true),
+    saveRepository: vi.fn().mockResolvedValue(true),
+    saveIssues: vi.fn().mockResolvedValue(true),
+    finish: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderSetup(model: OnboardingPageModel, path = "/org-1/workspaces/PAY/setup?step=issues") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <FirstRunSetup model={model} />
+    </MemoryRouter>,
+  );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function githubConnections(instances: OrganizationsIntegration[]) {
+  return { name: "github", readyInstances: [], allInstances: instances };
+}
+
+function githubConnection(id: string, metadata: Record<string, unknown>): OrganizationsIntegration {
+  return { metadata: { id, integrationName: "github" }, status: { state: "pending", metadata } };
+}
+
+describe("FirstRunSetup reliability", () => {
+  it("shows local placeholders while GitHub accounts and repositories load", () => {
+    const accounts = renderSetup(
+      pageModel({ openSection: "vcs", githubConnectionsLoading: true }),
+      "/org-1/workspaces/PAY/setup?step=vcs",
+    );
+    expect(screen.getByTestId("first-run-connect-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-connect-github")).not.toBeInTheDocument();
+
+    accounts.unmount();
+    renderSetup(
+      pageModel({ openSection: "repo", repositories: ["octo/stale-repo"], repositoriesLoading: true }),
+      "/org-1/workspaces/PAY/setup?step=repo",
+    );
+    expect(screen.getByTestId("first-run-repositories-loading")).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /octo\/stale-repo/ })).not.toBeInTheDocument();
+  });
+
+  it("locks the connect screen while GitHub opens and ignores a second click", async () => {
+    const user = userEvent.setup();
+    const navigation = deferred<boolean>();
+    const requestConnect = vi.fn(() => navigation.promise);
+    renderSetup(pageModel({ openSection: "vcs", requestConnect }), "/org-1/workspaces/PAY/setup?step=vcs");
+
+    const connect = screen.getByTestId("first-run-connect-github");
+    await user.click(connect);
+    expect(connect).toHaveTextContent(FIRST_RUN_COPY.connect.openingGitHub);
+    expect(connect).toBeDisabled();
+    expect(screen.getByTestId("first-run-back")).toBeDisabled();
+    await user.click(connect);
+    expect(requestConnect).toHaveBeenCalledTimes(1);
+
+    navigation.resolve(true);
+    await waitFor(() => expect(connect).toHaveTextContent(FIRST_RUN_COPY.connect.connectGitHub));
+  });
+
+  it("keeps repository and ticket screens locked until their saves finish", async () => {
+    const user = userEvent.setup();
+    const repositorySaved = deferred<boolean>();
+    const setup = { ...setupState(), selectedRepo: "acme/payments-service" };
+    const repository = renderSetup(
+      pageModel({ openSection: "repo", saveRepository: vi.fn(() => repositorySaved.promise), setup }),
+      "/org-1/workspaces/PAY/setup?step=repo",
+    );
+    const repositoryContinue = screen.getByTestId("first-run-continue-to-tickets");
+    await user.click(repositoryContinue);
+    expect(repositoryContinue).toHaveTextContent(FIRST_RUN_COPY.choose.saving);
+    expect(screen.getByTestId("first-run-back")).toBeDisabled();
+    repositorySaved.resolve(true);
+    expect(await screen.findByTestId("first-run-tickets")).toBeInTheDocument();
+
+    repository.unmount();
+    const issuesSaved = deferred<boolean>();
+    const saveIssues = vi.fn(() => issuesSaved.promise);
+    renderSetup(pageModel({ openSection: "issues", saveIssues }));
+    const issuesContinue = screen.getByTestId("first-run-analyze-tickets");
+    await user.click(issuesContinue);
+    expect(issuesContinue).toHaveTextContent(FIRST_RUN_COPY.tickets.saving);
+    await user.click(issuesContinue);
+    expect(saveIssues).toHaveBeenCalledTimes(1);
+    issuesSaved.resolve(true);
+    expect(await screen.findByTestId("first-run-agent")).toBeInTheDocument();
+  });
+
+  it("shows only the current user's GitHub account picker", () => {
+    const picker = (userId: string) =>
+      githubConnection("int-1", {
+        startedByUserID: userId,
+        state: "csrf",
+        githubApp: { slug: "superplane" },
+        pendingInstallations: [{ id: "11", accountLogin: "acme" }],
+      });
+    const mine = renderSetup(
+      pageModel({ openSection: "vcs", githubConnections: githubConnections([picker("user-1")]) }),
+      "/org-1/workspaces/PAY/setup?step=vcs",
+    );
+    expect(screen.getByRole("button", { name: FIRST_RUN_COPY.connect.useAccount("acme") })).toBeInTheDocument();
+
+    mine.unmount();
+    renderSetup(
+      pageModel({ openSection: "vcs", githubConnections: githubConnections([picker("another-user")]) }),
+      "/org-1/workspaces/PAY/setup?step=vcs",
+    );
+    expect(screen.queryByTestId("first-run-github-account-picker")).not.toBeInTheDocument();
+  });
+
+  it("opens the waiting screen from a GitHub request return", () => {
+    const request = githubConnection("int-1", { startedByUserID: "user-1", installRequested: true });
+    renderSetup(
+      pageModel({ openSection: "vcs", githubConnections: githubConnections([request]) }),
+      "/org-1/workspaces/PAY/setup?githubSetup=request&githubIntegrationId=int-1",
+    );
+    expect(screen.getByTestId("first-run-connect")).toBeInTheDocument();
+    expect(screen.getByTestId("first-run-github-install-requested")).toHaveTextContent(
+      FIRST_RUN_COPY.connect.installRequested,
+    );
+  });
+
+  it("uses server metadata for every requested organization", () => {
+    const request = githubConnection("int-1", {
+      startedByUserID: "user-1",
+      installRequests: [
+        { id: "1", accountLogin: "acme", requesterLogin: "member" },
+        { id: "2", accountLogin: "octo", requesterLogin: "member" },
+      ],
+    });
+    renderSetup(
+      pageModel({ openSection: "vcs", githubConnections: githubConnections([request]) }),
+      "/org-1/workspaces/PAY/setup?step=vcs&githubOrg=wrong&githubIntegrationId=int-1",
+    );
+    expect(screen.getByTestId("first-run-github-install-org")).toHaveTextContent("acme");
+    expect(screen.getByTestId("first-run-github-install-org")).toHaveTextContent("octo");
+    expect(screen.queryByText("wrong")).not.toBeInTheDocument();
+  });
+
+  it("replaces the waiting state with the approved account picker", () => {
+    const waiting = githubConnection("int-1", {
+      startedByUserID: "user-1",
+      state: "csrf",
+      githubApp: { slug: "superplane" },
+      installRequests: [{ id: "1", accountLogin: "acme", requesterLogin: "member" }],
+    });
+    const approved = githubConnection("int-1", {
+      startedByUserID: "user-1",
+      state: "csrf",
+      githubApp: { slug: "superplane" },
+      installRequests: [],
+      pendingInstallations: [{ id: "11", accountLogin: "acme" }],
+    });
+    const view = renderSetup(
+      pageModel({ openSection: "vcs", githubConnections: githubConnections([waiting]) }),
+      "/org-1/workspaces/PAY/setup?step=vcs&githubSetup=request&githubIntegrationId=int-1",
+    );
+    expect(screen.getByTestId("first-run-github-install-requested")).toBeInTheDocument();
+
+    view.rerender(
+      <MemoryRouter initialEntries={["/org-1/workspaces/PAY/setup?step=vcs"]}>
+        <FirstRunSetup model={pageModel({ openSection: "vcs", githubConnections: githubConnections([approved]) })} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId("first-run-github-install-requested")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: FIRST_RUN_COPY.connect.useAccount("acme") })).toBeInTheDocument();
+  });
+
+  it("does not borrow an organization or request from another member", () => {
+    const mine = githubConnection("mine", { startedByUserID: "user-1", installRequested: true });
+    const theirs = githubConnection("theirs", {
+      startedByUserID: "another-user",
+      installRequested: true,
+      installRequestedAccount: "wrong-org",
+    });
+    renderSetup(
+      pageModel({ openSection: "vcs", githubConnections: githubConnections([mine, theirs]) }),
+      "/org-1/workspaces/PAY/setup?step=vcs",
+    );
+    expect(screen.getByTestId("first-run-github-install-requested")).toBeInTheDocument();
+    expect(screen.queryByText("wrong-org")).not.toBeInTheDocument();
+  });
+
+  it("hides another member's request when the current user has none", () => {
+    const theirs = githubConnection("theirs", {
+      startedByUserID: "another-user",
+      installRequested: true,
+      installRequestedAccount: "their-org",
+    });
+    renderSetup(
+      pageModel({ openSection: "vcs", githubConnections: githubConnections([theirs]) }),
+      "/org-1/workspaces/PAY/setup?step=vcs",
+    );
+    expect(screen.queryByTestId("first-run-github-install-requested")).not.toBeInTheDocument();
+  });
+
+  it("ignores a stale request marker after server metadata loads", () => {
+    renderSetup(
+      pageModel({ openSection: "vcs", githubConnectionsLoading: false }),
+      "/org-1/workspaces/PAY/setup?step=vcs&githubSetup=request&githubOrg=stale-org",
+    );
+    expect(screen.queryByTestId("first-run-github-install-requested")).not.toBeInTheDocument();
+    expect(screen.queryByText("stale-org")).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
@@ -45,7 +45,12 @@ vi.mock("@/hooks/useRecheckGitHubInstallRequest", () => ({
 const bindMutate = vi.fn();
 
 vi.mock("@/hooks/useBindGitHubInstallation", () => ({
-  useBindGitHubInstallation: () => ({ mutate: bindMutate, isPending: false, variables: undefined }),
+  useBindGitHubInstallation: () => ({
+    mutateAsync: (variables: unknown) =>
+      new Promise<void>((resolve, reject) => {
+        bindMutate(variables, { onSuccess: resolve, onError: reject });
+      }),
+  }),
 }));
 
 const navigateSpy = vi.fn();
@@ -78,6 +83,7 @@ function pageModel(overrides: Partial<OnboardingPageModel> = {}): OnboardingPage
   return {
     setup: setupState(),
     hostedAgentReady: false,
+    agentLoading: false,
     openSection: "issues",
     setOpenSection: vi.fn(),
     requestConnect: vi.fn(),
@@ -105,7 +111,7 @@ function pageModel(overrides: Partial<OnboardingPageModel> = {}): OnboardingPage
 }
 
 function renderSetup(model: OnboardingPageModel, path = "/org-1/workspaces/PAY/setup?step=issues") {
-  render(
+  return render(
     <MemoryRouter initialEntries={[path]}>
       <FirstRunSetup model={model} />
     </MemoryRouter>,
@@ -309,30 +315,6 @@ describe("FirstRunSetup", () => {
     expect(screen.getByTestId("first-run-github-account-picker")).toBeInTheDocument();
   });
 
-  // A GitHub round trip reloads the page, so the picker data arrives after
-  // the first render. The screen must not flash the connect button first.
-  it("shows a placeholder on the connect screen while the connection list loads", () => {
-    renderSetup(
-      pageModel({ openSection: "vcs", githubConnectionsLoading: true }),
-      "/org-1/workspaces/PAY/setup?step=vcs",
-    );
-
-    expect(screen.getByTestId("first-run-connect-loading")).toBeInTheDocument();
-    expect(screen.queryByTestId("first-run-connect-github")).not.toBeInTheDocument();
-  });
-
-  // A refresh of the repository list must not show cached repositories from
-  // an earlier connection while the fresh list loads.
-  it("shows a placeholder on the repository screen while the list refreshes", () => {
-    renderSetup(
-      pageModel({ openSection: "repo", repositories: ["octo/stale-repo"], repositoriesLoading: true }),
-      "/org-1/workspaces/PAY/setup?step=repo",
-    );
-
-    expect(screen.getByTestId("first-run-repositories-loading")).toBeInTheDocument();
-    expect(screen.queryByRole("option", { name: /octo\/stale-repo/ })).not.toBeInTheDocument();
-  });
-
   it("moves the bound connection to another account through the picker", async () => {
     const user = userEvent.setup();
     const selectVcsConnection = vi.fn().mockResolvedValue(true);
@@ -432,102 +414,6 @@ describe("FirstRunSetup", () => {
     await waitFor(() => expect(selectVcsConnection).toHaveBeenCalledWith("int-new"));
     expect(screen.getByTestId("first-run-connect")).toBeInTheDocument();
     expect(screen.queryByTestId("first-run-choose")).not.toBeInTheDocument();
-  });
-
-  it("shows the GitHub account picker on the connect screen", () => {
-    renderSetup(
-      pageModel({
-        openSection: "vcs",
-        githubConnections: {
-          name: "github",
-          readyInstances: [],
-          allInstances: [
-            {
-              metadata: { id: "int-1", integrationName: "github" },
-              status: {
-                state: "pending",
-                metadata: {
-                  startedByUserID: "user-1",
-                  state: "csrf",
-                  githubApp: { slug: "superplane" },
-                  pendingInstallations: [
-                    { id: "11", accountLogin: "acme" },
-                    { id: "22", accountLogin: "octo" },
-                  ],
-                },
-              },
-            },
-          ],
-        },
-      }),
-      "/org-1/workspaces/PAY/setup?step=vcs",
-    );
-
-    expect(screen.getByTestId("first-run-github-account-picker")).toHaveTextContent(
-      FIRST_RUN_COPY.connect.selectAccount,
-    );
-    expect(screen.getByRole("button", { name: FIRST_RUN_COPY.connect.useAccount("acme") })).toBeInTheDocument();
-    expect(screen.queryByTestId("first-run-connect-github")).not.toBeInTheDocument();
-  });
-
-  it("does not show another member's GitHub account picker", () => {
-    renderSetup(
-      pageModel({
-        openSection: "vcs",
-        githubConnections: {
-          name: "github",
-          readyInstances: [],
-          allInstances: [
-            {
-              metadata: { id: "int-1", integrationName: "github" },
-              status: {
-                state: "pending",
-                metadata: {
-                  startedByUserID: "some-other-user",
-                  state: "csrf",
-                  githubApp: { slug: "superplane" },
-                  pendingInstallations: [
-                    { id: "11", accountLogin: "acme" },
-                    { id: "22", accountLogin: "octo" },
-                  ],
-                },
-              },
-            },
-          ],
-        },
-      }),
-      "/org-1/workspaces/PAY/setup?step=vcs",
-    );
-
-    expect(screen.queryByTestId("first-run-github-account-picker")).not.toBeInTheDocument();
-    expect(screen.getByTestId("first-run-connect-github")).toBeInTheDocument();
-  });
-
-  it("opens Connect when GitHub returned an install request without a step", () => {
-    renderSetup(pageModel({ openSection: "vcs" }), "/org-1/workspaces/PAY/setup?githubSetup=request");
-
-    expect(screen.getByTestId("first-run-connect")).toBeInTheDocument();
-    expect(screen.getByTestId("first-run-github-install-requested")).toBeInTheDocument();
-    expect(screen.queryByTestId("first-run-welcome")).not.toBeInTheDocument();
-  });
-
-  it("shows a waiting chip when GitHub returned an install request", () => {
-    renderSetup(pageModel({ openSection: "vcs" }), "/org-1/workspaces/PAY/setup?step=vcs&githubSetup=request");
-
-    expect(screen.getByTestId("first-run-github-install-requested")).toHaveTextContent(
-      FIRST_RUN_COPY.connect.installRequested,
-    );
-    expect(screen.getByTestId("first-run-connect-github")).toBeInTheDocument();
-  });
-
-  it("names the GitHub organization from the return query", () => {
-    renderSetup(
-      pageModel({ openSection: "vcs" }),
-      "/org-1/workspaces/PAY/setup?step=vcs&githubSetup=request&githubOrg=acme",
-    );
-
-    expect(screen.getByTestId("first-run-github-install-org")).toHaveTextContent("acme");
-    expect(screen.queryByText(FIRST_RUN_COPY.connect.installRequestedBody("acme"))).not.toBeInTheDocument();
   });
 
   it("counts the ticket screen as the last step when the agent screen is skipped", () => {

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
@@ -1,30 +1,8 @@
 import { LoadingButton } from "@/components/ui/loading-button";
 import { useAccount } from "@/contexts/useAccount";
 import { useAccountOrganizations } from "@/hooks/useAccountOrganizations";
-import { useMe } from "@/hooks/useMe";
 import { organizationMatchesRoute } from "@/lib/accountOrganizations";
-import { getApiErrorMessage } from "@/lib/errors";
-import {
-  hostedGitHubInstallRequested,
-  hostedGitHubInstallRequestedAccount,
-  type PendingGitHubInstallation,
-} from "@/lib/hostedGitHubInstall";
-import { useBindGitHubInstallation } from "@/hooks/useBindGitHubInstallation";
-import { useRecheckGitHubInstallRequest } from "@/hooks/useRecheckGitHubInstallRequest";
-import {
-  githubAccountPickerFromConnection,
-  pendingGitHubAccountPicker,
-  type PendingGitHubAccountPicker,
-} from "@/lib/startDirectGitHubConnect";
-import {
-  GITHUB_SETUP_ORG_PARAM,
-  GITHUB_SETUP_REQUEST_PARAM,
-  GITHUB_SETUP_REQUEST_VALUE,
-} from "@/lib/integrationSetupReturn";
-import { showErrorToast } from "@/lib/toast";
 import { posthog } from "@/posthog";
-import { useEffect, useRef, useState } from "react";
-import { useSearchParams } from "react-router";
 
 import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
 import { AgentStep } from "./AgentStep";
@@ -32,52 +10,20 @@ import { FirstRunChooseScreen } from "./first-run/FirstRunChooseScreen";
 import { FirstRunConnectScreen } from "./first-run/FirstRunConnectScreen";
 import { FIRST_RUN_STEP_COUNT, FirstRunHeading, FirstRunPanel, FirstRunShell } from "./first-run/FirstRunShell";
 import { FirstRunTicketsScreen } from "./first-run/FirstRunTicketsScreen";
-import type { FirstRunChrome, FirstRunTicketSource } from "./first-run/firstRunTypes";
+import type { FirstRunChrome } from "./first-run/firstRunTypes";
 import { FIRST_RUN_COPY } from "./first-run/firstRunCopy";
 import { FirstRunWelcomeScreen } from "./first-run/FirstRunWelcomeScreen";
-import { WIZARD_STEPS, type IntegrationId, type IssuesChoiceId, type WizardStepId } from "./onboardingFixtures";
-import { isWizardStepId } from "./onboardingStatus";
+import { WIZARD_STEPS } from "./onboardingFixtures";
+import {
+  DEFAULT_TICKET_SOURCE,
+  useFirstRunSetupFlow,
+  useFreshConnectionsOnConnectScreen,
+  type FirstRunScreen,
+  type FirstRunSetupFlow,
+  type IntegrationId,
+  type OnboardingPageModel,
+} from "./useFirstRunSetupFlow";
 import type { OnboardingSetupApi } from "./useOnboardingSetupState";
-import type { useOnboardingPageModel } from "./useOnboardingPageModel";
-
-type OnboardingPageModel = ReturnType<typeof useOnboardingPageModel>;
-
-type FirstRunScreen = "welcome" | "connect" | "choose" | "tickets" | "agent";
-
-const SCREEN_FOR_STEP: Record<WizardStepId, FirstRunScreen> = {
-  vcs: "connect",
-  repo: "choose",
-  issues: "tickets",
-  agent: "agent",
-  // The first-run screens derive the workspace name from the repository, so the
-  // last saved answer opens the coding agent screen.
-  name: "agent",
-};
-
-function initialFirstRunScreen(searchParams: URLSearchParams): FirstRunScreen {
-  const requestedStep = searchParams.get("step");
-  // A leftover githubSetup=request on a later step must not reopen Connect.
-  if (isWizardStepId(requestedStep)) {
-    return SCREEN_FOR_STEP[requestedStep];
-  }
-  if (searchParams.get(GITHUB_SETUP_REQUEST_PARAM) === GITHUB_SETUP_REQUEST_VALUE) {
-    return "connect";
-  }
-  return "welcome";
-}
-
-function startConnectOnPicker(searchParams: URLSearchParams): boolean {
-  const step = searchParams.get("step");
-  if (step === "vcs") return true;
-  return step === null && searchParams.get(GITHUB_SETUP_REQUEST_PARAM) === GITHUB_SETUP_REQUEST_VALUE;
-}
-
-const STEP_FOR_SCREEN: Partial<Record<FirstRunScreen, WizardStepId>> = {
-  connect: "vcs",
-  choose: "repo",
-  tickets: "issues",
-  agent: "agent",
-};
 
 const STEP_INDEX_FOR_SCREEN: Record<FirstRunScreen, number> = {
   welcome: 0,
@@ -98,26 +44,10 @@ const BACK_SCREEN: Partial<Record<FirstRunScreen, FirstRunScreen>> = {
 };
 
 /**
- * Hosted credentials leave the agent screen with no question to ask, so the
- * ticket screen becomes the last screen and provisions the workspace.
- */
-function screenWithoutAgent(screen: FirstRunScreen, skipAgentScreen: boolean): FirstRunScreen {
-  if (screen === "agent" && skipAgentScreen) return "tickets";
-  return screen;
-}
-
-/**
  * The first-run screens have no coding agent screen. This screen keeps the
  * wizard step copy, because provisioning needs a connected agent.
  */
 const AGENT_STEP: { id: "agent"; label: string; purpose: string } = WIZARD_STEPS[3];
-
-/**
- * GitHub Issues is the only source setup can connect, so the tickets screen
- * opens with it selected. Jira and Linear stay marked as coming soon.
- */
-const DEFAULT_TICKET_SOURCE: FirstRunTicketSource = "github-issues";
-const DEFAULT_ISSUES_CHOICE: IssuesChoiceId = "vcs";
 
 function firstNameOf(name: string | undefined): string | undefined {
   const first = name?.trim().split(/\s+/)[0];
@@ -129,84 +59,12 @@ function signOut() {
   window.location.href = "/logout";
 }
 
-/**
- * Saves the connection the account picker bound, once the refreshed
- * connection list reports it ready. The bind callback runs before the list
- * re-renders, so an effect makes the save see the ready connection. The
- * repository screen opens only after the save, so a fast repository pick
- * cannot store the prior connection.
- */
-function useSelectBoundGithubConnection(
-  boundIntegrationId: string | null,
-  clearBoundIntegrationId: () => void,
-  model: OnboardingPageModel,
-  onSelected: () => void,
-) {
-  const readyInstances = model.githubConnections.readyInstances;
-  const selectConnection = model.selectVcsConnection;
-
-  useEffect(() => {
-    if (!boundIntegrationId) return;
-    const bound = readyInstances.some((instance) => instance.metadata?.id === boundIntegrationId);
-    if (!bound) return;
-    clearBoundIntegrationId();
-    void selectConnection(boundIntegrationId).then((saved) => {
-      if (saved) onSelected();
-    });
-  }, [boundIntegrationId, clearBoundIntegrationId, readyInstances, selectConnection, onSelected]);
-}
-
-/**
- * The GitHub account picker reads the connection list from the cache. An
- * install or bind finished outside this document, or a browser Back, can
- * leave that list stale, so entering the connect screen refetches it.
- */
-function useFreshConnectionsOnConnectScreen(screen: FirstRunScreen, refresh: () => Promise<unknown>) {
-  useEffect(() => {
-    if (screen !== "connect") return;
-    void refresh();
-  }, [screen, refresh]);
-}
-
-/**
- * The connect step is two pages: the Connect GitHub page with the connect
- * button, and the account picker. Get started always opens the connect
- * button page; only a GitHub round trip (or Back from the repository screen)
- * opens the picker. So the user picks the GitHub account on every forward
- * pass, and Back walks repository, picker, connect, welcome in order.
- */
-function useConnectStage(
-  startOnPicker: boolean,
-  accountPicker: PendingGitHubAccountPicker | undefined,
-  sourcesLoading: boolean,
-) {
-  const [pickerOpen, setPickerOpen] = useState(startOnPicker);
-  return {
-    pickerShowing: pickerOpen && Boolean(accountPicker),
-    // A GitHub round trip reloads the page, so the picker data arrives after
-    // the first render. The screen shows a placeholder until the connection
-    // list settles, instead of flashing the connect button first.
-    pickerLoading: pickerOpen && !accountPicker && sourcesLoading,
-    setPickerOpen,
-  };
-}
-
-/** Reports a failed repository list, which the choose screen shows as empty. */
-function useRepositoryErrorToast(error: unknown) {
-  const reported = useRef<unknown>(null);
-
-  useEffect(() => {
-    if (!error || reported.current === error) return;
-    reported.current = error;
-    showErrorToast(getApiErrorMessage(error, "Failed to load repositories"));
-  }, [error]);
-}
-
 function AgentScreen({
   organizationId,
   setup,
   chrome,
   saving,
+  loading,
   onRequestConnect,
   onContinue,
 }: {
@@ -214,23 +72,31 @@ function AgentScreen({
   setup: OnboardingSetupApi;
   chrome: FirstRunChrome;
   saving: boolean;
+  loading: boolean;
   onRequestConnect: (id: IntegrationId) => void;
   onContinue: () => void;
 }) {
   return (
-    <FirstRunShell testId="first-run-agent" chrome={chrome} width="wide">
+    <FirstRunShell testId="first-run-agent" chrome={chrome} busy={saving || loading} width="wide">
       <FirstRunHeading headline={FIRST_RUN_COPY.agent.headline}>
         <p className="text-[13px] text-muted-foreground">{AGENT_STEP.purpose}</p>
       </FirstRunHeading>
 
       <div className="mt-8 space-y-4">
-        <FirstRunPanel>
-          <AgentStep organizationId={organizationId} setup={setup} onRequestConnect={onRequestConnect} />
-        </FirstRunPanel>
+        {loading ? (
+          <p className="text-[13px] text-muted-foreground" role="status">
+            {FIRST_RUN_COPY.agent.loading}
+          </p>
+        ) : null}
+        <fieldset disabled={saving || loading} className="contents">
+          <FirstRunPanel>
+            <AgentStep organizationId={organizationId} setup={setup} onRequestConnect={onRequestConnect} />
+          </FirstRunPanel>
+        </fieldset>
         <LoadingButton
           type="button"
           className="w-full"
-          disabled={!setup.agentReady}
+          disabled={!setup.agentReady || loading}
           loading={saving}
           loadingText={FIRST_RUN_COPY.finish.saving}
           onClick={onContinue}
@@ -244,164 +110,11 @@ function AgentScreen({
 }
 
 /**
- * Screen order and answer saving for workspace setup. The first-run screens
- * stay presentational, so this hook holds every step that talks to the API.
- */
-function useFirstRunSetupFlow(model: OnboardingPageModel) {
-  const { organizationId } = useFactoriesLayout();
-  const { data: me, isPending: meLoading } = useMe(true, organizationId);
-  const [searchParams] = useSearchParams();
-  const setup = model.setup;
-  const setOpenSection = model.setOpenSection;
-
-  const [openedScreen, setOpenedScreen] = useState<FirstRunScreen>(() => initialFirstRunScreen(searchParams));
-  const openStep = useRef(model.openSection);
-  const skipAgentScreen = model.hostedAgentReady;
-
-  useRepositoryErrorToast(model.repositoriesError);
-
-  // Setup selects the connection GitHub returns with, then opens the next step.
-  useEffect(() => {
-    if (model.openSection === openStep.current) return;
-    openStep.current = model.openSection;
-    setOpenedScreen(SCREEN_FOR_STEP[model.openSection]);
-  }, [model.openSection]);
-
-  // Pass the /me user id, not account.id. startedByUserID is the SuperPlane
-  // user. The /account id is the account, so a match would hide the picker.
-  // A bound connection keeps its picker data, so Back from the repository
-  // screen offers the accounts again instead of a dead connected state.
-  const selectedConnection = model.githubConnections.readyInstances.find(
-    (instance) => instance.metadata?.id === model.selectedVcsConnectionId,
-  );
-  const accountPicker =
-    pendingGitHubAccountPicker(model.githubConnections.allInstances, me?.id) ??
-    githubAccountPickerFromConnection(selectedConnection, me?.id);
-
-  // Only a GitHub round trip or a waiting install request lands on the
-  // account picker page. A fresh pass opens the Connect GitHub page.
-  const stage = useConnectStage(
-    startConnectOnPicker(searchParams),
-    accountPicker,
-    meLoading || model.githubConnectionsLoading,
-  );
-
-  const goToScreen = (next: FirstRunScreen, connectStage: "button" | "picker" = "button") => {
-    if (next === "connect") {
-      stage.setPickerOpen(connectStage === "picker");
-    }
-    const step = STEP_FOR_SCREEN[next];
-    if (step) {
-      // Keeps the provider return URL on the step the user is answering.
-      openStep.current = step;
-      setOpenSection(step);
-    }
-    setOpenedScreen(next);
-  };
-
-  const continueFromRepository = async () => {
-    const repository = setup.selectedRepo;
-    if (!repository) return;
-    setup.commitRepoStep();
-    if (!(await model.saveRepository(repository))) return;
-    goToScreen("tickets");
-  };
-
-  const continueFromTickets = async () => {
-    setup.setIssuesChoice(DEFAULT_ISSUES_CHOICE);
-    setup.commitIssuesStep();
-    if (!(await model.saveIssues(DEFAULT_ISSUES_CHOICE))) return;
-    if (skipAgentScreen) {
-      // The issues choice was just set above, in this same click; the setup
-      // state captured when this render closed over `model.finish` still
-      // holds the answer from before the click. Passing the answer here
-      // keeps a single click from saving a stale, empty issues source over
-      // the one `saveIssues` already stored.
-      await model.finish(DEFAULT_ISSUES_CHOICE);
-      return;
-    }
-    goToScreen("agent");
-  };
-
-  const selectTicketSource = (source: FirstRunTicketSource) => {
-    // Jira and Linear are not connectable yet, so the screen shows them as
-    // coming soon and reports GitHub Issues only.
-    if (source !== DEFAULT_TICKET_SOURCE) return;
-    setup.setIssuesChoice(DEFAULT_ISSUES_CHOICE);
-  };
-
-  const installRequested =
-    searchParams.get(GITHUB_SETUP_REQUEST_PARAM) === GITHUB_SETUP_REQUEST_VALUE ||
-    model.githubConnections.allInstances.some((instance) => hostedGitHubInstallRequested(instance.status?.metadata));
-
-  // An approved install request binds outside the wizard round trip, so the
-  // waiting screen rechecks GitHub through the connection until it is ready.
-  // The welcome screen stays first even while a request waits; Get started
-  // opens the connect screen, which shows the waiting state.
-  useRecheckGitHubInstallRequest(organizationId, model.githubConnections.allInstances);
-
-  const githubOrganization =
-    searchParams.get(GITHUB_SETUP_ORG_PARAM)?.trim() ||
-    model.githubConnections.allInstances
-      .map((instance) => hostedGitHubInstallRequestedAccount(instance.status?.metadata))
-      .find((account) => account !== "") ||
-    "";
-  // Binding through a page redirect reloads the whole app and walks the user
-  // through the connect screen again. Binding in place opens the repository
-  // screen directly once the connection is ready.
-  const bindInstallation = useBindGitHubInstallation(organizationId);
-  const [boundIntegrationId, setBoundIntegrationId] = useState<string | null>(null);
-  useSelectBoundGithubConnection(
-    boundIntegrationId,
-    () => setBoundIntegrationId(null),
-    model,
-    () => goToScreen("choose"),
-  );
-  const useInstallation = (installation: PendingGitHubInstallation) => {
-    const state = accountPicker?.state;
-    const pendingId = accountPicker?.id;
-    if (!state || bindInstallation.isPending) return;
-    bindInstallation.mutate(
-      { state, installationId: installation.id },
-      {
-        onSuccess: () => {
-          if (!pendingId) {
-            goToScreen("choose");
-            return;
-          }
-          setBoundIntegrationId(pendingId);
-        },
-        onError: (error) => showErrorToast(getApiErrorMessage(error, "Failed to connect the GitHub account")),
-      },
-    );
-  };
-
-  return {
-    screen: screenWithoutAgent(openedScreen, skipAgentScreen),
-    skipAgentScreen,
-    installRequested,
-    githubOrganization,
-    accountPicker,
-    pickerShowing: stage.pickerShowing,
-    pickerLoading: stage.pickerLoading,
-    closePicker: () => stage.setPickerOpen(false),
-    bindingInstallationId: bindInstallation.isPending ? bindInstallation.variables?.installationId : undefined,
-    useInstallation,
-    goToScreen,
-    continueFromRepository,
-    continueFromTickets,
-    selectTicketSource,
-  };
-}
-
-type FirstRunFlow = ReturnType<typeof useFirstRunSetupFlow>;
-
-/**
  * Back walks the exact screens in reverse order: repository, account picker,
  * Connect GitHub, welcome. The picker is a page of the connect screen, so
  * Back on the picker closes it instead of changing screens.
  */
-function backActionFor(target: FirstRunScreen, flow: FirstRunFlow): (() => void) | undefined {
+function backActionFor(target: FirstRunScreen, flow: FirstRunSetupFlow): (() => void) | undefined {
   if (target === "connect" && flow.pickerShowing) {
     return flow.closePicker;
   }
@@ -413,7 +126,7 @@ function backActionFor(target: FirstRunScreen, flow: FirstRunFlow): (() => void)
 }
 
 /** Picker data for the connect screen. The Connect GitHub page passes none. */
-function pickerPropsFor(flow: FirstRunFlow) {
+function pickerPropsFor(flow: FirstRunSetupFlow) {
   if (!flow.pickerShowing) {
     return {};
   }
@@ -456,6 +169,7 @@ export function FirstRunSetup({ model }: { model: OnboardingPageModel }) {
       stepIndex: STEP_INDEX_FOR_SCREEN[target],
       stepCount: flow.skipAgentScreen ? FIRST_RUN_STEP_COUNT - 1 : FIRST_RUN_STEP_COUNT,
       onBack: backActionFor(target, flow),
+      busy: flow.busy,
     };
   };
 
@@ -474,12 +188,14 @@ export function FirstRunSetup({ model }: { model: OnboardingPageModel }) {
       <FirstRunConnectScreen
         loading={flow.pickerLoading}
         installRequested={flow.installRequested}
-        githubOrganization={flow.githubOrganization}
+        githubOrganizations={flow.githubOrganizations}
         {...pickerPropsFor(flow)}
         bindingInstallationId={flow.bindingInstallationId}
+        connecting={flow.blockingAction === "opening-github"}
         chrome={chromeFor("connect")}
-        onConnectGitHub={() => model.requestConnect("github")}
+        onConnectGitHub={() => void flow.connectGitHub()}
         onUseInstallation={flow.useInstallation}
+        onInstallOther={() => void flow.installOnAnotherAccount()}
       />
     );
   }
@@ -490,6 +206,7 @@ export function FirstRunSetup({ model }: { model: OnboardingPageModel }) {
         repositories={model.repositories}
         selectedRepository={setup.selectedRepo}
         loading={model.repositoriesLoading}
+        saving={flow.blockingAction === "saving-repository"}
         chrome={chromeFor("choose")}
         onSelectRepository={setup.selectRepo}
         onEditConnection={() => model.requestConfigure()}
@@ -504,7 +221,16 @@ export function FirstRunSetup({ model }: { model: OnboardingPageModel }) {
         ticketSource={DEFAULT_TICKET_SOURCE}
         chrome={chromeFor("tickets")}
         continueLabel={flow.skipAgentScreen ? FIRST_RUN_COPY.tickets.analyze : FIRST_RUN_COPY.tickets.continue}
-        saving={flow.skipAgentScreen && model.saving}
+        saving={
+          flow.blockingAction === "saving-ticket-source" ||
+          flow.blockingAction === "finishing-setup" ||
+          (flow.skipAgentScreen && model.saving)
+        }
+        savingLabel={
+          flow.blockingAction === "finishing-setup" || (flow.skipAgentScreen && model.saving)
+            ? FIRST_RUN_COPY.finish.saving
+            : FIRST_RUN_COPY.tickets.saving
+        }
         onSelectTicketSource={flow.selectTicketSource}
         onAnalyzeTickets={() => void flow.continueFromTickets()}
       />
@@ -516,9 +242,10 @@ export function FirstRunSetup({ model }: { model: OnboardingPageModel }) {
       organizationId={organizationId}
       setup={setup}
       chrome={chromeFor("agent")}
-      saving={model.saving}
+      saving={flow.blockingAction === "finishing-setup" || model.saving}
+      loading={model.agentLoading}
       onRequestConnect={model.requestConnect}
-      onContinue={() => void model.finish()}
+      onContinue={() => void flow.finishSetup()}
     />
   );
 }

--- a/web_src/src/pages/factories/pages/onboarding/NewWorkspacePage.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/NewWorkspacePage.spec.tsx
@@ -80,6 +80,15 @@ describe("NewWorkspacePage", () => {
 
     expect(createFactory).not.toHaveBeenCalled();
     expect(screen.queryByTestId("github-app-required")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Checking GitHub setup…");
+  });
+
+  it("shows progress while the workspace is created", () => {
+    createFactory.mockReturnValue(new Promise(() => undefined));
+
+    renderPage();
+
+    expect(screen.getByRole("status")).toHaveTextContent("Creating workspace…");
   });
 
   it("does not create a workspace when the catalog request fails", () => {

--- a/web_src/src/pages/factories/pages/onboarding/NewWorkspacePage.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/NewWorkspacePage.tsx
@@ -1,10 +1,11 @@
 import { Link } from "@/components/Link/link";
-import { Button } from "@/components/ui/button";
+import { LoadingButton } from "@/components/ui/loading-button";
 import { useCreateFactory, useFactories } from "@/hooks/useFactoryData";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { getApiErrorMessage } from "@/lib/errors";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useNavigate, useParams } from "react-router";
+import { Loader2 } from "lucide-react";
 
 import { factoryListPath, factorySetupPath } from "../../lib/factoryPagePaths";
 import { useFactoriesThemeClass } from "../../lib/useFactoriesThemeClass";
@@ -39,6 +40,8 @@ function NewWorkspacePageContent({ organizationId }: { organizationId: string })
   const githubApp = useGithubAppAvailability(organizationId);
   const [error, setError] = useState<string | null>(null);
   const [attempt, setAttempt] = useState(0);
+  const [retryingCatalog, setRetryingCatalog] = useState(false);
+  const [retryingCreation, setRetryingCreation] = useState(false);
   // Workspace creation must run once per attempt, not on every render.
   const requested = useRef(false);
 
@@ -68,6 +71,8 @@ function NewWorkspacePageContent({ organizationId }: { organizationId: string })
         navigate(factorySetupPath(organizationId, factory.key), { replace: true });
       } catch (creationError) {
         setError(getApiErrorMessage(creationError, "Failed to create workspace"));
+      } finally {
+        setRetryingCreation(false);
       }
     };
 
@@ -87,31 +92,22 @@ function NewWorkspacePageContent({ organizationId }: { organizationId: string })
   const retry = () => {
     setError(null);
     requested.current = false;
+    setRetryingCreation(true);
     setAttempt((current) => current + 1);
   };
 
+  const retryCatalog = async () => {
+    if (retryingCatalog) return;
+    setRetryingCatalog(true);
+    try {
+      await githubApp.retry();
+    } finally {
+      setRetryingCatalog(false);
+    }
+  };
+
   if (githubApp.failed) {
-    return (
-      <div className="min-h-screen w-full bg-background text-foreground" data-testid="new-workspace">
-        <div className="mx-auto w-full max-w-3xl px-6 py-8 lg:px-8">
-          <h1 className="text-[22px] font-semibold tracking-[-0.02em]">Set up your workspace</h1>
-          <div className="mt-6 rounded-lg border border-border p-4">
-            <p className="text-[13px] text-destructive">SuperPlane could not check the GitHub App.</p>
-            <div className="mt-3 flex items-center gap-3">
-              <Button type="button" size="sm" onClick={githubApp.retry}>
-                Try again
-              </Button>
-              <Link
-                href={factoryListPath(organizationId)}
-                className="text-[13px] text-muted-foreground hover:underline"
-              >
-                Cancel
-              </Link>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
+    return <GitHubCatalogFailure organizationId={organizationId} retrying={retryingCatalog} onRetry={retryCatalog} />;
   }
 
   if (githubApp.resolved && !githubApp.available) {
@@ -119,29 +115,100 @@ function NewWorkspacePageContent({ organizationId }: { organizationId: string })
   }
 
   return (
-    <div className="min-h-screen w-full bg-background text-foreground" data-testid="new-workspace">
+    <WorkspaceCreationStatus
+      organizationId={organizationId}
+      error={error}
+      retrying={retryingCreation}
+      githubAppResolved={githubApp.resolved}
+      onRetry={retry}
+    />
+  );
+}
+
+function NewWorkspaceFrame({ children, busy }: { children: ReactNode; busy?: boolean }) {
+  return (
+    <div className="min-h-screen w-full bg-background text-foreground" data-testid="new-workspace" aria-busy={busy}>
       <div className="mx-auto w-full max-w-3xl px-6 py-8 lg:px-8">
         <h1 className="text-[22px] font-semibold tracking-[-0.02em]">Set up your workspace</h1>
-
-        {error ? (
-          <div className="mt-6 rounded-lg border border-border p-4">
-            <p className="text-[13px] text-destructive">{error}</p>
-            <div className="mt-3 flex items-center gap-3">
-              <Button type="button" size="sm" onClick={retry}>
-                Try again
-              </Button>
-              <Link
-                href={factoryListPath(organizationId)}
-                className="text-[13px] text-muted-foreground hover:underline"
-              >
-                Cancel
-              </Link>
-            </div>
-          </div>
-        ) : (
-          <p className="mt-6 text-[13px] text-muted-foreground">Creating the workspace…</p>
-        )}
+        {children}
       </div>
     </div>
+  );
+}
+
+function GitHubCatalogFailure({
+  organizationId,
+  retrying,
+  onRetry,
+}: {
+  organizationId: string;
+  retrying: boolean;
+  onRetry: () => Promise<void>;
+}) {
+  return (
+    <NewWorkspaceFrame busy={retrying || undefined}>
+      <div className="mt-6 rounded-lg border border-border p-4">
+        <p className="text-[13px] text-destructive">SuperPlane could not check the GitHub App.</p>
+        <div className="mt-3 flex items-center gap-3">
+          <LoadingButton
+            type="button"
+            size="sm"
+            onClick={() => void onRetry()}
+            loading={retrying}
+            loadingText="Trying again…"
+          >
+            Try again
+          </LoadingButton>
+          <Link
+            href={factoryListPath(organizationId)}
+            aria-disabled={retrying || undefined}
+            tabIndex={retrying ? -1 : undefined}
+            onClick={(event) => {
+              if (retrying) event.preventDefault();
+            }}
+            className={`text-[13px] text-muted-foreground hover:underline ${retrying ? "pointer-events-none opacity-50" : ""}`}
+          >
+            Cancel
+          </Link>
+        </div>
+      </div>
+    </NewWorkspaceFrame>
+  );
+}
+
+function WorkspaceCreationStatus({
+  organizationId,
+  error,
+  retrying,
+  githubAppResolved,
+  onRetry,
+}: {
+  organizationId: string;
+  error: string | null;
+  retrying: boolean;
+  githubAppResolved: boolean;
+  onRetry: () => void;
+}) {
+  return (
+    <NewWorkspaceFrame busy={!error || retrying || undefined}>
+      {error ? (
+        <div className="mt-6 rounded-lg border border-border p-4">
+          <p className="text-[13px] text-destructive">{error}</p>
+          <div className="mt-3 flex items-center gap-3">
+            <LoadingButton type="button" size="sm" onClick={onRetry} loading={retrying} loadingText="Trying again…">
+              Try again
+            </LoadingButton>
+            <Link href={factoryListPath(organizationId)} className="text-[13px] text-muted-foreground hover:underline">
+              Cancel
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <p className="mt-6 inline-flex items-center gap-2 text-[13px] text-muted-foreground" role="status">
+          <Loader2 className="size-4 animate-spin" aria-hidden />
+          {retrying ? "Trying again…" : githubAppResolved ? "Creating workspace…" : "Checking GitHub setup…"}
+        </p>
+      )}
+    </NewWorkspaceFrame>
   );
 }

--- a/web_src/src/pages/factories/pages/onboarding/OnboardingPage.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/OnboardingPage.tsx
@@ -1,7 +1,9 @@
 import { useConsumeIntegrationSetupReturnOnArrival } from "@/hooks/useConsumeIntegrationSetupReturnOnArrival";
+import { Loader2 } from "lucide-react";
 
 import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
 import { FirstRunSetup } from "./FirstRunSetup";
+import { FirstRunShell } from "./first-run/FirstRunShell";
 import { GithubAppRequiredNotice } from "./GithubAppRequiredNotice";
 import { useGithubAppAvailability } from "./useGithubAppAvailability";
 import { useOnboardingEntryPath } from "./useOnboardingEntryPath";
@@ -15,6 +17,17 @@ export function OnboardingPage() {
   useConsumeIntegrationSetupReturnOnArrival(layout.organizationId);
   const githubApp = useGithubAppAvailability(layout.organizationId);
   const model = useOnboardingPageModel({ ...layout, onboardingEntryPath, reresolveWorkspace });
+
+  if (!githubApp.resolved) {
+    return (
+      <FirstRunShell testId="workspace-setup-loading" busy>
+        <p className="inline-flex items-center gap-2 text-[13px] text-muted-foreground" role="status">
+          <Loader2 className="size-4 animate-spin" aria-hidden />
+          Checking GitHub setup…
+        </p>
+      </FirstRunShell>
+    );
+  }
 
   if (githubApp.resolved && !githubApp.failed && !githubApp.available) {
     return <GithubAppRequiredNotice />;

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunAnalysisScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunAnalysisScreen.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui/button";
+import { LoadingButton } from "@/components/ui/loading-button";
 import { cn } from "@/lib/utils";
 import { Check, Loader2 } from "lucide-react";
 
@@ -10,18 +10,20 @@ export function FirstRunAnalysisScreen({
   status,
   currentStageIndex,
   chrome,
+  retrying = false,
   onRetry,
 }: {
   status: FirstRunAnalysisStatus;
   /** 0–2 while running. Stages at or below this index are active or done. */
   currentStageIndex: number;
   chrome?: FirstRunChrome;
+  retrying?: boolean;
   onRetry: () => void;
 }) {
   const copy = FIRST_RUN_COPY.analysis;
 
   return (
-    <FirstRunShell testId="first-run-analysis" chrome={chrome}>
+    <FirstRunShell testId="first-run-analysis" chrome={chrome} busy={retrying || status !== "failed"}>
       <FirstRunHeading headline={copy.headline}>
         <p className="text-[13px] text-muted-foreground">{copy.body}</p>
         <p className="text-[13px] text-muted-foreground">{copy.reassurance}</p>
@@ -30,9 +32,15 @@ export function FirstRunAnalysisScreen({
       {status === "failed" ? (
         <div className="mt-8 space-y-4">
           <p className="text-[13px] text-destructive">{copy.failure}</p>
-          <Button type="button" onClick={onRetry} data-testid="first-run-run-again">
+          <LoadingButton
+            type="button"
+            onClick={onRetry}
+            loading={retrying}
+            loadingText={copy.retrying}
+            data-testid="first-run-run-again"
+          >
             {copy.retry}
-          </Button>
+          </LoadingButton>
         </div>
       ) : (
         <FirstRunPanel>

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunChooseScreen.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunChooseScreen.spec.tsx
@@ -99,6 +99,8 @@ describe("FirstRunChooseScreen", () => {
     expect(screen.getByTestId("first-run-repositories-loading")).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /octo\/stale-repo/ })).not.toBeInTheDocument();
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(FIRST_RUN_COPY.choose.loading);
+    expect(screen.getByTestId("first-run-repositories-spinner")).toBeInTheDocument();
   });
 
   it("disables continue until a repository is selected", () => {
@@ -131,5 +133,23 @@ describe("FirstRunChooseScreen", () => {
     const continueButton = screen.getByTestId("first-run-continue-to-tickets");
     expect(continueButton).toBeEnabled();
     expect(continueButton).toHaveTextContent(FIRST_RUN_COPY.choose.continueReady);
+  });
+
+  it("locks repository controls while the selection saves", () => {
+    render(
+      <FirstRunChooseScreen
+        repositories={["octo/repo"]}
+        selectedRepository="octo/repo"
+        saving
+        chrome={{ stepIndex: 2, onBack: vi.fn() }}
+        onSelectRepository={vi.fn()}
+        onEditConnection={vi.fn()}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("first-run-continue-to-tickets")).toHaveTextContent(FIRST_RUN_COPY.choose.saving);
+    expect(screen.getByRole("option", { name: /octo\/repo/ })).toBeDisabled();
+    expect(screen.getByText(FIRST_RUN_COPY.choose.editConnection)).toBeDisabled();
   });
 });

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunChooseScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunChooseScreen.tsx
@@ -1,6 +1,6 @@
-import { Button } from "@/components/ui/button";
+import { LoadingButton } from "@/components/ui/loading-button";
 import { cn } from "@/lib/utils";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Loader2 } from "lucide-react";
 import { useState } from "react";
 
 import { RepositoryPicker } from "../onboardingSteps";
@@ -12,6 +12,7 @@ export function FirstRunChooseScreen({
   repositories,
   selectedRepository,
   loading,
+  saving = false,
   chrome,
   onSelectRepository,
   onEditConnection,
@@ -21,6 +22,7 @@ export function FirstRunChooseScreen({
   selectedRepository: string | null;
   /** True while the repository list loads or refreshes; hides stale entries. */
   loading?: boolean;
+  saving?: boolean;
   chrome?: FirstRunChrome;
   onSelectRepository: (repository: string) => void;
   onEditConnection: () => void;
@@ -28,9 +30,10 @@ export function FirstRunChooseScreen({
 }) {
   const copy = FIRST_RUN_COPY.choose;
   const [whyMissingOpen, setWhyMissingOpen] = useState(false);
+  const busy = Boolean(loading || saving);
 
   return (
-    <FirstRunShell testId="first-run-choose" chrome={chrome}>
+    <FirstRunShell testId="first-run-choose" chrome={chrome} busy={busy}>
       <FirstRunHeading headline={copy.headline}>
         <p className="text-[13px] text-muted-foreground">{copy.repositoryHelper}</p>
       </FirstRunHeading>
@@ -44,6 +47,7 @@ export function FirstRunChooseScreen({
               host="github"
               repos={repositories}
               selectedRepo={selectedRepository}
+              disabled={busy}
               onSelect={onSelectRepository}
             />
           )}
@@ -52,6 +56,7 @@ export function FirstRunChooseScreen({
             <button
               type="button"
               onClick={onEditConnection}
+              disabled={busy}
               className="font-medium text-foreground underline underline-offset-2 hover:no-underline"
             >
               {copy.editConnection}
@@ -63,15 +68,17 @@ export function FirstRunChooseScreen({
         </FirstRunPanel>
 
         <div className="space-y-2">
-          <Button
+          <LoadingButton
             type="button"
             className="w-full"
-            disabled={!selectedRepository}
+            disabled={!selectedRepository || busy}
+            loading={saving}
+            loadingText={copy.saving}
             onClick={onContinue}
             data-testid="first-run-continue-to-tickets"
           >
             {selectedRepository ? copy.continueReady : copy.continue}
-          </Button>
+          </LoadingButton>
           <p className="text-[12px] text-muted-foreground">{copy.moreLater}</p>
         </div>
 
@@ -79,9 +86,15 @@ export function FirstRunChooseScreen({
           className="rounded-lg border border-border p-3 text-left open:pb-4"
           open={whyMissingOpen}
           onToggle={(event) => setWhyMissingOpen(event.currentTarget.open)}
+          aria-disabled={busy || undefined}
           data-testid="first-run-choose-why-missing"
         >
-          <summary className="flex cursor-pointer list-none items-center justify-between gap-2 text-[13px] text-muted-foreground [&::-webkit-details-marker]:hidden">
+          <summary
+            className={cn(
+              "flex cursor-pointer list-none items-center justify-between gap-2 text-[13px] text-muted-foreground [&::-webkit-details-marker]:hidden",
+              busy && "pointer-events-none opacity-50",
+            )}
+          >
             {copy.missingTitle}
             <ChevronDown
               className={cn("size-3.5 shrink-0 transition-transform", whyMissingOpen && "rotate-180")}
@@ -99,21 +112,15 @@ export function FirstRunChooseScreen({
   );
 }
 
-/** Mirrors the repository picker layout: a search field and a short list. */
 function RepositoryListLoading() {
   return (
-    <div className="space-y-3" data-testid="first-run-repositories-loading" aria-hidden>
-      <div className="h-9 animate-pulse rounded-md bg-accent/40" />
-      <div className="rounded-lg border border-border">
-        <ul className="divide-y divide-border">
-          {[0, 1, 2].map((row) => (
-            <li key={row} className="flex items-center gap-3 px-3 py-2.5">
-              <div className="size-4 shrink-0 animate-pulse rounded bg-accent/40" />
-              <div className="h-3.5 w-40 animate-pulse rounded bg-accent/40" />
-            </li>
-          ))}
-        </ul>
-      </div>
+    <div
+      className="flex min-h-32 items-center justify-center gap-2 text-[13px] text-muted-foreground"
+      data-testid="first-run-repositories-loading"
+      role="status"
+    >
+      <Loader2 className="size-4 animate-spin" data-testid="first-run-repositories-spinner" aria-hidden />
+      <span>{FIRST_RUN_COPY.choose.loading}</span>
     </div>
   );
 }

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.spec.tsx
@@ -40,6 +40,7 @@ describe("FirstRunConnectScreen", () => {
     expect(screen.queryByTestId("first-run-github-install-org")).not.toBeInTheDocument();
     expect(screen.queryByTestId("first-run-github-install-help")).not.toBeInTheDocument();
     expect(screen.getByTestId("first-run-connect-github")).toBeInTheDocument();
+    expect(screen.getByText(FIRST_RUN_COPY.connect.installRequestedNext)).toBeInTheDocument();
     expect(screen.queryByText(FIRST_RUN_COPY.connect.connectError)).not.toBeInTheDocument();
     expect(document.querySelector(".text-destructive")).not.toBeInTheDocument();
 
@@ -224,6 +225,15 @@ describe("FirstRunConnectScreen", () => {
     expect(screen.getByTestId("first-run-connect-loading")).toBeInTheDocument();
     expect(screen.queryByTestId("first-run-connect-github")).not.toBeInTheDocument();
     expect(screen.queryByTestId("first-run-github-account-picker")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(FIRST_RUN_COPY.connect.loadingAccounts);
+  });
+
+  it("shows progress and prevents another connect while GitHub opens", () => {
+    render(<FirstRunConnectScreen connecting onConnectGitHub={vi.fn()} />);
+
+    const connect = screen.getByTestId("first-run-connect-github");
+    expect(connect).toHaveTextContent(FIRST_RUN_COPY.connect.openingGitHub);
+    expect(connect).toBeDisabled();
   });
 
   it("never shows a connected state; the picker or the connect button always shows", () => {

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@/components/ui/button";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Clock } from "lucide-react";
@@ -23,7 +22,8 @@ function SignedInAsLine({ login }: { login: string }) {
   );
 }
 
-function FirstRunInstallRequested({ githubOrganization }: { githubOrganization: string }) {
+function FirstRunInstallRequested({ githubOrganizations }: { githubOrganizations: string[] }) {
+  const organization = githubOrganizations.length === 1 ? githubOrganizations[0] : "";
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -33,11 +33,14 @@ function FirstRunInstallRequested({ githubOrganization }: { githubOrganization: 
               <IntegrationChoiceIcon name="github" />
               <div className="min-w-0 flex-1 text-left">
                 <p className="text-[13px] font-medium">{copy.installRequested}</p>
-                {githubOrganization ? (
-                  <p className="mt-0.5 text-[13px] text-muted-foreground" data-testid="first-run-github-install-org">
-                    {githubOrganization}
-                  </p>
+                {githubOrganizations.length > 0 ? (
+                  <ul className="mt-0.5 text-[13px] text-muted-foreground" data-testid="first-run-github-install-org">
+                    {githubOrganizations.map((account) => (
+                      <li key={account}>{account}</li>
+                    ))}
+                  </ul>
                 ) : null}
+                <p className="mt-1 text-[12px] text-muted-foreground">{copy.installRequestedNext}</p>
               </div>
               <Clock className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" aria-hidden />
             </div>
@@ -48,7 +51,7 @@ function FirstRunInstallRequested({ githubOrganization }: { githubOrganization: 
         side="top"
         className="w-[var(--radix-tooltip-trigger-width)] max-w-md space-y-1 text-left text-pretty"
       >
-        <p>{copy.installRequestedBody(githubOrganization)}</p>
+        <p>{copy.installRequestedBody(organization)}</p>
         <p>{copy.installRequestedNext}</p>
       </TooltipContent>
     </Tooltip>
@@ -60,15 +63,19 @@ function FirstRunGitHubAccountPicker({
   githubAppSlug,
   githubState,
   bindingInstallationId,
+  disabled,
   onUseInstallation,
+  onInstallOther,
 }: {
   installations: PendingGitHubInstallation[];
   githubAppSlug: string;
   githubState: string;
   bindingInstallationId?: string;
+  disabled?: boolean;
   onUseInstallation: (installation: PendingGitHubInstallation) => void;
+  onInstallOther?: () => void;
 }) {
-  const binding = bindingInstallationId !== undefined;
+  const binding = bindingInstallationId !== undefined || disabled;
   return (
     <div className="space-y-3 text-left" data-testid="first-run-github-account-picker">
       <FirstRunPanel>
@@ -82,6 +89,7 @@ function FirstRunGitHubAccountPicker({
           className="w-full justify-start"
           data-testid={`first-run-github-use-${installation.accountLogin}`}
           loading={bindingInstallationId === installation.id}
+          loadingText={copy.connectingAccount(installation.accountLogin)}
           disabled={binding}
           onClick={() => onUseInstallation(installation)}
         >
@@ -93,11 +101,22 @@ function FirstRunGitHubAccountPicker({
           {copy.missingAccount}{" "}
           <a
             href={hostedGitHubInstallURL(githubAppSlug, githubState)}
-            className="font-medium text-foreground underline underline-offset-2 hover:no-underline"
             data-testid="first-run-github-install-other"
+            aria-disabled={binding || undefined}
+            tabIndex={binding ? -1 : undefined}
+            onClick={(event) => {
+              if (binding || onInstallOther) event.preventDefault();
+              if (!binding) onInstallOther?.();
+            }}
+            className={`font-medium text-foreground underline underline-offset-2 hover:no-underline ${binding ? "pointer-events-none opacity-50" : ""}`}
           >
             {copy.installThere}
           </a>
+        </p>
+      ) : null}
+      {disabled ? (
+        <p className="text-[13px] text-muted-foreground" role="status">
+          {copy.openingGitHub}
         </p>
       ) : null}
     </div>
@@ -106,21 +125,25 @@ function FirstRunGitHubAccountPicker({
 
 function connectScreenState({
   installRequested,
-  githubOrganization,
+  githubOrganizations,
   pendingInstallations,
   githubState,
 }: {
   installRequested: boolean;
-  githubOrganization: string;
+  githubOrganizations: string[];
   pendingInstallations: PendingGitHubInstallation[];
   githubState: string;
 }) {
   const showAccountPicker = pendingInstallations.length >= 1 && githubState !== "";
   // A picker that offers the requested organization means the request is
   // approved, so the waiting state must not show next to it.
-  const requestApproved = pendingInstallations.some(
-    (installation) => installation.accountLogin.toLowerCase() === githubOrganization.toLowerCase(),
-  );
+  const requestApproved =
+    githubOrganizations.length > 0 &&
+    githubOrganizations.every((organization) =>
+      pendingInstallations.some(
+        (installation) => installation.accountLogin.toLowerCase() === organization.toLowerCase(),
+      ),
+    );
   return {
     showAccountPicker,
     waitingForApproval: installRequested && !(showAccountPicker && requestApproved),
@@ -131,66 +154,95 @@ export function FirstRunConnectScreen({
   loading = false,
   installRequested = false,
   githubOrganization = "",
+  githubOrganizations,
   pendingInstallations = [],
   githubState = "",
   githubAppSlug = "",
   githubLogin = "",
   bindingInstallationId,
+  connecting = false,
   connectError,
   chrome,
   onConnectGitHub,
   onUseInstallation,
+  onInstallOther,
 }: {
   /** True while the picker data still loads after a GitHub round trip. */
   loading?: boolean;
   installRequested?: boolean;
   githubOrganization?: string;
+  githubOrganizations?: string[];
   pendingInstallations?: PendingGitHubInstallation[];
   githubState?: string;
   githubAppSlug?: string;
   /** GitHub login that authorized this connect. Shown only with the account picker. */
   githubLogin?: string;
   bindingInstallationId?: string;
+  connecting?: boolean;
   connectError?: string;
   chrome?: FirstRunChrome;
   onConnectGitHub: () => void;
   onUseInstallation?: (installation: PendingGitHubInstallation) => void;
+  onInstallOther?: () => void;
 }) {
+  const requestedOrganizations = requestedGitHubOrganizations(githubOrganizations, githubOrganization);
   const { showAccountPicker, waitingForApproval } = connectScreenState({
     installRequested,
-    githubOrganization,
+    githubOrganizations: requestedOrganizations,
     pendingInstallations,
     githubState,
   });
 
   return (
-    <FirstRunShell testId="first-run-connect" chrome={chrome}>
-      <FirstRunHeading headline={copy.headline}>
-        <p className="text-[15px] leading-6 text-muted-foreground">{copy.body}</p>
-        {showAccountPicker && githubLogin ? <SignedInAsLine login={githubLogin} /> : null}
-      </FirstRunHeading>
+    <FirstRunShell
+      testId="first-run-connect"
+      chrome={chrome}
+      busy={loading || connecting || bindingInstallationId !== undefined}
+    >
+      <ConnectScreenHeading showAccountPicker={showAccountPicker} githubLogin={githubLogin} />
 
       <div className="mt-8 space-y-6">
         {loading ? (
           <ConnectScreenLoading />
         ) : (
           <ConnectScreenBody
-            githubOrganization={githubOrganization}
+            githubOrganizations={requestedOrganizations}
             pendingInstallations={pendingInstallations}
             githubState={githubState}
             githubAppSlug={githubAppSlug}
             bindingInstallationId={bindingInstallationId}
+            connecting={connecting}
             showAccountPicker={showAccountPicker}
             waitingForApproval={waitingForApproval}
             onConnectGitHub={onConnectGitHub}
             onUseInstallation={onUseInstallation}
+            onInstallOther={onInstallOther}
           />
         )}
         <p className="text-[12px] text-muted-foreground">{copy.trust}</p>
-        {connectError && !waitingForApproval ? <p className="text-[13px] text-destructive">{connectError}</p> : null}
+        <ConnectScreenError error={connectError} waitingForApproval={waitingForApproval} />
       </div>
     </FirstRunShell>
   );
+}
+
+function requestedGitHubOrganizations(organizations: string[] | undefined, legacyOrganization: string): string[] {
+  if (organizations) return organizations;
+  return legacyOrganization ? [legacyOrganization] : [];
+}
+
+function ConnectScreenHeading({ showAccountPicker, githubLogin }: { showAccountPicker: boolean; githubLogin: string }) {
+  return (
+    <FirstRunHeading headline={copy.headline}>
+      <p className="text-[15px] leading-6 text-muted-foreground">{copy.body}</p>
+      {showAccountPicker && githubLogin ? <SignedInAsLine login={githubLogin} /> : null}
+    </FirstRunHeading>
+  );
+}
+
+function ConnectScreenError({ error, waitingForApproval }: { error?: string; waitingForApproval: boolean }) {
+  if (!error || waitingForApproval) return null;
+  return <p className="text-[13px] text-destructive">{error}</p>;
 }
 
 /**
@@ -199,44 +251,53 @@ export function FirstRunConnectScreen({
  */
 function ConnectScreenLoading() {
   return (
-    <div className="space-y-3" data-testid="first-run-connect-loading" aria-hidden>
-      <div className="h-14 animate-pulse rounded-md bg-accent/40" />
-      <div className="h-9 w-40 animate-pulse rounded-md bg-accent/40" />
+    <div className="space-y-3" data-testid="first-run-connect-loading" role="status">
+      <p className="text-[13px] text-muted-foreground">{copy.loadingAccounts}</p>
+      <div aria-hidden>
+        <div className="h-14 animate-pulse rounded-md bg-accent/40" />
+        <div className="mt-3 h-9 w-40 animate-pulse rounded-md bg-accent/40" />
+      </div>
     </div>
   );
 }
 
 function ConnectScreenBody({
-  githubOrganization,
+  githubOrganizations,
   pendingInstallations,
   githubState,
   githubAppSlug,
   bindingInstallationId,
+  connecting,
   showAccountPicker,
   waitingForApproval,
   onConnectGitHub,
   onUseInstallation,
+  onInstallOther,
 }: {
-  githubOrganization: string;
+  githubOrganizations: string[];
   pendingInstallations: PendingGitHubInstallation[];
   githubState: string;
   githubAppSlug: string;
   bindingInstallationId?: string;
+  connecting: boolean;
   showAccountPicker: boolean;
   waitingForApproval: boolean;
   onConnectGitHub: () => void;
   onUseInstallation?: (installation: PendingGitHubInstallation) => void;
+  onInstallOther?: () => void;
 }) {
   if (showAccountPicker && onUseInstallation) {
     return (
       <>
-        {waitingForApproval ? <FirstRunInstallRequested githubOrganization={githubOrganization} /> : null}
+        {waitingForApproval ? <FirstRunInstallRequested githubOrganizations={githubOrganizations} /> : null}
         <FirstRunGitHubAccountPicker
           installations={pendingInstallations}
           githubAppSlug={githubAppSlug}
           githubState={githubState}
           bindingInstallationId={bindingInstallationId}
+          disabled={connecting}
           onUseInstallation={onUseInstallation}
+          onInstallOther={onInstallOther}
         />
       </>
     );
@@ -244,10 +305,17 @@ function ConnectScreenBody({
 
   return (
     <>
-      {waitingForApproval ? <FirstRunInstallRequested githubOrganization={githubOrganization} /> : null}
-      <Button type="button" className="min-w-40" onClick={onConnectGitHub} data-testid="first-run-connect-github">
+      {waitingForApproval ? <FirstRunInstallRequested githubOrganizations={githubOrganizations} /> : null}
+      <LoadingButton
+        type="button"
+        className="min-w-40"
+        onClick={onConnectGitHub}
+        loading={connecting}
+        loadingText={copy.openingGitHub}
+        data-testid="first-run-connect-github"
+      >
         {copy.connectGitHub}
-      </Button>
+      </LoadingButton>
     </>
   );
 }

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunShell.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunShell.tsx
@@ -16,88 +16,113 @@ export function FirstRunShell({
   children,
   testId,
   chrome,
+  busy = false,
   width = "narrow",
 }: {
   children: ReactNode;
   testId: string;
   chrome?: FirstRunChrome;
+  busy?: boolean;
   width?: "narrow" | "wide";
 }) {
   useFactoriesThemeClass();
-  const copy = FIRST_RUN_COPY.chrome;
-  const identity = chrome?.email ?? chrome?.displayName;
-  const stepCount = chrome?.stepCount ?? FIRST_RUN_STEP_COUNT;
+  const controlsDisabled = busy || Boolean(chrome?.busy);
 
   return (
-    <div className="fixed inset-0 bg-background text-foreground" data-testid={testId}>
-      <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between px-6 py-5">
-        <div className="pointer-events-auto flex items-center gap-3">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="text-muted-foreground hover:text-foreground"
-            onClick={chrome?.onLogOut}
-            data-testid="first-run-log-out"
-          >
-            {copy.logOut}
-          </Button>
-          <FirstRunOrganizationSwitch organizationSwitch={chrome?.organizationSwitch} />
-        </div>
-        {identity ? (
-          <p className="text-right text-[13px] leading-5 text-muted-foreground" data-testid="first-run-signed-in">
-            <span className="block">{copy.loggedInAs}</span>
-            <span className="block text-foreground">{identity}</span>
-          </p>
-        ) : null}
-      </div>
+    <div
+      className="fixed inset-0 bg-background text-foreground"
+      data-testid={testId}
+      aria-busy={controlsDisabled || undefined}
+    >
+      <FirstRunTopBar chrome={chrome} disabled={controlsDisabled} />
 
       <div className="flex h-full items-center justify-center overflow-y-auto px-6 py-24">
         <div className={cn("w-full text-center", width === "wide" ? "max-w-xl" : "max-w-md")}>
           {children}
-          {chrome?.onBack ? (
-            <Button
-              type="button"
-              variant="ghost"
-              className="mt-4 text-muted-foreground hover:text-foreground"
-              onClick={chrome.onBack}
-              data-testid="first-run-back"
-            >
-              {copy.back}
-            </Button>
-          ) : null}
+          <FirstRunBack onBack={chrome?.onBack} disabled={controlsDisabled} />
         </div>
       </div>
 
-      <FirstRunWorkspaceSwitch switcher={chrome?.workspaceSwitch} />
+      <FirstRunWorkspaceSwitch switcher={chrome?.workspaceSwitch} disabled={controlsDisabled} />
+      <FirstRunProgress chrome={chrome} />
+    </div>
+  );
+}
 
-      {chrome ? (
-        <nav
-          className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center pb-6"
-          aria-label={copy.stepLabel(chrome.stepIndex + 1, stepCount)}
+function FirstRunTopBar({ chrome, disabled }: { chrome?: FirstRunChrome; disabled: boolean }) {
+  const identity = chrome?.email ?? chrome?.displayName;
+  return (
+    <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between px-6 py-5">
+      <div className="pointer-events-auto flex items-center gap-3">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:text-foreground"
+          onClick={chrome?.onLogOut}
+          disabled={disabled}
+          data-testid="first-run-log-out"
         >
-          <ol className="flex items-center gap-1.5">
-            {Array.from({ length: stepCount }, (_, index) => (
-              <li
-                key={index}
-                className={cn(
-                  "size-1.5 rounded-full",
-                  index === chrome.stepIndex ? "bg-foreground" : "bg-muted-foreground/30",
-                )}
-                aria-current={index === chrome.stepIndex ? "step" : undefined}
-              />
-            ))}
-          </ol>
-        </nav>
+          {FIRST_RUN_COPY.chrome.logOut}
+        </Button>
+        <FirstRunOrganizationSwitch organizationSwitch={chrome?.organizationSwitch} disabled={disabled} />
+      </div>
+      {identity ? (
+        <p className="text-right text-[13px] leading-5 text-muted-foreground" data-testid="first-run-signed-in">
+          <span className="block">{FIRST_RUN_COPY.chrome.loggedInAs}</span>
+          <span className="block text-foreground">{identity}</span>
+        </p>
       ) : null}
     </div>
   );
 }
 
+function FirstRunBack({ onBack, disabled }: { onBack?: () => void; disabled: boolean }) {
+  if (!onBack) return null;
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      className="mt-4 text-muted-foreground hover:text-foreground"
+      onClick={onBack}
+      disabled={disabled}
+      data-testid="first-run-back"
+    >
+      {FIRST_RUN_COPY.chrome.back}
+    </Button>
+  );
+}
+
+function FirstRunProgress({ chrome }: { chrome?: FirstRunChrome }) {
+  if (!chrome) return null;
+  const stepCount = chrome.stepCount ?? FIRST_RUN_STEP_COUNT;
+  return (
+    <nav
+      className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center pb-6"
+      aria-label={FIRST_RUN_COPY.chrome.stepLabel(chrome.stepIndex + 1, stepCount)}
+    >
+      <ol className="flex items-center gap-1.5">
+        {Array.from({ length: stepCount }, (_, index) => (
+          <li
+            key={index}
+            className={cn(
+              "size-1.5 rounded-full",
+              index === chrome.stepIndex ? "bg-foreground" : "bg-muted-foreground/30",
+            )}
+            aria-current={index === chrome.stepIndex ? "step" : undefined}
+          />
+        ))}
+      </ol>
+    </nav>
+  );
+}
+
 function FirstRunOrganizationSwitch({
   organizationSwitch,
+  disabled,
 }: {
   organizationSwitch: FirstRunChrome["organizationSwitch"];
+  disabled?: boolean;
 }) {
   if (!organizationSwitch) return null;
 
@@ -110,6 +135,7 @@ function FirstRunOrganizationSwitch({
           size="icon-xs"
           className="text-muted-foreground hover:text-foreground"
           aria-label={FIRST_RUN_COPY.chrome.switchOrganization}
+          disabled={disabled}
           data-testid="first-run-organization-switch"
         >
           <ArrowRightLeft className="size-4" aria-hidden />

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunTicketsScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunTicketsScreen.tsx
@@ -10,6 +10,7 @@ export function FirstRunTicketsScreen({
   chrome,
   continueLabel = FIRST_RUN_COPY.tickets.analyze,
   saving = false,
+  savingLabel = FIRST_RUN_COPY.finish.saving,
   onSelectTicketSource,
   onAnalyzeTickets,
 }: {
@@ -18,13 +19,14 @@ export function FirstRunTicketsScreen({
   continueLabel?: string;
   /** True while this screen provisions the workspace, on the last screen. */
   saving?: boolean;
+  savingLabel?: string;
   onSelectTicketSource: (source: FirstRunTicketSource) => void;
   onAnalyzeTickets: () => void;
 }) {
   const copy = FIRST_RUN_COPY.tickets;
 
   return (
-    <FirstRunShell testId="first-run-tickets" chrome={chrome}>
+    <FirstRunShell testId="first-run-tickets" chrome={chrome} busy={saving}>
       <FirstRunHeading headline={copy.headline} />
 
       <div className="mt-8 space-y-4">
@@ -35,6 +37,7 @@ export function FirstRunTicketsScreen({
               title={copy.githubIssues}
               detail={copy.githubIssuesHelper}
               selected={ticketSource === "github-issues"}
+              disabled={saving}
               onSelect={() => onSelectTicketSource("github-issues")}
             />
             <ConnectOptionRow
@@ -42,6 +45,7 @@ export function FirstRunTicketsScreen({
               title={copy.jira}
               detail={copy.jiraHelper}
               soon
+              disabled={saving}
               onSelect={() => undefined}
             />
             <ConnectOptionRow
@@ -49,6 +53,7 @@ export function FirstRunTicketsScreen({
               title={copy.linear}
               detail={copy.linearHelper}
               soon
+              disabled={saving}
               onSelect={() => undefined}
             />
           </div>
@@ -64,7 +69,7 @@ export function FirstRunTicketsScreen({
             className="w-full"
             disabled={!ticketSource}
             loading={saving}
-            loadingText={FIRST_RUN_COPY.finish.saving}
+            loadingText={savingLabel}
             onClick={onAnalyzeTickets}
             data-testid="first-run-analyze-tickets"
           >

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunWorkspaceSwitch.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunWorkspaceSwitch.tsx
@@ -15,14 +15,22 @@ function workspaceLabel(factory: FirstRunWorkspaceOption): string {
 
 export function FirstRunWorkspaceSwitch({
   switcher,
+  disabled,
 }: {
   switcher: NonNullable<FirstRunChrome["workspaceSwitch"]> | undefined;
+  disabled?: boolean;
 }) {
   if (!switcher) return null;
-  return <FirstRunWorkspaceSwitchMenu switcher={switcher} />;
+  return <FirstRunWorkspaceSwitchMenu switcher={switcher} disabled={disabled} />;
 }
 
-function FirstRunWorkspaceSwitchMenu({ switcher }: { switcher: NonNullable<FirstRunChrome["workspaceSwitch"]> }) {
+function FirstRunWorkspaceSwitchMenu({
+  switcher,
+  disabled,
+}: {
+  switcher: NonNullable<FirstRunChrome["workspaceSwitch"]>;
+  disabled?: boolean;
+}) {
   const navigate = useNavigate();
   const copy = FIRST_RUN_COPY.chrome;
   const [open, setOpen] = useState(false);
@@ -37,6 +45,7 @@ function FirstRunWorkspaceSwitchMenu({ switcher }: { switcher: NonNullable<First
             type="button"
             aria-label={`${copy.switchWorkspace}, ${currentName}`}
             title={currentName}
+            disabled={disabled}
             className={cn(
               factoriesRailControlClassName,
               "bg-muted text-[11px] font-medium tracking-[-0.01em] text-foreground hover:bg-accent",

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunCopy.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunCopy.ts
@@ -34,6 +34,9 @@ export const FIRST_RUN_COPY = {
     installRequested: GITHUB_INSTALL_REQUEST_TITLE,
     installRequestedBody: githubInstallRequestBody,
     installRequestedNext: GITHUB_INSTALL_REQUEST_NEXT,
+    openingGitHub: "Opening GitHub…",
+    loadingAccounts: "Loading GitHub accounts…",
+    connectingAccount: (account: string) => `Connecting ${account}…`,
   },
   choose: {
     headline: "Choose a repository",
@@ -45,6 +48,8 @@ export const FIRST_RUN_COPY = {
     accessHint: "You need admin access to the GitHub App or organization to change the repositories.",
     continue: "Choose a repository to continue",
     continueReady: "Continue",
+    saving: "Saving repository…",
+    loading: "Loading repositories…",
     moreLater: "You can add more repositories later.",
     missingTitle: "Why is my repository not shown?",
     missingReasons: [
@@ -66,15 +71,17 @@ export const FIRST_RUN_COPY = {
     linearHelper: "Find tickets in your Linear backlog.",
     analyze: "Analyze my tickets",
     continue: "Connect agent",
+    saving: "Saving ticket source…",
   },
   agent: {
     headline: "Connect agent",
+    loading: "Checking agent availability…",
   },
   // Shared by every screen that provisions the workspace. Hosted credentials
   // move that action from the agent screen to the ticket screen.
   finish: {
     action: "Finish setup",
-    saving: "Finishing setup...",
+    saving: "Finishing setup…",
   },
   analysis: {
     headline: "Analyzing your backlog",
@@ -87,6 +94,7 @@ export const FIRST_RUN_COPY = {
     overrun: "The analysis needs more time than usual. It is still running.",
     failure: "The analysis did not finish. Try again.",
     retry: "Run analysis again",
+    retrying: "Trying again…",
   },
   results: {
     headline: "Tickets SuperPlane can implement",

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunTypes.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunTypes.ts
@@ -8,6 +8,7 @@ export type FirstRunWorkspaceOption = {
 };
 
 export type FirstRunChrome = {
+  busy?: boolean;
   email?: string;
   displayName?: string;
   onLogOut?: () => void;

--- a/web_src/src/pages/factories/pages/onboarding/onboardingSteps.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingSteps.tsx
@@ -49,6 +49,7 @@ export function ConnectOptionRow({
   connectLabel,
   connected,
   soon,
+  disabled,
   onSelect,
   onConnect,
 }: {
@@ -61,14 +62,16 @@ export function ConnectOptionRow({
   connectLabel?: string;
   connected?: boolean;
   soon?: boolean;
+  disabled?: boolean;
   onSelect: () => void;
   onConnect?: () => void;
 }) {
-  const needsConnect = Boolean(connectLabel) && !connected && !soon;
+  const needsConnect = needsConnection(connectLabel, connected, soon);
   const rowToneClass = connectOptionRowTone(Boolean(soon), Boolean(selected));
+  const unavailable = Boolean(soon || disabled);
 
   const select = () => {
-    if (soon) return;
+    if (unavailable) return;
     onSelect();
     if (needsConnect) onConnect?.();
   };
@@ -76,16 +79,16 @@ export function ConnectOptionRow({
   return (
     <div
       className={cn("relative rounded-lg border px-4 py-3 transition-colors", rowToneClass)}
-      aria-disabled={soon || undefined}
+      aria-disabled={unavailable || undefined}
       data-soon={soon ? "true" : undefined}
     >
       {soon ? <ComingSoonRibbon /> : null}
       <div className="flex flex-wrap items-start gap-3">
         <button
           type="button"
-          className={cn("flex min-w-0 flex-1 items-start gap-3 text-left", soon && "cursor-not-allowed")}
+          className={cn("flex min-w-0 flex-1 items-start gap-3 text-left", unavailable && "cursor-not-allowed")}
           onClick={select}
-          disabled={soon}
+          disabled={unavailable}
         >
           <span className="mt-0.5 shrink-0">{icon}</span>
           <span className="min-w-0 flex-1">
@@ -110,6 +113,7 @@ export function ConnectOptionRow({
               <Button
                 type="button"
                 size="sm"
+                disabled={disabled}
                 onClick={() => {
                   onSelect();
                   onConnect?.();
@@ -123,6 +127,10 @@ export function ConnectOptionRow({
       </div>
     </div>
   );
+}
+
+function needsConnection(connectLabel?: string, connected?: boolean, soon?: boolean): boolean {
+  return Boolean(connectLabel) && !connected && !soon;
 }
 
 export function NameStep({ setup }: { setup: OnboardingSetupApi }) {
@@ -153,6 +161,7 @@ export function RepositoryPicker({
   onSelect,
   title,
   description,
+  disabled,
 }: {
   host: VcsHostId;
   repos: string[];
@@ -161,6 +170,7 @@ export function RepositoryPicker({
   /** Only for pickers that need their own heading, such as the backlog picker. */
   title?: string;
   description?: string;
+  disabled?: boolean;
 }) {
   const [query, setQuery] = useState("");
 
@@ -186,6 +196,7 @@ export function RepositoryPicker({
           placeholder="Search repositories"
           className="h-9 pl-9"
           aria-label="Search repositories"
+          disabled={disabled}
         />
       </div>
       <div
@@ -206,6 +217,7 @@ export function RepositoryPicker({
                     role="option"
                     aria-selected={selected}
                     onClick={() => onSelect(repo)}
+                    disabled={disabled}
                     className={cn(
                       "flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors",
                       selected ? "bg-accent/50" : "hover:bg-accent/30",

--- a/web_src/src/pages/factories/pages/onboarding/useFirstRunSetupFlow.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useFirstRunSetupFlow.ts
@@ -1,0 +1,365 @@
+import { useBindGitHubInstallation } from "@/hooks/useBindGitHubInstallation";
+import { useMe } from "@/hooks/useMe";
+import { useRecheckGitHubInstallRequest } from "@/hooks/useRecheckGitHubInstallRequest";
+import { getApiErrorMessage } from "@/lib/errors";
+import { hostedGitHubInstallURL, type PendingGitHubInstallation } from "@/lib/hostedGitHubInstall";
+import {
+  GITHUB_SETUP_INTEGRATION_PARAM,
+  GITHUB_SETUP_ORG_PARAM,
+  GITHUB_SETUP_REQUEST_PARAM,
+  GITHUB_SETUP_REQUEST_VALUE,
+} from "@/lib/integrationSetupReturn";
+import {
+  githubAccountPickerFromConnection,
+  pendingGitHubAccountPicker,
+  pendingGitHubRequestConnection,
+  type PendingGitHubAccountPicker,
+} from "@/lib/startDirectGitHubConnect";
+import { showErrorToast } from "@/lib/toast";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router";
+
+import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
+import type { FirstRunTicketSource } from "./first-run/firstRunTypes";
+import { type IntegrationId, type IssuesChoiceId, type WizardStepId } from "./onboardingFixtures";
+import { isWizardStepId } from "./onboardingStatus";
+import type { useOnboardingPageModel } from "./useOnboardingPageModel";
+
+export type OnboardingPageModel = ReturnType<typeof useOnboardingPageModel>;
+export type FirstRunScreen = "welcome" | "connect" | "choose" | "tickets" | "agent";
+type FirstRunBlockingAction =
+  | "opening-github"
+  | "binding-github"
+  | "saving-github-connection"
+  | "saving-repository"
+  | "saving-ticket-source"
+  | "finishing-setup";
+
+export const DEFAULT_TICKET_SOURCE: FirstRunTicketSource = "github-issues";
+const DEFAULT_ISSUES_CHOICE: IssuesChoiceId = "vcs";
+const SCREEN_FOR_STEP: Record<WizardStepId, FirstRunScreen> = {
+  vcs: "connect",
+  repo: "choose",
+  issues: "tickets",
+  agent: "agent",
+  name: "agent",
+};
+const STEP_FOR_SCREEN: Partial<Record<FirstRunScreen, WizardStepId>> = {
+  connect: "vcs",
+  choose: "repo",
+  tickets: "issues",
+  agent: "agent",
+};
+
+function initialFirstRunScreen(searchParams: URLSearchParams): FirstRunScreen {
+  const requestedStep = searchParams.get("step");
+  if (isWizardStepId(requestedStep)) return SCREEN_FOR_STEP[requestedStep];
+  return searchParams.get(GITHUB_SETUP_REQUEST_PARAM) === GITHUB_SETUP_REQUEST_VALUE ? "connect" : "welcome";
+}
+
+function startConnectOnPicker(searchParams: URLSearchParams): boolean {
+  const step = searchParams.get("step");
+  if (step === "vcs") return true;
+  return step === null && searchParams.get(GITHUB_SETUP_REQUEST_PARAM) === GITHUB_SETUP_REQUEST_VALUE;
+}
+
+function screenWithoutAgent(screen: FirstRunScreen, skipAgentScreen: boolean): FirstRunScreen {
+  return screen === "agent" && skipAgentScreen ? "tickets" : screen;
+}
+
+function useFirstRunBlockingAction() {
+  const lock = useRef(false);
+  const [action, setAction] = useState<FirstRunBlockingAction | null>(null);
+  const begin = useCallback((next: FirstRunBlockingAction): boolean => {
+    if (lock.current) return false;
+    lock.current = true;
+    setAction(next);
+    return true;
+  }, []);
+  const finish = useCallback(() => {
+    lock.current = false;
+    setAction(null);
+  }, []);
+  const run = useCallback(
+    async (next: FirstRunBlockingAction, operation: () => Promise<void>) => {
+      if (!begin(next)) return;
+      try {
+        await operation();
+      } finally {
+        finish();
+      }
+    },
+    [begin, finish],
+  );
+  return { action, busy: action !== null, begin, finish, setAction, run };
+}
+
+function useGitHubConnectionState(model: OnboardingPageModel, organizationId: string) {
+  const { data: me, isPending: meLoading } = useMe(true, organizationId);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const callbackIntegrationId = searchParams.get(GITHUB_SETUP_INTEGRATION_PARAM)?.trim() || undefined;
+  const resolved = resolveGitHubConnection(model, me?.id, callbackIntegrationId);
+  const requestConnection = resolved.requestConnection;
+  const callbackRequestPending = model.githubConnectionsLoading && hasRequestMarker(searchParams);
+
+  useEffect(() => {
+    if (model.githubConnectionsLoading || requestConnection || !hasRequestMarker(searchParams)) return;
+    const next = new URLSearchParams(searchParams);
+    next.delete(GITHUB_SETUP_REQUEST_PARAM);
+    next.delete(GITHUB_SETUP_ORG_PARAM);
+    next.delete(GITHUB_SETUP_INTEGRATION_PARAM);
+    setSearchParams(next, { replace: true });
+  }, [model.githubConnectionsLoading, requestConnection, searchParams, setSearchParams]);
+
+  return {
+    ...resolved,
+    callbackIntegrationId,
+    installRequested: Boolean(requestConnection) || callbackRequestPending,
+    githubOrganizations: requestedOrganizations(requestConnection, callbackRequestPending, searchParams),
+    sourcesLoading: meLoading || model.githubConnectionsLoading,
+    startOnPicker: startConnectOnPicker(searchParams),
+    initialScreen: initialFirstRunScreen(searchParams),
+  };
+}
+
+function resolveGitHubConnection(model: OnboardingPageModel, userId?: string, callbackIntegrationId?: string) {
+  const requestConnection = pendingGitHubRequestConnection(
+    model.githubConnections.allInstances,
+    userId,
+    callbackIntegrationId,
+  );
+  const preferredId = requestConnection?.id ?? callbackIntegrationId;
+  const preferredConnection = model.githubConnections.allInstances.find((item) => item.metadata?.id === preferredId);
+  const selectedConnection = model.githubConnections.readyInstances.find(
+    (item) => item.metadata?.id === model.selectedVcsConnectionId,
+  );
+  const accountPicker =
+    githubAccountPickerFromConnection(preferredConnection, userId) ??
+    pendingGitHubAccountPicker(model.githubConnections.allInstances, userId, requestConnection?.id) ??
+    githubAccountPickerFromConnection(selectedConnection, userId);
+  return { requestConnection, accountPicker };
+}
+
+function hasRequestMarker(searchParams: URLSearchParams): boolean {
+  return searchParams.get(GITHUB_SETUP_REQUEST_PARAM) === GITHUB_SETUP_REQUEST_VALUE;
+}
+
+function requestedOrganizations(
+  request: ReturnType<typeof pendingGitHubRequestConnection>,
+  callbackRequestPending: boolean,
+  searchParams: URLSearchParams,
+): string[] {
+  if (request) return request.requests.map((item) => item.accountLogin).filter(Boolean);
+  if (!callbackRequestPending) return [];
+  const account = searchParams.get(GITHUB_SETUP_ORG_PARAM)?.trim();
+  return account ? [account] : [];
+}
+
+function useFirstRunNavigation(
+  model: OnboardingPageModel,
+  skipAgentScreen: boolean,
+  connection: ReturnType<typeof useGitHubConnectionState>,
+) {
+  const [openedScreen, setOpenedScreen] = useState<FirstRunScreen>(connection.initialScreen);
+  const [pickerOpen, setPickerOpen] = useState(connection.startOnPicker);
+  const openStep = useRef(model.openSection);
+
+  useEffect(() => {
+    if (model.openSection === openStep.current) return;
+    openStep.current = model.openSection;
+    setOpenedScreen(SCREEN_FOR_STEP[model.openSection]);
+  }, [model.openSection]);
+
+  const goToScreen = (next: FirstRunScreen, connectStage: "button" | "picker" = "button") => {
+    if (next === "connect") setPickerOpen(connectStage === "picker" || Boolean(connection.requestConnection));
+    const step = STEP_FOR_SCREEN[next];
+    if (step) {
+      openStep.current = step;
+      model.setOpenSection(step);
+    }
+    setOpenedScreen(next);
+  };
+
+  return {
+    screen: screenWithoutAgent(openedScreen, skipAgentScreen),
+    pickerShowing: pickerOpen && Boolean(connection.accountPicker),
+    pickerLoading: pickerOpen && !connection.accountPicker && connection.sourcesLoading,
+    closePicker: () => setPickerOpen(false),
+    goToScreen,
+  };
+}
+
+function waitForBrowserPaint(): Promise<void> {
+  return new Promise((resolve) => window.requestAnimationFrame(() => resolve()));
+}
+
+function useFirstRunCommands(
+  model: OnboardingPageModel,
+  skipAgentScreen: boolean,
+  connection: ReturnType<typeof useGitHubConnectionState>,
+  navigation: ReturnType<typeof useFirstRunNavigation>,
+  blocking: ReturnType<typeof useFirstRunBlockingAction>,
+) {
+  const continueFromRepository = () =>
+    blocking.run("saving-repository", async () => {
+      const repository = model.setup.selectedRepo;
+      if (!repository) return;
+      model.setup.commitRepoStep();
+      if (await model.saveRepository(repository)) navigation.goToScreen("tickets");
+    });
+  const continueFromTickets = () =>
+    blocking.run("saving-ticket-source", async () => {
+      model.setup.setIssuesChoice(DEFAULT_ISSUES_CHOICE);
+      model.setup.commitIssuesStep();
+      if (!(await model.saveIssues(DEFAULT_ISSUES_CHOICE))) return;
+      if (!skipAgentScreen) return navigation.goToScreen("agent");
+      blocking.setAction("finishing-setup");
+      await model.finish(DEFAULT_ISSUES_CHOICE);
+    });
+  const connectGitHub = () =>
+    blocking.run("opening-github", async () => {
+      await waitForBrowserPaint();
+      await model.requestConnect("github", connection.requestConnection?.id ?? connection.callbackIntegrationId);
+    });
+  const finishSetup = () =>
+    blocking.run("finishing-setup", async () => {
+      await model.finish();
+    });
+  const installOnAnotherAccount = () => {
+    const state = connection.accountPicker?.state;
+    const slug = connection.accountPicker?.appSlug;
+    if (!state || !slug) return Promise.resolve();
+    return blocking.run("opening-github", async () => {
+      await waitForBrowserPaint();
+      window.location.assign(hostedGitHubInstallURL(slug, state));
+    });
+  };
+  const selectTicketSource = (source: FirstRunTicketSource) => {
+    if (source === DEFAULT_TICKET_SOURCE) model.setup.setIssuesChoice(DEFAULT_ISSUES_CHOICE);
+  };
+  return {
+    connectGitHub,
+    continueFromRepository,
+    continueFromTickets,
+    finishSetup,
+    installOnAnotherAccount,
+    selectTicketSource,
+  };
+}
+
+function useSelectBoundGithubConnection(
+  boundIntegrationId: string | null,
+  model: OnboardingPageModel,
+  onSelected: () => void,
+  onFinished: () => void,
+) {
+  const selecting = useRef<string | null>(null);
+  useEffect(() => {
+    if (!boundIntegrationId || selecting.current === boundIntegrationId) return;
+    if (!model.githubConnections.readyInstances.some((item) => item.metadata?.id === boundIntegrationId)) return;
+    selecting.current = boundIntegrationId;
+    void model
+      .selectVcsConnection(boundIntegrationId)
+      .then((saved) => {
+        if (saved) onSelected();
+      })
+      .finally(() => {
+        selecting.current = null;
+        onFinished();
+      });
+  }, [boundIntegrationId, model, onFinished, onSelected]);
+}
+
+function useGitHubInstallationBinding(
+  organizationId: string,
+  model: OnboardingPageModel,
+  accountPicker: PendingGitHubAccountPicker | undefined,
+  goToScreen: (screen: FirstRunScreen) => void,
+  blocking: ReturnType<typeof useFirstRunBlockingAction>,
+) {
+  const bindInstallation = useBindGitHubInstallation(organizationId);
+  const [boundIntegrationId, setBoundIntegrationId] = useState<string | null>(null);
+  const [bindingInstallationId, setBindingInstallationId] = useState<string>();
+  const finish = () => {
+    setBoundIntegrationId(null);
+    setBindingInstallationId(undefined);
+    blocking.finish();
+  };
+  useSelectBoundGithubConnection(
+    boundIntegrationId,
+    model,
+    () => {
+      blocking.setAction("saving-github-connection");
+      goToScreen("choose");
+    },
+    finish,
+  );
+
+  const useInstallation = async (installation: PendingGitHubInstallation) => {
+    if (!accountPicker?.state || !blocking.begin("binding-github")) return;
+    setBindingInstallationId(installation.id);
+    try {
+      await bindInstallation.mutateAsync({ state: accountPicker.state, installationId: installation.id });
+      if (accountPicker.id) return setBoundIntegrationId(accountPicker.id);
+      goToScreen("choose");
+      finish();
+    } catch (error) {
+      showErrorToast(getApiErrorMessage(error, "Failed to connect the GitHub account"));
+      finish();
+    }
+  };
+  return { bindingInstallationId, useInstallation };
+}
+
+function useRepositoryErrorToast(error: unknown) {
+  const reported = useRef<unknown>(null);
+  useEffect(() => {
+    if (!error || reported.current === error) return;
+    reported.current = error;
+    showErrorToast(getApiErrorMessage(error, "Failed to load repositories"));
+  }, [error]);
+}
+
+export function useFreshConnectionsOnConnectScreen(screen: FirstRunScreen, refresh: () => Promise<unknown>) {
+  useEffect(() => {
+    if (screen === "connect") void refresh();
+  }, [screen, refresh]);
+}
+
+export function useFirstRunSetupFlow(model: OnboardingPageModel) {
+  const { organizationId } = useFactoriesLayout();
+  const skipAgentScreen = model.hostedAgentReady;
+  const blocking = useFirstRunBlockingAction();
+  const connection = useGitHubConnectionState(model, organizationId);
+  const navigation = useFirstRunNavigation(model, skipAgentScreen, connection);
+  const commands = useFirstRunCommands(model, skipAgentScreen, connection, navigation, blocking);
+  const binding = useGitHubInstallationBinding(
+    organizationId,
+    model,
+    connection.accountPicker,
+    navigation.goToScreen,
+    blocking,
+  );
+  useRepositoryErrorToast(model.repositoriesError);
+  useRecheckGitHubInstallRequest(
+    organizationId,
+    connection.requestConnection?.id,
+    navigation.screen === "connect" && connection.installRequested,
+  );
+
+  return {
+    ...navigation,
+    ...commands,
+    ...binding,
+    skipAgentScreen,
+    installRequested: connection.installRequested,
+    githubOrganizations: connection.githubOrganizations,
+    requestIntegrationId: connection.requestConnection?.id ?? connection.callbackIntegrationId,
+    accountPicker: connection.accountPicker,
+    blockingAction: blocking.action,
+    busy: blocking.busy || model.saving,
+  };
+}
+
+export type FirstRunSetupFlow = ReturnType<typeof useFirstRunSetupFlow>;
+export type { IntegrationId };

--- a/web_src/src/pages/factories/pages/onboarding/useGithubAppAvailability.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useGithubAppAvailability.ts
@@ -25,7 +25,7 @@ export function githubAppAvailabilityFromCatalog(args: {
 }
 
 export function useGithubAppAvailability(organizationId: string): GithubAppAvailability & {
-  retry: () => void;
+  retry: () => Promise<void>;
 } {
   const definitions = useAvailableIntegrations({ enabled: !!organizationId, organizationId });
   const githubDefinition = (definitions.data ?? []).find((definition) => definition.name === "github");
@@ -35,8 +35,8 @@ export function useGithubAppAvailability(organizationId: string): GithubAppAvail
       isError: definitions.isError,
       githubDefinition,
     }),
-    retry: () => {
-      void definitions.refetch();
+    retry: async () => {
+      await definitions.refetch();
     },
   };
 }

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -208,6 +208,21 @@ function useOnboardingGithubRepos(organizationId: string, githubIntegrationId: s
   };
 }
 
+/**
+ * After an organization rename, the connection list reloads under the new
+ * slug before the repository request can start. Keep one loader visible
+ * through both requests.
+ */
+function isRepositoryListLoading(args: {
+  savedIntegrationId?: string;
+  selectedIntegrationId: string;
+  connectionsLoading: boolean;
+  repositoriesLoading: boolean;
+}): boolean {
+  if (!args.savedIntegrationId && !args.selectedIntegrationId) return false;
+  return args.connectionsLoading || args.repositoriesLoading;
+}
+
 function useOnboardingGithubConnectionSelected(args: {
   organizationId: string;
   factoryId: string;
@@ -468,6 +483,7 @@ export function useOnboardingPageModel(args: {
     // True when hosted credentials cover the agent, so setup can skip the
     // agent screen and provision from the ticket screen.
     hostedAgentReady: isHostedAgentReady(agent.plan),
+    agentLoading: agent.hostedModelsLoading,
     openSection,
     setOpenSection,
     requestConnect: connect.requestConnect,
@@ -496,7 +512,12 @@ export function useOnboardingPageModel(args: {
     },
     integrationDialogs: connect.dialogs,
     repositories: github.repositories,
-    repositoriesLoading: github.repositoriesLoading,
+    repositoriesLoading: isRepositoryListLoading({
+      savedIntegrationId: onboarding?.vcsIntegrationId,
+      selectedIntegrationId: githubIntegrationId,
+      connectionsLoading: connect.connectionsLoading,
+      repositoriesLoading: github.repositoriesLoading,
+    }),
     repositoriesError: github.repositoriesError,
     canConfigureWorkspace: canConfigureWorkspace(canAct),
     saving: saving || installer.isInstalling || createIntake.isPending || createPRFeedbackHandler.isPending,

--- a/web_src/src/pages/home/useIntegrationConnectDialog.tsx
+++ b/web_src/src/pages/home/useIntegrationConnectDialog.tsx
@@ -155,12 +155,12 @@ export function useIntegrationConnectDialog({
     createIntegration: createIntegrationMutation.mutateAsync,
   });
 
-  const requestConnect = (integrationName: string) => {
+  const requestConnect = async (integrationName: string, preferredIntegrationId?: string): Promise<boolean> => {
     if (integrationName === "github" && githubConnect.hosted) {
-      void connectGitHubWithoutDialog();
-      return;
+      return connectGitHubWithoutDialog(false, preferredIntegrationId);
     }
     openConnectDialog(integrationName);
+    return false;
   };
 
   const requestPrivateGitHubConnect = useCallback(() => {
@@ -294,30 +294,31 @@ function useHostedGitHubConnect({
   }) => Promise<{ data: OrganizationsCreateIntegrationResponse }>;
 }) {
   const navigate = useNavigate();
-  const pendingGitHubConnectRef = useRef<false | { forceNew: boolean }>(false);
+  const pendingGitHubConnectRef = useRef<false | { forceNew: boolean; preferredIntegrationId?: string }>(false);
 
   const connectGitHubWithoutDialog = useCallback(
-    async (forceNew = false) => {
+    async (forceNew = false, preferredIntegrationId?: string): Promise<boolean> => {
       const userGate = hostedGitHubConnectUserGate(currentUserId, currentUserResolved);
       if (userGate !== "run") {
         if (userGate === "queue") {
-          pendingGitHubConnectRef.current = { forceNew };
+          pendingGitHubConnectRef.current = { forceNew, preferredIntegrationId };
         } else {
           pendingGitHubConnectRef.current = false;
           showErrorToast("Failed to connect GitHub");
         }
-        return;
+        return false;
       }
 
       pendingGitHubConnectRef.current = false;
       try {
-        await startDirectGitHubConnect({
+        return await startDirectGitHubConnect({
           organizationId,
           returnTo,
           existingNames: existingIntegrationNames,
           connected,
           currentUserId,
           forceNew,
+          preferredIntegrationId,
           goTo: navigate,
           create: async (payload) => {
             const response = await createIntegration(payload);
@@ -327,6 +328,7 @@ function useHostedGitHubConnect({
         });
       } catch (error) {
         showErrorToast(getApiErrorMessage(error, "Failed to connect GitHub"));
+        return false;
       }
     },
     [
@@ -349,9 +351,9 @@ function useHostedGitHubConnect({
       return;
     }
 
-    const { forceNew } = pendingGitHubConnectRef.current;
+    const { forceNew, preferredIntegrationId } = pendingGitHubConnectRef.current;
     pendingGitHubConnectRef.current = false;
-    void connectGitHubWithoutDialog(forceNew);
+    void connectGitHubWithoutDialog(forceNew, preferredIntegrationId);
   }, [connectGitHubWithoutDialog, currentUserId, currentUserResolved]);
 
   return connectGitHubWithoutDialog;


### PR DESCRIPTION
## Summary\n\n- Track GitHub installation requests for the correct connection and user.\n- Update onboarding after an organization approves the GitHub App.\n- Keep onboarding screens mounted during loading and prevent duplicate actions.\n- Repair GitHub OAuth state after an installation is revoked.\n\n## Test plan\n\n- [x] Run the targeted GitHub installation-request E2E test.\n- [x] Run GitHub integration package tests.\n- [x] Run targeted GitHub connection tests.\n- [x] Run Go formatting, lint, and build checks.\n- [x] Run frontend formatting, lint, and build checks.\n- [x] Check generated artifacts.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61880725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/superplane/-/pull-requests/superplanehq/superplane/7290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a></h2>

The PR is not yet safe to merge because account-less GitHub installation requests can still be permanently removed before GitHub exposes them.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Account\-less requests remain discarded** <a href="https://github.com/superplanehq/superplane/pull/7290#discussion_r3963612452">▶</a>

<!-- /greptile_comment -->