### PR TITLE
feat: Remove Quick Edit from Automation Menus

### DIFF
--- a/web_src/src/pages/factories/lib/columnAutomations.spec.ts
+++ b/web_src/src/pages/factories/lib/columnAutomations.spec.ts
@@ -4,7 +4,6 @@ import type { FactoriesFactoryIntake, FactoriesFactoryPrFeedbackHandler, Factori
 
 import {
   applyColumnAutomationsOverlay,
-  automationOffersAgentEdit,
   buildColumnAutomations,
   catalogForColumn,
   columnAutomationOpenPath,
@@ -109,15 +108,6 @@ describe("columnTitleForKey", () => {
     expect(columnTitleForKey("backlog")).toBe("Backlog");
     expect(columnTitleForKey("phase-0", [IMPLEMENT_COLUMN])).toBe("Implement");
     expect(columnTitleForKey("phase-3", [IMPLEMENT_COLUMN])).toBe("Phase 4");
-  });
-});
-
-describe("automationOffersAgentEdit", () => {
-  it("offers agent edit for analysis and agent-step automations", () => {
-    expect(automationOffersAgentEdit({ kind: "analysis" })).toBe(true);
-    expect(automationOffersAgentEdit({ kind: "agent-step" })).toBe(true);
-    expect(automationOffersAgentEdit({ kind: "intake" })).toBe(false);
-    expect(automationOffersAgentEdit({ kind: "custom" })).toBe(false);
   });
 });
 

--- a/web_src/src/pages/factories/lib/columnAutomations.ts
+++ b/web_src/src/pages/factories/lib/columnAutomations.ts
@@ -451,10 +451,6 @@ export function applyColumnAutomationsOverlay(
     .map((automation) => (disabled.has(automation.id) ? { ...automation, health: "disabled" } : automation));
 }
 
