### PR TITLE
fix: Bound worker poll queries with SQL LIMIT

### DIFF
--- a/pkg/models/app_message.go
+++ b/pkg/models/app_message.go
@@ -39,15 +39,20 @@ func CreateAppMessage(tx *gorm.DB, canvasID uuid.UUID, nodeID string, payload an
 	return tx.Create(message).Error
 }
 
-func ListAppMessages(tx *gorm.DB) ([]AppMessage, error) {
+func ListAppMessages(tx *gorm.DB, limit int) ([]AppMessage, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var messages []AppMessage
 
 	query := tx.
 		Table("app_messages").
-		Select("app_messages.*")
+		Select("app_messages.*").
+		Order("app_messages.created_at ASC").
+		Limit(limit)
 
 	err := withActiveCanvas(query, "app_messages.canvas_id").
-		Order("app_messages.created_at ASC").
 		Find(&messages).
 		Error
 	if err != nil {

--- a/pkg/models/canvas.go
+++ b/pkg/models/canvas.go
@@ -362,7 +362,11 @@ func ListOrganizationCanvases(tx *gorm.DB, organizationID uuid.UUID) ([]Canvas, 
 	return canvases, nil
 }
 
-func ListDeletedCanvases(db *gorm.DB) ([]Canvas, error) {
+func ListDeletedCanvases(db *gorm.DB, limit int) ([]Canvas, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var canvases []Canvas
 	err := db.
 		Model(&Canvas{}).
@@ -381,6 +385,8 @@ func ListDeletedCanvases(db *gorm.DB) ([]Canvas, error) {
 			"COALESCE(workflows.deleted_at, organizations.deleted_at) AS deleted_at",
 		).
 		Where("workflows.deleted_at IS NOT NULL OR organizations.deleted_at IS NOT NULL").
+		Order("COALESCE(workflows.deleted_at, organizations.deleted_at) ASC").
+		Limit(limit).
 		Find(&canvases).
 		Error
 

--- a/pkg/models/canvas_event.go
+++ b/pkg/models/canvas_event.go
@@ -208,12 +208,18 @@ func CountCanvasEvents(db *gorm.DB, canvasID uuid.UUID, nodeID string) (int64, e
 	return count, nil
 }
 
-func ListPendingCanvasEvents() ([]CanvasEvent, error) {
+func ListPendingCanvasEvents(limit int) ([]CanvasEvent, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var events []CanvasEvent
 	query := database.Conn().
 		Table("workflow_events").
 		Select("workflow_events.*").
-		Where("workflow_events.state = ?", CanvasEventStatePending)
+		Where("workflow_events.state = ?", CanvasEventStatePending).
+		Order("workflow_events.created_at ASC").
+		Limit(limit)
 
 	err := withActiveCanvas(query, "workflow_events.workflow_id").
 		Find(&events).

--- a/pkg/models/canvas_node_execution.go
+++ b/pkg/models/canvas_node_execution.go
@@ -111,13 +111,18 @@ func (e *CanvasNodeExecution) BeforeCreate(tx *gorm.DB) error {
 	return nil
 }
 
-func ListPendingNodeExecutions() ([]CanvasNodeExecution, error) {
+func ListPendingNodeExecutions(limit int) ([]CanvasNodeExecution, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var executions []CanvasNodeExecution
 	query := database.Conn().
 		Table("workflow_node_executions").
 		Select("workflow_node_executions.*").
 		Where("workflow_node_executions.state = ?", CanvasNodeExecutionStatePending).
-		Order("workflow_node_executions.created_at DESC")
+		Order("workflow_node_executions.created_at ASC").
+		Limit(limit)
 
 	err := withActiveCanvas(query, "workflow_node_executions.workflow_id").
 		Find(&executions).
@@ -129,14 +134,19 @@ func ListPendingNodeExecutions() ([]CanvasNodeExecution, error) {
 	return executions, nil
 }
 
-func ListCancellingNodeExecutions(db *gorm.DB) ([]CanvasNodeExecution, error) {
+func ListCancellingNodeExecutions(db *gorm.DB, limit int) ([]CanvasNodeExecution, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var executions []CanvasNodeExecution
 	query := db.
 		Table("workflow_node_executions").
 		Select("workflow_node_executions.*").
 		Where("workflow_node_executions.state = ?", CanvasNodeExecutionStateCancelling).
 		Where("workflow_node_executions.cancelled_at IS NOT NULL").
-		Order("workflow_node_executions.cancelled_at ASC")
+		Order("workflow_node_executions.cancelled_at ASC").
+		Limit(limit)
 
 	err := withActiveCanvas(query, "workflow_node_executions.workflow_id").
 		Find(&executions).

--- a/pkg/models/canvas_node_request.go
+++ b/pkg/models/canvas_node_request.go
@@ -71,7 +71,11 @@ func LockNodeRequest(tx *gorm.DB, id uuid.UUID) (*CanvasNodeRequest, error) {
 	return &request, nil
 }
 
-func ListNodeRequests() ([]CanvasNodeRequest, error) {
+func ListNodeRequests(limit int) ([]CanvasNodeRequest, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var requests []CanvasNodeRequest
 
 	now := time.Now()
@@ -79,7 +83,9 @@ func ListNodeRequests() ([]CanvasNodeRequest, error) {
 		Table("workflow_node_requests").
 		Select("workflow_node_requests.*").
 		Where("workflow_node_requests.state = ?", NodeExecutionRequestStatePending).
-		Where("workflow_node_requests.run_at <= ?", now)
+		Where("workflow_node_requests.run_at <= ?", now).
+		Order("workflow_node_requests.run_at ASC").
+		Limit(limit)
 
 	err := withActiveCanvas(query, "workflow_node_requests.workflow_id").
 		Find(&requests).

--- a/pkg/models/canvas_run.go
+++ b/pkg/models/canvas_run.go
@@ -676,11 +676,16 @@ func (r *CanvasRun) CalculateResult(tx *gorm.DB) (string, error) {
 	return CanvasRunResultPassed, nil
 }
 
-func ListPendingRuns(tx *gorm.DB) ([]CanvasRun, error) {
+func ListPendingRuns(tx *gorm.DB, limit int) ([]CanvasRun, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var runs []CanvasRun
 	err := tx.
 		Where("state = ?", CanvasRunStatePending).
 		Order("created_at ASC").
+		Limit(limit).
 		Find(&runs).
 		Error
 	if err != nil {

--- a/pkg/models/factory.go
+++ b/pkg/models/factory.go
@@ -366,7 +366,11 @@ func (f *Factory) ListCanvases(tx *gorm.DB) ([]Canvas, error) {
 	return canvases, nil
 }
 
-func ListDeletedFactories(tx *gorm.DB) ([]Factory, error) {
+func ListDeletedFactories(tx *gorm.DB, limit int) ([]Factory, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var factories []Factory
 	err := tx.
 		Model(&Factory{}).
@@ -385,6 +389,8 @@ func ListDeletedFactories(tx *gorm.DB) ([]Factory, error) {
 			"LEAST(factories.deleted_at, organizations.deleted_at) AS deleted_at",
 		).
 		Where("factories.deleted_at IS NOT NULL OR organizations.deleted_at IS NOT NULL").
+		Order("LEAST(factories.deleted_at, organizations.deleted_at) ASC").
+		Limit(limit).
 		Find(&factories).
 		Error
 	if err != nil {

--- a/pkg/models/factory_cleanup_test.go
+++ b/pkg/models/factory_cleanup_test.go
@@ -23,7 +23,7 @@ func Test__ListDeletedFactories(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, factory.SoftDelete(database.DB(t.Context())))
 
-	deleted, err := models.ListDeletedFactories(database.DB(t.Context()))
+	deleted, err := models.ListDeletedFactories(database.DB(t.Context()), 100)
 	require.NoError(t, err)
 
 	var found bool
@@ -50,7 +50,7 @@ func Test__ListDeletedFactories__IncludesFactoriesInDeletedOrg(t *testing.T) {
 		Update("deleted_at", deletedAt).
 		Error)
 
-	deleted, err := models.ListDeletedFactories(database.DB(t.Context()))
+	deleted, err := models.ListDeletedFactories(database.DB(t.Context()), 100)
 	require.NoError(t, err)
 
 	var found *models.Factory
@@ -86,7 +86,7 @@ func Test__ListDeletedFactories__UsesEarliestDeletedAt(t *testing.T) {
 		Update("deleted_at", orgDeletedAt).
 		Error)
 
-	deleted, err := models.ListDeletedFactories(db)
+	deleted, err := models.ListDeletedFactories(db, 100)
 	require.NoError(t, err)
 
 	var found *models.Factory

--- a/pkg/models/integration.go
+++ b/pkg/models/integration.go
@@ -278,10 +278,16 @@ func FindIntegrationByName(db *gorm.DB, orgID uuid.UUID, integrationName string)
 	return &integration, nil
 }
 
-func ListDeletedIntegrations() ([]Integration, error) {
+func ListDeletedIntegrations(limit int) ([]Integration, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var integrations []Integration
 	err := database.Conn().Unscoped().
 		Where("deleted_at IS NOT NULL").
+		Order("deleted_at ASC").
+		Limit(limit).
 		Find(&integrations).
 		Error
 

--- a/pkg/models/integration_request.go
+++ b/pkg/models/integration_request.go
@@ -78,7 +78,11 @@ func LeaseIntegrationRequest(tx *gorm.DB, id uuid.UUID, lease time.Duration) (*I
 	return &request, nil
 }
 
-func ListIntegrationRequests() ([]IntegrationRequest, error) {
+func ListIntegrationRequests(limit int) ([]IntegrationRequest, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var requests []IntegrationRequest
 
 	now := time.Now()
@@ -87,6 +91,8 @@ func ListIntegrationRequests() ([]IntegrationRequest, error) {
 		Where("app_installation_requests.state = ?", IntegrationRequestStatePending).
 		Where("app_installation_requests.run_at <= ?", now).
 		Where("app_installations.deleted_at IS NULL").
+		Order("app_installation_requests.run_at ASC").
+		Limit(limit).
 		Find(&requests).
 		Error
 	if err != nil {

--- a/pkg/models/integration_request_test.go
+++ b/pkg/models/integration_request_test.go
@@ -43,7 +43,7 @@ func Test__LeaseIntegrationRequest(t *testing.T) {
 		assert.True(t, leased.RunAt.After(before.Add(lease-time.Minute)),
 			"expected run_at to be pushed ~lease into the future")
 
-		listed, err := ListIntegrationRequests()
+		listed, err := ListIntegrationRequests(100)
 		require.NoError(t, err)
 		assert.Empty(t, listed, "a leased request must not be listed as due")
 	})
@@ -84,7 +84,7 @@ func Test__LeaseIntegrationRequest(t *testing.T) {
 		}
 		require.NoError(t, database.Conn().Create(expired).Error)
 
-		listed, err := ListIntegrationRequests()
+		listed, err := ListIntegrationRequests(100)
 		require.NoError(t, err)
 		require.Len(t, listed, 1, "an expired lease must be listed as due again")
 		assert.Equal(t, expired.ID, listed[0].ID)

--- a/pkg/models/organization.go
+++ b/pkg/models/organization.go
@@ -265,16 +265,22 @@ func HardDeleteOrganization(id string) error {
 		Error
 }
 
-func ListDeletedOrganizations() ([]Organization, error) {
-	return ListDeletedOrganizationsInTransaction(database.Conn())
+func ListDeletedOrganizations(limit int) ([]Organization, error) {
+	return ListDeletedOrganizationsInTransaction(database.Conn(), limit)
 }
 
-func ListDeletedOrganizationsInTransaction(tx *gorm.DB) ([]Organization, error) {
+func ListDeletedOrganizationsInTransaction(tx *gorm.DB, limit int) ([]Organization, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var organizations []Organization
 
 	err := tx.
 		Unscoped().
 		Where("deleted_at IS NOT NULL").
+		Order("deleted_at ASC").
+		Limit(limit).
 		Find(&organizations).
 		Error
 	if err != nil {

--- a/pkg/models/webhook.go
+++ b/pkg/models/webhook.go
@@ -146,10 +146,16 @@ func FindActiveWebhookNodesInTransaction(tx *gorm.DB, webhookID uuid.UUID) ([]Ca
 	return nodes, nil
 }
 
-func ListPendingWebhooks() ([]Webhook, error) {
+func ListPendingWebhooks(limit int) ([]Webhook, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var webhooks []Webhook
 	err := database.Conn().
 		Where("state = ?", WebhookStatePending).
+		Order("created_at ASC").
+		Limit(limit).
 		Find(&webhooks).
 		Error
 
@@ -160,10 +166,16 @@ func ListPendingWebhooks() ([]Webhook, error) {
 	return webhooks, nil
 }
 
-func ListDeletedWebhooks() ([]Webhook, error) {
+func ListDeletedWebhooks(limit int) ([]Webhook, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	var webhooks []Webhook
 	err := database.Conn().Unscoped().
 		Where("deleted_at IS NOT NULL").
+		Order("deleted_at ASC").
+		Limit(limit).
 		Find(&webhooks).
 		Error
 

--- a/pkg/models/worker_poll_limit_test.go
+++ b/pkg/models/worker_poll_limit_test.go
@@ -1,0 +1,129 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+)
+
+func Test__ListPendingWebhooks__RespectsLimit(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		createdAt := now.Add(time.Duration(i) * time.Minute)
+		webhook := &Webhook{
+			ID:        uuid.New(),
+			State:     WebhookStatePending,
+			Secret:    []byte("secret"),
+			CreatedAt: &createdAt,
+			UpdatedAt: &createdAt,
+		}
+		require.NoError(t, database.Conn().Create(webhook).Error)
+	}
+
+	listed, err := ListPendingWebhooks(2)
+	require.NoError(t, err)
+	require.Len(t, listed, 2, "poll must not load more rows than the batch limit")
+	assert.True(t, listed[0].CreatedAt.Before(*listed[1].CreatedAt),
+		"pending webhooks must be returned oldest-first so a deep backlog does not starve early work")
+}
+
+func Test__ListIntegrationRequests__RespectsLimit(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+
+	organization, err := CreateOrganization("org-"+uuid.NewString(), "")
+	require.NoError(t, err)
+
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		integration, err := CreateIntegration(uuid.New(), organization.ID, "dummy", "integration-"+uuid.NewString(), nil)
+		require.NoError(t, err)
+
+		runAt := now.Add(time.Duration(i)*time.Minute - time.Hour)
+		require.NoError(t, database.Conn().Create(&IntegrationRequest{
+			ID:                uuid.New(),
+			AppInstallationID: integration.ID,
+			State:             IntegrationRequestStatePending,
+			Type:              IntegrationRequestTypeSync,
+			RunAt:             runAt,
+			CreatedAt:         runAt,
+			UpdatedAt:         runAt,
+		}).Error)
+	}
+
+	listed, err := ListIntegrationRequests(2)
+	require.NoError(t, err)
+	require.Len(t, listed, 2, "poll must not load more rows than the batch limit")
+	assert.True(t, listed[0].RunAt.Before(listed[1].RunAt),
+		"due integration requests must be returned earliest-run-at first")
+}
+
+func Test__ListDeletedWebhooks__RespectsLimit(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		createdAt := now.Add(time.Duration(i) * time.Minute)
+		webhook := &Webhook{
+			ID:        uuid.New(),
+			State:     WebhookStateReady,
+			Secret:    []byte("secret"),
+			CreatedAt: &createdAt,
+			UpdatedAt: &createdAt,
+		}
+		require.NoError(t, database.Conn().Create(webhook).Error)
+		require.NoError(t, database.Conn().Delete(webhook).Error)
+	}
+
+	listed, err := ListDeletedWebhooks(2)
+	require.NoError(t, err)
+	require.Len(t, listed, 2, "cleanup poll must not load more rows than the batch limit")
+}
+
+func Test__ListPendingRuns__RespectsLimit(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+
+	organization, err := CreateOrganization("org-"+uuid.NewString(), "")
+	require.NoError(t, err)
+
+	now := time.Now()
+	liveVersionID := uuid.New()
+	canvas := &Canvas{
+		OrganizationID: organization.ID,
+		LiveVersionID:  &liveVersionID,
+		Name:           "poll-limit-canvas",
+		CreatedAt:      &now,
+		UpdatedAt:      &now,
+	}
+	require.NoError(t, database.Conn().Create(canvas).Error)
+	require.NoError(t, database.Conn().Create(&CanvasVersion{
+		ID:         liveVersionID,
+		WorkflowID: canvas.ID,
+		CreatedAt:  &now,
+		UpdatedAt:  &now,
+	}).Error)
+
+	for i := 0; i < 5; i++ {
+		createdAt := now.Add(time.Duration(i) * time.Minute)
+		require.NoError(t, database.Conn().Create(&CanvasRun{
+			ID:         uuid.New(),
+			WorkflowID: canvas.ID,
+			NodeID:     "trigger",
+			VersionID:  liveVersionID,
+			State:      CanvasRunStatePending,
+			CreatedAt:  &createdAt,
+			UpdatedAt:  &createdAt,
+		}).Error)
+	}
+
+	listed, err := ListPendingRuns(database.Conn(), 2)
+	require.NoError(t, err)
+	require.Len(t, listed, 2, "pending-run sweep must bound work in SQL, not after load")
+	assert.True(t, listed[0].CreatedAt.Before(*listed[1].CreatedAt),
+		"pending runs must be returned oldest-first")
+}

--- a/pkg/workers/app_message_worker.go
+++ b/pkg/workers/app_message_worker.go
@@ -44,7 +44,7 @@ func (w *AppMessageWorker) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			appMessages, err := models.ListAppMessages(database.Conn())
+			appMessages, err := models.ListAppMessages(database.Conn(), workerPollBatchSize)
 			if err != nil {
 				w.logger.Errorf("Error listing pending app messages: %v", err)
 				continue

--- a/pkg/workers/app_message_worker_test.go
+++ b/pkg/workers/app_message_worker_test.go
@@ -62,7 +62,7 @@ func Test__AppMessageWorker_LockAndProcessMessage__deliversBroadcast(t *testing.
 	payload := map[string]any{"message": "hello"}
 	require.NoError(t, models.CreateAppMessage(database.Conn(), sourceCanvas.ID, sourceNodes[0].NodeID, payload))
 
-	messages, err := models.ListAppMessages(database.Conn())
+	messages, err := models.ListAppMessages(database.Conn(), workerPollBatchSize)
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
 
@@ -128,7 +128,7 @@ func Test__AppMessageWorker_LockAndProcessMessage__deletesMessageWithoutSubscrib
 		map[string]any{"message": "ignored"},
 	))
 
-	messages, err := models.ListAppMessages(database.Conn())
+	messages, err := models.ListAppMessages(database.Conn(), workerPollBatchSize)
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
 
@@ -208,7 +208,7 @@ func Test__AppMessageWorker_LockAndProcessMessage__skipsStaleSubscriptionAndDeli
 	payload := map[string]any{"message": "hello"}
 	require.NoError(t, models.CreateAppMessage(database.Conn(), sourceCanvas.ID, sourceNodes[0].NodeID, payload))
 
-	messages, err := models.ListAppMessages(database.Conn())
+	messages, err := models.ListAppMessages(database.Conn(), workerPollBatchSize)
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
 
@@ -288,7 +288,7 @@ func Test__AppMessageWorker_LockAndProcessMessage__skipsTargetNodeInErrorState(t
 		map[string]any{"message": "hello"},
 	))
 
-	messages, err := models.ListAppMessages(database.Conn())
+	messages, err := models.ListAppMessages(database.Conn(), workerPollBatchSize)
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
 
@@ -356,7 +356,7 @@ func Test__AppMessageWorker_LockAndProcessMessage__skipsSubscriptionOnDeletedTar
 		map[string]any{"message": "hello"},
 	))
 
-	messages, err := models.ListAppMessages(database.Conn())
+	messages, err := models.ListAppMessages(database.Conn(), workerPollBatchSize)
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
 
@@ -409,7 +409,7 @@ func Test__AppMessageWorker_LockAndProcessMessage__deletesMessageWhenSourceNodeD
 
 	require.NoError(t, models.DeleteCanvasNode(database.Conn(), sourceNodes[0]))
 
-	messages, err := models.ListAppMessages(database.Conn())
+	messages, err := models.ListAppMessages(database.Conn(), workerPollBatchSize)
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
 

--- a/pkg/workers/canvas_cleanup_worker.go
+++ b/pkg/workers/canvas_cleanup_worker.go
@@ -55,7 +55,7 @@ func (w *CanvasCleanupWorker) Start(ctx context.Context) {
 			return
 		case <-ticker.C:
 			tickStart := time.Now()
-			canvases, err := models.ListDeletedCanvases(database.Conn())
+			canvases, err := models.ListDeletedCanvases(database.Conn(), workerPollBatchSize)
 			if err != nil {
 				w.logger.Errorf("Error finding deleted canvases: %v", err)
 				continue

--- a/pkg/workers/canvas_cleanup_worker_test.go
+++ b/pkg/workers/canvas_cleanup_worker_test.go
@@ -408,7 +408,7 @@ func Test__CanvasCleanupWorker_ProcessesWorkflowFromSoftDeletedOrganization(t *t
 		Update("deleted_at", deletedAtOutsideGracePeriod).
 		Error)
 
-	canvases, err := models.ListDeletedCanvases(database.Conn())
+	canvases, err := models.ListDeletedCanvases(database.Conn(), workerPollBatchSize)
 	require.NoError(t, err)
 	require.Len(t, canvases, 1)
 	require.Equal(t, canvas.ID, canvases[0].ID)

--- a/pkg/workers/event_router.go
+++ b/pkg/workers/event_router.go
@@ -51,7 +51,7 @@ func (w *EventRouter) Start(ctx context.Context) {
 		case <-ticker.C:
 			tickStart := time.Now()
 
-			events, err := models.ListPendingCanvasEvents()
+			events, err := models.ListPendingCanvasEvents(workerPollBatchSize)
 			if err != nil {
 				w.logger.Errorf("Error finding canvas nodes ready to be processed: %v", err)
 			}

--- a/pkg/workers/event_router_test.go
+++ b/pkg/workers/event_router_test.go
@@ -114,7 +114,7 @@ func Test__EventRouter_DoesNotRouteEventForSoftDeletedOrganization(t *testing.T)
 	event := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
 	require.NoError(t, models.SoftDeleteOrganization(r.Organization.ID.String()))
 
-	events, err := models.ListPendingCanvasEvents()
+	events, err := models.ListPendingCanvasEvents(workerPollBatchSize)
 	require.NoError(t, err)
 	for _, pending := range events {
 		assert.NotEqual(t, event.ID, pending.ID)

--- a/pkg/workers/execution_terminator.go
+++ b/pkg/workers/execution_terminator.go
@@ -64,7 +64,7 @@ func (w *ExecutionTerminator) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			executions, err := models.ListCancellingNodeExecutions(database.Conn())
+			executions, err := models.ListCancellingNodeExecutions(database.Conn(), workerPollBatchSize)
 			if err != nil {
 				w.logger.Errorf("Error finding cancelling executions: %v", err)
 				continue

--- a/pkg/workers/factory_cleanup_worker.go
+++ b/pkg/workers/factory_cleanup_worker.go
@@ -39,7 +39,7 @@ func (w *FactoryCleanupWorker) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case tickTime := <-ticker.C:
-			factories, err := models.ListDeletedFactories(database.Conn())
+			factories, err := models.ListDeletedFactories(database.Conn(), workerPollBatchSize)
 			if err != nil {
 				w.logger.Errorf("Error finding deleted factories: %v", err)
 				continue

--- a/pkg/workers/factory_cleanup_worker_test.go
+++ b/pkg/workers/factory_cleanup_worker_test.go
@@ -261,7 +261,7 @@ func Test__OrganizationCleanupWorker_WaitsForFactories(t *testing.T) {
 		Update("deleted_at", deletedAtOutsideGracePeriod).
 		Error)
 
-	deletedOrganizations, err := models.ListDeletedOrganizations()
+	deletedOrganizations, err := models.ListDeletedOrganizations(workerPollBatchSize)
 	require.NoError(t, err)
 	require.Len(t, deletedOrganizations, 1)
 

--- a/pkg/workers/integration_cleanup_worker.go
+++ b/pkg/workers/integration_cleanup_worker.go
@@ -42,7 +42,7 @@ func (w *IntegrationCleanupWorker) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			integrations, err := models.ListDeletedIntegrations()
+			integrations, err := models.ListDeletedIntegrations(workerPollBatchSize)
 			if err != nil {
 				w.log("Error finding deleted integrations: %v", err)
 			}

--- a/pkg/workers/integration_request_worker.go
+++ b/pkg/workers/integration_request_worker.go
@@ -57,7 +57,7 @@ func (w *IntegrationRequestWorker) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			requests, err := models.ListIntegrationRequests()
+			requests, err := models.ListIntegrationRequests(workerPollBatchSize)
 			if err != nil {
 				w.log("Error finding app installation requests: %v", err)
 			}

--- a/pkg/workers/integration_request_worker_test.go
+++ b/pkg/workers/integration_request_worker_test.go
@@ -181,7 +181,7 @@ func Test__IntegrationRequestWorker_LeasesBeforeProcessing(t *testing.T) {
 			stateDuringSync = request.State
 			runAtDuringSync = request.RunAt
 
-			listed, err := models.ListIntegrationRequests()
+			listed, err := models.ListIntegrationRequests(workerPollBatchSize)
 			require.NoError(t, err)
 			for _, listedRequest := range listed {
 				if listedRequest.AppInstallationID == installationID {

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -80,7 +80,7 @@ func (w *NodeExecutor) Start(ctx context.Context) {
 		case <-ticker.C:
 			tickStart := time.Now()
 
-			executions, err := models.ListPendingNodeExecutions()
+			executions, err := models.ListPendingNodeExecutions(workerPollBatchSize)
 			if err != nil {
 				w.logger.Errorf("Error finding workflow nodes ready to be processed: %v", err)
 			}

--- a/pkg/workers/node_executor_test.go
+++ b/pkg/workers/node_executor_test.go
@@ -125,7 +125,7 @@ func Test__NodeExecutor_DoesNotProcessExecutionForSoftDeletedOrganization(t *tes
 
 	require.NoError(t, models.SoftDeleteOrganization(r.Organization.ID.String()))
 
-	executions, err := models.ListPendingNodeExecutions()
+	executions, err := models.ListPendingNodeExecutions(workerPollBatchSize)
 	require.NoError(t, err)
 	for _, pending := range executions {
 		assert.NotEqual(t, execution.ID, pending.ID)

--- a/pkg/workers/node_request_worker.go
+++ b/pkg/workers/node_request_worker.go
@@ -56,7 +56,7 @@ func (w *NodeRequestWorker) Start(ctx context.Context) {
 		case <-ticker.C:
 			tickStart := time.Now()
 
-			requests, err := models.ListNodeRequests()
+			requests, err := models.ListNodeRequests(workerPollBatchSize)
 			if err != nil {
 				w.logger.Errorf("Error finding workflow nodes ready to be processed: %v", err)
 			}

--- a/pkg/workers/node_request_worker_test.go
+++ b/pkg/workers/node_request_worker_test.go
@@ -573,7 +573,7 @@ func Test__NodeRequestWorker_CompletesDeletedNodeRequests(t *testing.T) {
 
 	require.NoError(t, database.Conn().Delete(&canvasNodes[0]).Error)
 
-	requests, err := models.ListNodeRequests()
+	requests, err := models.ListNodeRequests(workerPollBatchSize)
 	require.NoError(t, err)
 
 	found := false
@@ -1026,7 +1026,7 @@ func Test__NodeRequestWorker_DoesNotProcessDeletedWorkflowRequests(t *testing.T)
 	//
 	// Verify that ListNodeRequests does not return the request for the deleted workflow.
 	//
-	requests, err := models.ListNodeRequests()
+	requests, err := models.ListNodeRequests(workerPollBatchSize)
 	require.NoError(t, err)
 
 	// Check that our request is not in the list
@@ -1090,7 +1090,7 @@ func Test__NodeRequestWorker_DoesNotProcessSoftDeletedOrganizationRequests(t *te
 
 	require.NoError(t, models.SoftDeleteOrganization(r.Organization.ID.String()))
 
-	requests, err := models.ListNodeRequests()
+	requests, err := models.ListNodeRequests(workerPollBatchSize)
 	require.NoError(t, err)
 	for _, pending := range requests {
 		assert.NotEqual(t, request.ID, pending.ID)

--- a/pkg/workers/organization_cleanup_worker.go
+++ b/pkg/workers/organization_cleanup_worker.go
@@ -43,7 +43,7 @@ func (w *OrganizationCleanupWorker) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case tickTime := <-ticker.C:
-			organizations, err := models.ListDeletedOrganizations()
+			organizations, err := models.ListDeletedOrganizations(workerPollBatchSize)
 			if err != nil {
 				w.logger.Errorf("Error finding deleted organizations: %v", err)
 				continue

--- a/pkg/workers/organization_cleanup_worker_test.go
+++ b/pkg/workers/organization_cleanup_worker_test.go
@@ -65,7 +65,7 @@ func Test__OrganizationCleanupWorker_GracePeriod(t *testing.T) {
 		deletedAtWithinGracePeriod := time.Now().AddDate(0, 0, -29)
 		require.NoError(t, database.Conn().Unscoped().Model(&models.Organization{}).Where("id = ?", r.Organization.ID).Update("deleted_at", deletedAtWithinGracePeriod).Error)
 
-		deletedOrganizations, err := models.ListDeletedOrganizations()
+		deletedOrganizations, err := models.ListDeletedOrganizations(workerPollBatchSize)
 		require.NoError(t, err)
 		require.Len(t, deletedOrganizations, 1)
 
@@ -94,13 +94,13 @@ func Test__OrganizationCleanupWorker_GracePeriod(t *testing.T) {
 		deletedAtOutsideGracePeriod := time.Now().AddDate(0, 0, -31)
 		require.NoError(t, database.Conn().Unscoped().Model(&models.Organization{}).Where("id = ?", r2.Organization.ID).Update("deleted_at", deletedAtOutsideGracePeriod).Error)
 
-		deletedCanvases, err := models.ListDeletedCanvases(database.Conn())
+		deletedCanvases, err := models.ListDeletedCanvases(database.Conn(), workerPollBatchSize)
 		require.NoError(t, err)
 		require.Len(t, deletedCanvases, 1)
 		require.Equal(t, canvas.ID, deletedCanvases[0].ID)
 		require.NoError(t, canvasWorker.LockAndProcessCanvas(deletedCanvases[0]))
 
-		deletedOrganizations, err := models.ListDeletedOrganizations()
+		deletedOrganizations, err := models.ListDeletedOrganizations(workerPollBatchSize)
 		require.NoError(t, err)
 		require.Len(t, deletedOrganizations, 1)
 

--- a/pkg/workers/poll_batch.go
+++ b/pkg/workers/poll_batch.go
@@ -1,0 +1,7 @@
+package workers
+
+// workerPollBatchSize bounds how many eligible rows a worker reads per poll.
+// It matches other sweep limits (pending runs, started runs, repository
+// provisioner) and exceeds the typical semaphore weight of 25 so a replica
+// can keep slots filled without loading the full backlog.
+const workerPollBatchSize = 100

--- a/pkg/workers/run_initializer.go
+++ b/pkg/workers/run_initializer.go
@@ -71,14 +71,10 @@ func (w *RunInitializer) Start(ctx context.Context) {
 }
 
 func (w *RunInitializer) sweepPendingRuns() {
-	runs, err := models.ListPendingRuns(database.Conn())
+	runs, err := models.ListPendingRuns(database.Conn(), pendingRunsSweepLimit)
 	if err != nil {
 		w.logger.Errorf("Error listing pending runs: %v", err)
 		return
-	}
-
-	if len(runs) > pendingRunsSweepLimit {
-		runs = runs[:pendingRunsSweepLimit]
 	}
 
 	for _, run := range runs {

--- a/pkg/workers/webhook_cleanup_worker.go
+++ b/pkg/workers/webhook_cleanup_worker.go
@@ -47,7 +47,7 @@ func (w *WebhookCleanupWorker) Start(ctx context.Context) {
 		case <-ticker.C:
 			tickStart := time.Now()
 
-			webhooks, err := models.ListDeletedWebhooks()
+			webhooks, err := models.ListDeletedWebhooks(workerPollBatchSize)
 			if err != nil {
 				w.logger.Errorf("Error finding workflow nodes ready to be processed: %v", err)
 			}

--- a/pkg/workers/webhook_provisioner.go
+++ b/pkg/workers/webhook_provisioner.go
@@ -60,7 +60,7 @@ func (w *WebhookProvisioner) Start(ctx context.Context) {
 		case <-ticker.C:
 			tickStart := time.Now()
 
-			webhooks, err := models.ListPendingWebhooks()
+			webhooks, err := models.ListPendingWebhooks(workerPollBatchSize)
 			if err != nil {
 				w.logger.Errorf("Error finding workflow nodes ready to be processed: %v", err)
 			}


### PR DESCRIPTION
## Summary

Polling workers capped concurrency in process, but their ListPending and ListDeleted queries still loaded every eligible row. On a large backlog, each replica repeated that full read before SKIP LOCKED chose a worker.

This change passes a batch limit into those list helpers and applies LIMIT in SQL. The batch size is 100, the same sweep size used by the repository provisioner and run finalizer. Queries also order oldest-first so a deep backlog does not starve early work. The pending-run sweep no longer loads the full set and then slices in memory.

Closes #6989

## Test plan

- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/models` and confirm the new poll-limit tests pass
- [ ] Create more than 100 pending webhooks and confirm one WebhookProvisioner tick claims at most 100 rows
- [ ] Create more than 100 due integration requests and confirm ListIntegrationRequests returns at most the batch size
- [ ] Confirm pending executions and pending runs still progress under load with the new oldest-first order
- [ ] Confirm deleted-resource cleanup workers still drain soft-deleted rows across ticks