### PR TITLE
fix: Stop Waiting-for-Checks Runs on Cancel

### DIFF
--- a/pkg/components/runner/compute_usage_test.go
+++ b/pkg/components/runner/compute_usage_test.go
@@ -15,7 +15,8 @@ type kvState struct {
 	kv map[string]string
 }
 
-func (s *kvState) IsFinished() bool { return false }
+func (s *kvState) IsFinished() bool   { return false }
+func (s *kvState) IsCancelling() bool { return false }
 func (s *kvState) SetKV(key, value string) error {
 	if s.kv == nil {
 		s.kv = map[string]string{}

--- a/pkg/components/ssh/ssh_test.go
+++ b/pkg/components/ssh/ssh_test.go
@@ -941,6 +941,7 @@ func TestSSHCommand_HandleHook_FileModeRetryReportsMissingFile(t *testing.T) {
 type fakeExecutionState struct{ finished bool }
 
 func (f *fakeExecutionState) IsFinished() bool                                       { return f.finished }
+func (f *fakeExecutionState) IsCancelling() bool                                     { return false }
 func (f *fakeExecutionState) SetKV(key, value string) error                          { return nil }
 func (f *fakeExecutionState) GetKV(key string) (string, error)                       { return "", nil }
 func (f *fakeExecutionState) Emit(channel, payloadType string, payloads []any) error { return nil }

--- a/pkg/core/component.go
+++ b/pkg/core/component.go
@@ -112,6 +112,7 @@ type CanvasMemoryRecord struct {
  */
 type ExecutionStateContext interface {
 	IsFinished() bool
+	IsCancelling() bool
 	SetKV(key, value string) error
 	GetKV(key string) (string, error)
 

--- a/pkg/grpc/actions/canvases/cancel_run_test.go
+++ b/pkg/grpc/actions/canvases/cancel_run_test.go
@@ -99,6 +99,53 @@ func Test__CancelRun__RequestsCancellationAndDrainsWork(t *testing.T) {
 	assert.Zero(t, queueItemCount)
 }
 
+func Test__CancelRun__DrainsWaitForPullRequestChecks(t *testing.T) {
+	r := support.Setup(t)
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "wait-pr-checks",
+				Name:   "Wait For Pull Request Checks",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "github.waitForPullRequestChecks"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "wait-pr-checks", "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), rootEvent)
+	require.NoError(t, err)
+	require.NoError(t, rootEvent.Routed())
+
+	execution := support.CreateCanvasNodeExecution(t, canvas.ID, "wait-pr-checks", rootEvent.ID, rootEvent.ID)
+	execution.RunID = run.ID
+	execution.State = models.CanvasNodeExecutionStateStarted
+	require.NoError(t, database.Conn().Save(execution).Error)
+
+	runAt := time.Now().Add(time.Minute)
+	require.NoError(t, execution.CreateRequest(database.Conn(), models.NodeRequestTypeInvokeAction, models.NodeExecutionRequestSpec{
+		InvokeAction: &models.InvokeAction{ActionName: "evaluate", Parameters: map[string]any{}},
+	}, &runAt))
+
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+
+	response, err := CancelRun(ctx, database.DB(t.Context()), canvas, run.ID)
+	require.NoError(t, err)
+	require.NotNil(t, response.Run)
+	assert.Equal(t, pb.CanvasRun_STATE_CANCELLING, response.Run.State)
+
+	updatedExecution, err := models.FindNodeExecution(canvas.ID, execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateCancelling, updatedExecution.State)
+}
+
 func Test__CancelRun__IsIdempotentForCancellingRun(t *testing.T) {
 	r := support.Setup(t)
 

--- a/pkg/integrations/github/components/checks/wait_for_pull_request_checks.go
+++ b/pkg/integrations/github/components/checks/wait_for_pull_request_checks.go
@@ -238,11 +238,15 @@ func (c *WaitForPullRequestChecks) Hooks() []core.Hook {
 	}
 }
 
+func waitChecksStopped(state core.ExecutionStateContext) bool {
+	return state.IsFinished() || state.IsCancelling()
+}
+
 func (c *WaitForPullRequestChecks) HandleHook(ctx core.ActionHookContext) error {
 	if ctx.Name != waitChecksEvaluateHook {
 		return fmt.Errorf("unknown action: %s", ctx.Name)
 	}
-	if ctx.ExecutionState.IsFinished() {
+	if waitChecksStopped(ctx.ExecutionState) {
 		return nil
 	}
 
@@ -301,7 +305,7 @@ func (c *WaitForPullRequestChecks) HandleWebhook(ctx core.WebhookRequestContext)
 	if err != nil {
 		return http.StatusOK, nil, nil
 	}
-	if executionCtx.ExecutionState.IsFinished() {
+	if waitChecksStopped(executionCtx.ExecutionState) {
 		return http.StatusOK, nil, nil
 	}
 
@@ -330,7 +334,7 @@ type waitChecksRuntime struct {
 }
 
 func evaluateWaitForPullRequestChecks(ctx waitChecksRuntime, now time.Time) error {
-	if ctx.ExecutionState.IsFinished() {
+	if waitChecksStopped(ctx.ExecutionState) {
 		return nil
 	}
 

--- a/pkg/integrations/github/components/checks/wait_for_pull_request_checks_test.go
+++ b/pkg/integrations/github/components/checks/wait_for_pull_request_checks_test.go
@@ -268,6 +268,33 @@ func Test__WaitForPullRequestChecks__HandleWebhook(t *testing.T) {
 		assert.Empty(t, httpCtx.Requests)
 	})
 
+	t.Run("does not schedule evaluate when the execution is cancelling", func(t *testing.T) {
+		requests := &contexts.RequestContext{}
+		executionState := &contexts.ExecutionStateContext{Cancelling: true}
+		headers := http.Header{}
+		headers.Set("X-GitHub-Event", "check_run")
+
+		code, _, err := component.HandleWebhook(signedWaitChecksRequest(
+			[]byte(fmt.Sprintf(`{
+				"repository": {"name": "hello", "full_name": "testhq/hello"},
+				"check_run": {"head_sha": %q, "name": "build"}
+			}`, sha)),
+			headers,
+			WaitForPullRequestChecksConfiguration{Repository: "hello", Ref: sha},
+			func(key, value string) (*core.ExecutionContext, error) {
+				return &core.ExecutionContext{
+					Requests:       requests,
+					ExecutionState: executionState,
+				}, nil
+			},
+			httpCtx,
+		))
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Empty(t, requests.Action)
+	})
+
 	t.Run("rejects an invalid signature", func(t *testing.T) {
 		headers := http.Header{}
 		headers.Set("X-GitHub-Event", "status")
@@ -307,6 +334,27 @@ func Test__WaitForPullRequestChecks__HandleHook(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Empty(t, httpCtx.requests)
+	})
+
+	t.Run("skips work when the execution is cancelling", func(t *testing.T) {
+		httpCtx := newSnapshotHTTP(passingCheckRunsBody(sha), passingStatusesBody(sha))
+		executionState := &contexts.ExecutionStateContext{Cancelling: true}
+		requests := &contexts.RequestContext{}
+
+		err := component.HandleHook(core.ActionHookContext{
+			Name:           waitChecksEvaluateHook,
+			Configuration:  WaitForPullRequestChecksConfiguration{Repository: "hello", Ref: sha},
+			HTTP:           httpCtx,
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: executionState,
+			Metadata:       &contexts.MetadataContext{},
+			Requests:       requests,
+			Logger:         logrus.NewEntry(logrus.New()),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, httpCtx.requests)
+		assert.Empty(t, requests.Action)
+		assert.Empty(t, executionState.Channel)
 	})
 
 	t.Run("emits passed after a later evaluate", func(t *testing.T) {

--- a/pkg/workers/contexts/execution_state_context.go
+++ b/pkg/workers/contexts/execution_state_context.go
@@ -36,6 +36,10 @@ func (s *ExecutionStateContext) IsFinished() bool {
 	return s.execution.State == models.CanvasNodeExecutionStateFinished
 }
 
+func (s *ExecutionStateContext) IsCancelling() bool {
+	return s.execution.State == models.CanvasNodeExecutionStateCancelling
+}
+
 func (s *ExecutionStateContext) Pass() error {
 	newEvents, err := s.execution.PassInTransaction(s.tx, map[string][]any{})
 	if err != nil {

--- a/pkg/workers/execution_terminator_test.go
+++ b/pkg/workers/execution_terminator_test.go
@@ -2,6 +2,7 @@ package workers
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -103,4 +104,48 @@ func Test__ExecutionTerminator__InvokesComponentCancel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, models.CanvasNodeExecutionStateFinished, updatedExecution.State)
 	assert.Equal(t, models.CanvasNodeExecutionResultCancelled, updatedExecution.Result)
+}
+
+func Test__ExecutionTerminator__CancelsWaitForPullRequestChecks(t *testing.T) {
+	r := support.Setup(t)
+
+	terminator := NewExecutionTerminator("", r.AuthService, r.Encryptor, r.Registry)
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "wait-pr-checks",
+				Name:   "Wait For Pull Request Checks",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "github.waitForPullRequestChecks"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "wait-pr-checks", "default", nil)
+	execution := support.CreateCanvasNodeExecution(t, canvas.ID, "wait-pr-checks", rootEvent.ID, rootEvent.ID)
+	require.NoError(t, database.Conn().Model(execution).Update("state", models.CanvasNodeExecutionStateStarted).Error)
+
+	runAt := time.Now().Add(time.Minute)
+	require.NoError(t, execution.CreateRequest(database.Conn(), models.NodeRequestTypeInvokeAction, models.NodeExecutionRequestSpec{
+		InvokeAction: &models.InvokeAction{ActionName: "evaluate", Parameters: map[string]any{}},
+	}, &runAt))
+
+	require.NoError(t, execution.RequestCancellation(database.DB(t.Context()), &r.User))
+	require.NoError(t, terminator.LockAndCancelExecution(*execution))
+
+	updatedExecution, err := models.FindNodeExecution(canvas.ID, execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, updatedExecution.State)
+	assert.Equal(t, models.CanvasNodeExecutionResultCancelled, updatedExecution.Result)
+
+	pending, err := models.CountPendingRequestsForExecutionsInTransaction(database.Conn(), []uuid.UUID{execution.ID})
+	require.NoError(t, err)
+	assert.Zero(t, pending)
 }

--- a/test/support/contexts/contexts.go
+++ b/test/support/contexts/contexts.go
@@ -256,6 +256,7 @@ func (s *SubscriptionContext) SendMessage(message any) error {
 
 type ExecutionStateContext struct {
 	Finished       bool
+	Cancelling     bool
 	Passed         bool
 	FailureReason  string
 	FailureMessage string
@@ -267,6 +268,10 @@ type ExecutionStateContext struct {
 
 func (c *ExecutionStateContext) IsFinished() bool {
 	return c.Finished
+}
+
+func (c *ExecutionStateContext) IsCancelling() bool {
+	return c.Cancelling
 }
 
 func (c *ExecutionStateContext) Pass() error {

--- a/web_src/src/pages/factories/lib/workOrderPullRequest.ts
+++ b/web_src/src/pages/factories/lib/workOrderPullRequest.ts
@@ -78,12 +78,15 @@ export function isActiveCanvasRun(run: CanvasesCanvasRunRef | undefined): boolea
   if (!run?.id) {
     return false;
   }
-  return run.state === "STATE_PENDING" || run.state === "STATE_STARTED" || run.state === "STATE_CANCELLING";
+  return run.state === "STATE_PENDING" || run.state === "STATE_STARTED";
 }
 
 export function statusForCanvasRun(run: CanvasesCanvasRunRef | undefined): "passed" | "running" | "pending" | "failed" {
-  if (run?.state === "STATE_STARTED" || run?.state === "STATE_CANCELLING") {
+  if (run?.state === "STATE_STARTED") {
     return "running";
+  }
+  if (run?.state === "STATE_CANCELLING") {
+    return "failed";
   }
   if (run?.state === "STATE_FINISHED") {
     if (run.result === "RESULT_PASSED") {

--- a/web_src/src/pages/factories/pages/prFeedbackSettingsModel.spec.ts
+++ b/web_src/src/pages/factories/pages/prFeedbackSettingsModel.spec.ts
@@ -86,6 +86,35 @@ describe("activePRFeedbackWorkOrderIds", () => {
     ).toEqual(new Set(["wo-1", "wo-3"]));
   });
 
+  it("does not treat a cancelling or cancelled check wait as waiting", () => {
+    expect(
+      waitingOnChecksWorkOrderIds([
+        {
+          workOrderId: "wo-cancelling",
+          activities: [
+            {
+              access: "concurrent",
+              state: "active",
+              description: "Waiting for checks on a82fd91",
+              run: run({ id: "r-cancelling", state: "STATE_CANCELLING" }),
+            },
+          ],
+        },
+        {
+          workOrderId: "wo-cancelled",
+          activities: [
+            {
+              access: "concurrent",
+              state: "active",
+              description: "Waiting for checks on a82fd91",
+              run: run({ id: "r-cancelled", state: "STATE_FINISHED", result: "RESULT_CANCELLED" }),
+            },
+          ],
+        },
+      ]),
+    ).toEqual(new Set());
+  });
+
   it("does not treat a concurrent check wait as addressing feedback", () => {
     const pullRequests: FactoriesFactoryPullRequest[] = [
       {

--- a/web_src/src/pages/factories/pages/useWorkOrderPRFeedbackRunHref.spec.ts
+++ b/web_src/src/pages/factories/pages/useWorkOrderPRFeedbackRunHref.spec.ts
@@ -140,6 +140,7 @@ describe("statusForCanvasRun", () => {
   it("maps generic run state onto log phase status", () => {
     expect(statusForCanvasRun(run({ state: "STATE_PENDING" }))).toBe("pending");
     expect(statusForCanvasRun(run({ state: "STATE_STARTED" }))).toBe("running");
+    expect(statusForCanvasRun(run({ state: "STATE_CANCELLING" }))).toBe("failed");
     expect(statusForCanvasRun(run({ state: "STATE_FINISHED", result: "RESULT_PASSED" }))).toBe("passed");
     expect(statusForCanvasRun(run({ state: "STATE_FINISHED", result: "RESULT_FAILED" }))).toBe("failed");
     expect(statusForCanvasRun(run({ state: "STATE_FINISHED", result: "RESULT_CANCELLED" }))).toBe("failed");
@@ -147,11 +148,12 @@ describe("statusForCanvasRun", () => {
 });
 
 describe("isActiveCanvasRun", () => {
-  it("treats pending, started, and cancelling as active", () => {
+  it("treats pending and started as active", () => {
     expect(isActiveCanvasRun(run({ id: "1", state: "STATE_PENDING" }))).toBe(true);
     expect(isActiveCanvasRun(run({ id: "2", state: "STATE_STARTED" }))).toBe(true);
-    expect(isActiveCanvasRun(run({ id: "3", state: "STATE_CANCELLING" }))).toBe(true);
+    expect(isActiveCanvasRun(run({ id: "3", state: "STATE_CANCELLING" }))).toBe(false);
     expect(isActiveCanvasRun(run({ id: "4", state: "STATE_FINISHED", result: "RESULT_PASSED" }))).toBe(false);
     expect(isActiveCanvasRun(run({ id: "5", state: "STATE_FINISHED", result: "RESULT_FAILED" }))).toBe(false);
+    expect(isActiveCanvasRun(run({ id: "6", state: "STATE_FINISHED", result: "RESULT_CANCELLED" }))).toBe(false);
   });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunFooterActions.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunFooterActions.spec.tsx
@@ -160,6 +160,9 @@ describe("useSplitRunFooterActions", () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: ["factories", "org-1", "factory-1", "work-orders", "wo-1"],
     });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["factories", "org-1", "factory-1", "pull-requests"],
+    });
   });
 
   it("cancels the canvas run before closing a running order", async () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunFooterActions.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunFooterActions.ts
@@ -1,10 +1,6 @@
 import { canvasesCancelRun } from "@/api-client";
-import {
-  factoryQueryKeys,
-  useCloseWorkOrder,
-  useDispatchWorkOrder,
-  useUpdateWorkOrderStatus,
-} from "@/hooks/useFactoryData";
+import { useCloseWorkOrder, useDispatchWorkOrder, useUpdateWorkOrderStatus } from "@/hooks/useFactoryData";
+import { invalidateFactoryWorkOrderQueries } from "@/hooks/useFactoryWebsocket";
 import { getApiErrorMessage } from "@/lib/errors";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
@@ -72,12 +68,7 @@ function useSplitRunCancelRun(organizationId?: string, factoryId?: string, order
       if (!organizationId || !factoryId) {
         return;
       }
-      await queryClient.invalidateQueries({ queryKey: factoryQueryKeys.workOrders(organizationId, factoryId) });
-      if (orderId) {
-        await queryClient.invalidateQueries({
-          queryKey: factoryQueryKeys.workOrderDetail(organizationId, factoryId, orderId),
-        });
-      }
+      invalidateFactoryWorkOrderQueries(queryClient, organizationId, factoryId, orderId);
     },
   });
 }


### PR DESCRIPTION
## Summary

Stop already cancelled the canvas run. The factory card stayed in Waiting for checks.

Cancelling still counted as an active run. Stop also did not refresh pull-request activity.

This change treats a cancelling run as stopped. It refreshes pull-request data after Stop. The wait component ignores evaluate work after cancel.

## Test plan

- [ ] Open a work order that is waiting for pull request checks.
- [ ] Click Stop on the waiting-for-checks phase.
- [ ] Confirm the toast shows Automation stopped.
- [ ] Confirm the phase leaves the running waiting state.
- [ ] Confirm a later GitHub synchronize event can start a new wait run.


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61888045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/superplane/-/pull-requests/superplanehq/superplane/7291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge.

<!-- /greptile_comment -->