-export function automationOffersAgentEdit(automation: Pick<ColumnAutomation, "kind">): boolean {
-  return automation.kind === "agent-step" || automation.kind === "analysis";
-}
-
 export function catalogEntryToAutomation(
   entry: ColumnAutomationCatalogEntry,
   columnTitle: string,
@@ -492,8 +488,6 @@ export const COLUMN_AUTOMATIONS_COPY = {
   needsRepairLabel: "Needs repair",
   disabledLabel: "Disabled",
   editLabel: "Edit automation",
-  editAgentLabel: "Edit Agent",
-  editAutomationMenuLabel: "Edit Automation",
   tabsLabel: "Automation sections",
   generalTab: "General",
   agentTab: "Agent",

--- a/web_src/src/pages/factories/pages/ColumnAutomationsIndicator.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsIndicator.tsx
@@ -1,5 +1,5 @@
 import { emptyColumnAutomationActivity } from "../lib/columnAutomationActivity";
-import { automationOffersAgentEdit, type ColumnAutomation } from "../lib/columnAutomations";
+import type { ColumnAutomation } from "../lib/columnAutomations";
 import { ColumnAutomationsPopup, type ColumnAutomationRowAction } from "./ColumnAutomationsPopup";
 
 /** One header icon for each configured automation. */
@@ -7,14 +7,11 @@ export function ColumnAutomationsHeaderSlot({
   title,
   automations,
   onRowAction,
-  canEditAgent,
   testId,
 }: {
   title: string;
   automations?: ColumnAutomation[];
   onRowAction?: (automation: ColumnAutomation, action: ColumnAutomationRowAction) => void;
-  /** When set, overrides the default agent-edit offer for every icon in this slot. */
-  canEditAgent?: boolean;
   testId: string;
 }) {
   if (!onRowAction || !automations || automations.length === 0) {
@@ -28,8 +25,6 @@ export function ColumnAutomationsHeaderSlot({
             automation={automation}
             activity={automation.activity ?? emptyColumnAutomationActivity(automation.runningCount)}
             onAction={(action) => onRowAction(automation, action)}
-            showEditAgent={canEditAgent ?? automationOffersAgentEdit(automation)}
-            showEditAutomation={Boolean(automation.canvasId)}
           />
         </div>
       ))}

--- a/web_src/src/pages/factories/pages/ColumnAutomationsPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsPopup.spec.tsx
@@ -116,28 +116,13 @@ describe("ColumnAutomationsPopup", () => {
     expect(onAction).toHaveBeenCalledWith("settings");
   });
 
-  it("offers Edit Agent ahead of Edit Automation when both are present", async () => {
-    const user = userEvent.setup();
-    const onAction = vi.fn();
-    render(
-      <ColumnAutomationsPopup automation={AGENT} onAction={onAction} showEditAgent showEditAutomation defaultOpen />,
-    );
+  it("does not offer Edit Agent or Edit Automation", () => {
+    renderPopup({ automation: AGENT });
 
-    const editAgent = screen.getByTestId("column-automation-step-0-app-refund-implementer-edit-agent");
-    const editAutomation = screen.getByTestId("column-automation-step-0-app-refund-implementer-edit");
-    expect(editAgent).toHaveTextContent("Edit Agent");
-    expect(editAutomation).toHaveTextContent("Edit Automation");
-    expect(editAgent.compareDocumentPosition(editAutomation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-
-    await user.click(editAgent);
-    expect(onAction).toHaveBeenCalledWith("edit-agent");
-  });
-
-  it("hides edit actions when they are not offered", () => {
-    renderPopup();
-
-    expect(screen.queryByTestId("column-automation-intake-github-edit-agent")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("column-automation-intake-github-edit")).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Edit Agent" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Edit Automation" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("column-automation-step-0-app-refund-implementer-edit-agent")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("column-automation-step-0-app-refund-implementer-edit")).not.toBeInTheDocument();
   });
 });
 

--- a/web_src/src/pages/factories/pages/ColumnAutomationsPopup.stories.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsPopup.stories.tsx
@@ -87,21 +87,10 @@ export const InfoOpen: Story = {
   name: "Info open",
 };
 
-export const PhaseEditActions: Story = {
-  name: "Phase edit actions",
-  args: {
-    automation: ANALYSIS,
-    showEditAgent: true,
-    showEditAutomation: true,
-  },
-};
-
 export const WithActivity: Story = {
   name: "With last-run activity",
   args: {
     automation: ANALYSIS,
-    showEditAgent: true,
-    showEditAutomation: true,
     activity: HEALTHY_ACTIVITY,
   },
 };
@@ -110,8 +99,6 @@ export const WithFailedActivity: Story = {
   name: "With failed last run",
   args: {
     automation: ANALYSIS,
-    showEditAgent: true,
-    showEditAutomation: true,
     activity: FAILED_ACTIVITY,
   },
 };

--- a/web_src/src/pages/factories/pages/ColumnAutomationsPopup.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationsPopup.tsx
@@ -1,12 +1,6 @@
 import { cn } from "@/lib/utils";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/ui/dropdownMenu";
-import { Bot, LoaderCircle, Pencil, Sparkles, Workflow } from "lucide-react";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
+import { Bot, LoaderCircle, Sparkles, Workflow } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 import { type ColumnAutomationActivity, type ColumnAutomationLastRunStatus } from "../lib/columnAutomationActivity";
@@ -14,7 +8,7 @@ import { COLUMN_AUTOMATIONS_COPY, type ColumnAutomation, type ColumnAutomationKi
 
 export type { ColumnAutomationActivity, ColumnAutomationLastRunStatus };
 
-export type ColumnAutomationRowAction = "settings" | "edit" | "edit-agent" | "disable" | "enable" | "remove";
+export type ColumnAutomationRowAction = "settings" | "disable" | "enable" | "remove";
 
 const KIND_FALLBACK_ICON: Partial<Record<ColumnAutomationKind, LucideIcon>> = {
   analysis: Sparkles,
@@ -25,25 +19,20 @@ const KIND_FALLBACK_ICON: Partial<Record<ColumnAutomationKind, LucideIcon>> = {
 interface ColumnAutomationsPopupProps {
   automation: ColumnAutomation;
   onAction: (action: ColumnAutomationRowAction) => void;
-  showEditAgent?: boolean;
-  showEditAutomation?: boolean;
   activity?: ColumnAutomationActivity;
   /** Open the menu on first render. Used by stories. */
   defaultOpen?: boolean;
 }
 
-/** Header icon. Click opens a menu with the automation summary and edit actions. */
+/** Header icon. Click opens a menu with the automation summary. */
 export function ColumnAutomationsPopup({
   automation,
   onAction,
-  showEditAgent = false,
-  showEditAutomation = false,
   activity,
   defaultOpen = false,
 }: ColumnAutomationsPopupProps) {
   const needsRepair = automation.health === "needs-repair";
   const disabled = automation.health === "disabled";
-  const hasEditActions = showEditAgent || showEditAutomation;
 
   return (
     <DropdownMenu defaultOpen={defaultOpen}>
@@ -76,31 +65,6 @@ export function ColumnAutomationsPopup({
             onOpenSettings={() => onAction("settings")}
           />
         </div>
-        {hasEditActions ? (
-          <>
-            <DropdownMenuSeparator className="my-0" />
-            <div className="p-1">
-              {showEditAgent ? (
-                <DropdownMenuItem
-                  onSelect={() => onAction("edit-agent")}
-                  data-testid={`column-automation-${automation.id}-edit-agent`}
-                >
-                  <Bot className="h-3.5 w-3.5" aria-hidden />
-                  {COLUMN_AUTOMATIONS_COPY.editAgentLabel}
-                </DropdownMenuItem>
-              ) : null}
-              {showEditAutomation ? (
-                <DropdownMenuItem
-                  onSelect={() => onAction("edit")}
-                  data-testid={`column-automation-${automation.id}-edit`}
-                >
-                  <Pencil className="h-3.5 w-3.5" aria-hidden />
-                  {COLUMN_AUTOMATIONS_COPY.editAutomationMenuLabel}
-                </DropdownMenuItem>
-              ) : null}
-            </div>
-          </>
-        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -871,56 +871,14 @@ describe("LinesPage board editing", () => {
     expect(screen.getByTestId("lines-column-title-backlog")).toHaveTextContent("Inbox");
   });
 
-  it("offers full-screen automation editing and inline agent editing", async () => {
+  it("hides Edit Agent and Edit Automation on the automation menu", async () => {
     const user = userEvent.setup();
     renderLinesBoard();
 
     await user.click(screen.getByTestId("column-automation-icon-step-0-app-refund-implementer"));
-    expect(screen.getByTestId("column-automation-step-0-app-refund-implementer-edit")).toHaveTextContent(
-      "Edit Automation",
-    );
-    expect(screen.getByTestId("column-automation-step-0-app-refund-implementer-edit-agent")).toHaveTextContent(
-      "Edit Agent",
-    );
-    await user.click(screen.getByTestId("column-automation-step-0-app-refund-implementer-edit"));
-
-    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
-      factoryAppConfigurePath("org-1", PRIMARY_FACTORY_KEY, "app-refund-implementer", {
-        from: "lines",
-        lineId: REFUND_LINE_PLAN_ID,
-      }),
-    );
-  });
-
-  it("opens the agent editor with the canvas agent name and steps", async () => {
-    const user = userEvent.setup();
-    renderLinesBoard();
-
-    await user.click(screen.getByTestId("column-automation-icon-step-0-app-refund-implementer"));
-    await user.click(screen.getByTestId("column-automation-step-0-app-refund-implementer-edit-agent"));
-
-    expect(screen.getByRole("heading", { level: 2, name: "Implement From Task Description" })).toBeInTheDocument();
-    expect(screen.queryByTestId("planning-review-nav")).not.toBeInTheDocument();
-    expect(screen.getByTestId("planning-review-settings")).toBeInTheDocument();
-    expect(screen.getByText("Concurrency")).toBeInTheDocument();
-    expect(screen.getByText("Model used")).toBeInTheDocument();
-    expect(screen.getByTestId("planning-review-step-kind-0")).toHaveTextContent("Bash");
-    expect(screen.getByTestId("planning-review-step-summary-0")).toHaveTextContent("Clone Repo");
-    expect(screen.getByTestId("planning-review-step-toggle-0")).toHaveAttribute("aria-expanded", "false");
-    await user.click(screen.getByTestId("planning-review-step-toggle-0"));
-    expect(screen.getByTestId("planning-review-step-name-0")).toHaveValue("Clone Repo");
-    expect(screen.getByTestId("planning-review-step-body-0-editor")).toBeInTheDocument();
-  });
-
-  it("hides Edit Agent when the column canvas has no agent", async () => {
-    useCanvasMock.mockReturnValue(canvasQuery(canvasWithoutAgent));
-    const user = userEvent.setup();
-    renderLinesBoard();
-
-    await user.click(screen.getByTestId("column-automation-icon-step-0-app-refund-implementer"));
-    expect(screen.getByTestId("column-automation-step-0-app-refund-implementer-edit")).toHaveTextContent(
-      "Edit Automation",
-    );
+    expect(screen.queryByRole("menuitem", { name: "Edit Agent" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Edit Automation" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("column-automation-step-0-app-refund-implementer-edit")).not.toBeInTheDocument();
     expect(screen.queryByTestId("column-automation-step-0-app-refund-implementer-edit-agent")).not.toBeInTheDocument();
   });
 
@@ -929,7 +887,7 @@ describe("LinesPage board editing", () => {
     renderLinesBoard();
 
     await user.click(screen.getByTestId("column-automation-icon-step-0-app-refund-implementer"));
-    await user.click(screen.getByTestId("column-automation-step-0-app-refund-implementer-edit-agent"));
+    await user.click(screen.getByTestId("column-automation-row-step-0-app-refund-implementer"));
     await user.click(screen.getByTestId("planning-review-step-toggle-0"));
     const stepName = screen.getByTestId("planning-review-step-name-0");
     await user.clear(stepName);
@@ -945,7 +903,7 @@ describe("LinesPage board editing", () => {
       );
     });
     expect(commitCanvasStagingMutateAsync).toHaveBeenCalledWith("Update agent");
-    expect(screen.queryByTestId("lines-planning-review")).not.toBeInTheDocument();
+    expect(screen.getByTestId("column-automation-view")).toBeInTheDocument();
   });
 
   it("keeps Backlog Edit as the only edit action", async () => {

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -136,9 +136,7 @@ import {
 import { replaceLineStepParallelism } from "../lib/factoryLineFormShared";
 import { ColumnLaneMenu } from "./ColumnLaneMenu";
 import { ParallelismSettingsDialog } from "./ParallelismSettingsDialog";
-import { PlanningReviewPopup } from "./PlanningReviewPopup";
 import { ProductiveIntakeSetupDialog } from "./ProductiveIntakeSetupDialog";
-import { useColumnCanvasAgentEditor } from "./useColumnCanvasAgentEditor";
 import {
   ADD_INTAKE_TEMPLATES,
   apiIntakeSource,
@@ -722,19 +720,6 @@ function LineDetail({
       if (href) {
         navigate(href);
       }
-      return;
-    }
-    if (action === "edit-agent") {
-      const href = columnAutomationOpenPath(automation, { organizationId, factoryKey, lineId: line.id });
-      if (href) {
-        navigate(href);
-      }
-      return;
-    }
-    if (action === "edit" && automation.canvasId) {
-      navigate(
-        factoryAppConfigurePath(organizationId, factoryKey, automation.canvasId, { from: "lines", lineId: line.id }),
-      );
       return;
     }
     if (action === "disable") {
@@ -1540,7 +1525,6 @@ function PhaseColumn({
   const scrollRef = useRef<HTMLUListElement>(null);
   const [visibleCount, setVisibleCount] = useState(LINE_PHASE_RUNS_PAGE_SIZE);
   const [parallelismOpen, setParallelismOpen] = useState(false);
-  const agentEditor = useColumnCanvasAgentEditor(organizationId, column.appId);
   const totalRuns = column.runs.length;
   const hasMore = visibleCount < totalRuns;
 
@@ -1585,14 +1569,7 @@ function PhaseColumn({
             <ColumnAutomationsHeaderSlot
               title={title}
               automations={automations}
-              canEditAgent={Boolean(agentEditor.agentNode)}
-              onRowAction={(automation, action) => {
-                if (action === "edit-agent") {
-                  agentEditor.openEditor?.();
-                  return;
-                }
-                onAutomationRowAction?.(automation, action);
-              }}
+              onRowAction={onAutomationRowAction}
               testId={`lines-phase-${column.stepIndex}-automations`}
             />
             <ColumnLaneMenu
@@ -1629,17 +1606,6 @@ function PhaseColumn({
         }}
         onClose={() => setParallelismOpen(false)}
       />
-      {agentEditor.editorOpen ? (
-        <PlanningReviewPopup
-          key={agentEditor.agentNode?.id ?? "agent"}
-          onClose={agentEditor.closeEditor}
-          organizationId={organizationId}
-          automationHref={configureHref ?? undefined}
-          initialDraft={agentEditor.draft ?? { title: "Editing Agent", components: [] }}
-          isLoading={agentEditor.isLoading || !agentEditor.draft}
-          onSave={agentEditor.save}
-        />
-      ) : null}
     </>
   );
 }

--- a/web_src/src/pages/factories/pages/PlanningReviewPopup.stories.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewPopup.stories.tsx
@@ -8,8 +8,7 @@ import { RunOverlayBoardBackdrop } from "./work-order-popup-redesign/popupShared
 const AUTOMATION_HREF = "/organizations/demo-org/factories/refunds/apps/app-refund-planner?configure=1";
 
 /**
- * Simple editing mode for one phase agent. The automation icon action
- * Edit Agent opens this popup.
+ * Simple editing mode for one phase agent.
  */
 const meta = {
   title: "Factories/Pages/Planning Review",


### PR DESCRIPTION
## Summary

The column automation icon menu offered Edit Agent and Edit Automation. Those shortcuts skip the settings popup.

Operators now open settings from the summary row. Agent and canvas edits stay on the settings tabs.

## Test plan

- [ ] Open a column automation icon menu on the board.
- [ ] Confirm Edit Agent and Edit Automation are gone.
- [ ] Click the summary row. Confirm the settings popup opens.
- [ ] Open the Agent tab and confirm the agent editor is present.
- [ ] Open the Automation tab and confirm Edit automation is on the header.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62050389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/superplane/-/pull-requests/superplanehq/superplane/7300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a></h2>

The settings-first workflow needs correction before merging because locally added phase automations can now have a summary row that silently does nothing.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Canvas\-less settings silently fail** <a href="https://github.com/superplanehq/superplane/pull/7300/files#diff-3bf875b010b2a7ef093bfeb9a49cf05ee07d00992d901f1e8773f3f541b1584bR722">▶</a>

<!-- /greptile_comment -->