### PR TITLE
feat: Move Workspace Settings into the Switcher

### DIFF
--- a/web_src/src/pages/factories/__fixtures__/FactoriesHarness.smoke.spec.tsx
+++ b/web_src/src/pages/factories/__fixtures__/FactoriesHarness.smoke.spec.tsx
@@ -183,7 +183,8 @@ describe("FactoriesHarness tasks", () => {
     expect(componentsToggle).toHaveAttribute("aria-pressed", "false");
   }, 15000);
 
-  it("lets the signed-in user open workspace settings from the sidebar cog", async () => {
+  it("lets the signed-in user open workspace settings from the workspace menu", async () => {
+    const user = userEvent.setup();
     render(
       <FactoriesHarness
         pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/overview`}
@@ -191,13 +192,12 @@ describe("FactoriesHarness tasks", () => {
       />,
     );
 
-    const settingsLink = await screen.findByTestId("factories-workspace-settings-link", {}, { timeout: 8000 });
-    await waitFor(() => {
-      expect(settingsLink).toHaveAttribute(
-        "href",
-        factorySettingsWorkspaceGeneralPath(FACTORIES_ORGANIZATION_ID, PRIMARY_FACTORY_KEY),
-      );
-    });
+    await user.click(await screen.findByTestId("factories-workspace-switch", {}, { timeout: 8000 }));
+    const settingsLink = await screen.findByTestId("factories-workspace-settings-link");
+    expect(settingsLink).toHaveAttribute(
+      "href",
+      factorySettingsWorkspaceGeneralPath(FACTORIES_ORGANIZATION_ID, PRIMARY_FACTORY_KEY),
+    );
     expect(settingsLink).not.toHaveClass("pointer-events-none");
   }, 10000);
 

--- a/web_src/src/pages/factories/layout/FactoriesLayout.stories.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesLayout.stories.tsx
@@ -5,8 +5,8 @@ import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../__fixtures__/fa
 import { FactoriesLayout } from "./FactoriesLayout";
 
 /**
- * The Factories layout shell: a thin icon rail (workspace, intake, board,
- * velocity, settings, new task, user) and the line board as the main pane.
+ * The Factories layout shell: a thin icon rail (workspace, board,
+ * Velocity, user) and the line board as the main pane.
  * Stories mount the layout with a live route so the rail controls behave.
  */
 const meta = {

--- a/web_src/src/pages/factories/layout/FactoriesSidebar.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesSidebar.tsx
@@ -18,8 +18,8 @@ interface FactoriesSidebarProps {
 }
 
 /**
- * Icon rail shared by the workspace shell and workspace settings, so the
- * board, Velocity, and settings stay one click away on both screens.
+ * Icon rail shared by the workspace shell and workspace settings.
+ * Board and Velocity stay on the rail. Workspace settings open from the switcher.
  */
 export function FactoriesSidebar({ organizationId, factoryKey, factory, factories }: FactoriesSidebarProps) {
   const navigate = useNavigate();
@@ -40,6 +40,7 @@ export function FactoriesSidebar({ organizationId, factoryKey, factory, factorie
         factory={factory}
         factories={factories}
         canCreateFactory={canAct("factories", "create")}
+        canOpenSettings={canAct("factories", "update")}
         permissionsLoading={permissionsLoading}
         onCreateFactory={() => navigate(newFactoryPath(organizationId))}
       />
@@ -47,8 +48,6 @@ export function FactoriesSidebar({ organizationId, factoryKey, factory, factorie
         organizationId={organizationId}
         factoryKey={factoryKey}
         lineId={routeLineId ?? firstFactoryLineId(factory)}
-        canOpenSettings={canAct("factories", "update")}
-        permissionsLoading={permissionsLoading}
       />
       <div className="flex-1" />
       <SidebarUserMenu

--- a/web_src/src/pages/factories/layout/FactoriesSidebarNav.spec.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesSidebarNav.spec.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { TooltipProvider } from "@/ui/tooltip";
 import { FACTORIES_ORGANIZATION_ID, REFUND_FACTORY, REFUND_LINE_PLAN_ID } from "../__fixtures__/factoryPageResponses";
-import { factoryHomePath, factorySettingsWorkspaceGeneralPath, factoryVelocityPath } from "../lib/factoryPagePaths";
+import { factoryHomePath, factoryVelocityPath } from "../lib/factoryPagePaths";
 import { FactoriesSidebarNav } from "./FactoriesSidebarNav";
 
 function renderNav(path: string) {
@@ -15,8 +15,6 @@ function renderNav(path: string) {
           organizationId={FACTORIES_ORGANIZATION_ID}
           factoryKey={REFUND_FACTORY.key!}
           lineId={REFUND_LINE_PLAN_ID}
-          canOpenSettings
-          permissionsLoading={false}
         />
       </TooltipProvider>
     </MemoryRouter>,
@@ -27,27 +25,20 @@ const org = FACTORIES_ORGANIZATION_ID;
 const key = REFUND_FACTORY.key!;
 
 describe("FactoriesSidebarNav", () => {
-  it("places Board and Settings under the switcher", () => {
+  it("places Board and Velocity under the switcher", () => {
     renderNav(`/${org}/workspaces/${key}/lines/${REFUND_LINE_PLAN_ID}`);
 
     const nav = screen.getByTestId("factories-sidebar-nav");
-    const controls = [
-      screen.getByTestId("factories-nav-board"),
-      screen.getByTestId("factories-nav-velocity"),
-      screen.getByTestId("factories-workspace-settings-link"),
-    ];
+    const controls = [screen.getByTestId("factories-nav-board"), screen.getByTestId("factories-nav-velocity")];
 
-    expect(controls.map((node) => nav.contains(node))).toEqual([true, true, true]);
+    expect(controls.map((node) => nav.contains(node))).toEqual([true, true]);
+    expect(screen.queryByTestId("factories-workspace-settings-link")).not.toBeInTheDocument();
     expect(screen.queryByTestId("factories-sidebar-create-work-order")).not.toBeInTheDocument();
     expect(screen.queryByTestId("factories-nav-intake")).not.toBeInTheDocument();
     expect(screen.queryByTestId("factories-nav-pr-feedback")).not.toBeInTheDocument();
     expect(screen.getByTestId("factories-nav-board")).toHaveAttribute(
       "href",
       factoryHomePath(org, key, REFUND_LINE_PLAN_ID),
-    );
-    expect(screen.getByTestId("factories-workspace-settings-link")).toHaveAttribute(
-      "href",
-      factorySettingsWorkspaceGeneralPath(org, key),
     );
   });
 

--- a/web_src/src/pages/factories/layout/FactoriesSidebarNav.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesSidebarNav.tsx
@@ -1,21 +1,14 @@
 import { cn } from "@/lib/utils";
-import { Gauge, Kanban, Settings } from "lucide-react";
+import { Gauge, Kanban } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Link, useLocation } from "react-router";
-import {
-  factoryHomePath,
-  factorySettingsSectionPath,
-  factorySettingsWorkspaceGeneralPath,
-  factoryVelocityPath,
-} from "../lib/factoryPagePaths";
-import { factoriesRailControlClassName, isBoardPath, isSettingsPath, isVelocityPath } from "./factoriesRail";
+import { factoryHomePath, factoryVelocityPath } from "../lib/factoryPagePaths";
+import { factoriesRailControlClassName, isBoardPath, isVelocityPath } from "./factoriesRail";
 
 interface FactoriesSidebarNavProps {
   organizationId: string;
   factoryKey: string;
   lineId?: string;
-  canOpenSettings: boolean;
-  permissionsLoading: boolean;
 }
 
 function railLinkClassName(isCurrent: boolean) {
@@ -50,37 +43,29 @@ function RailNavLink({
 }
 
 /**
- * Icon rail under the workspace switcher: the line board, the Velocity link,
- * then settings. Intakes and PR feedback open from their listener rows on
- * the board, so they do not need a rail icon.
+ * Icon rail under the workspace switcher: the line board and Velocity.
+ * Workspace settings open from the workspace switcher.
  */
-export function FactoriesSidebarNav({ organizationId, factoryKey, lineId, canOpenSettings }: FactoriesSidebarNavProps) {
+export function FactoriesSidebarNav({ organizationId, factoryKey, lineId }: FactoriesSidebarNavProps) {
   const { pathname } = useLocation();
   const boardHref = factoryHomePath(organizationId, factoryKey, lineId);
   const velocityHref = factoryVelocityPath(organizationId, factoryKey);
-  const settingsHref = canOpenSettings
-    ? factorySettingsWorkspaceGeneralPath(organizationId, factoryKey)
-    : factorySettingsSectionPath(organizationId, factoryKey, "account", "profile");
-  const boardCurrent = isBoardPath(pathname);
-  const velocityCurrent = isVelocityPath(pathname);
-  const settingsCurrent = isSettingsPath(pathname);
 
   return (
     <nav className="flex flex-col items-center gap-1 px-1.5" aria-label="Workspace" data-testid="factories-sidebar-nav">
-      <RailNavLink to={boardHref} label="Board" Icon={Kanban} testId="factories-nav-board" isCurrent={boardCurrent} />
+      <RailNavLink
+        to={boardHref}
+        label="Board"
+        Icon={Kanban}
+        testId="factories-nav-board"
+        isCurrent={isBoardPath(pathname)}
+      />
       <RailNavLink
         to={velocityHref}
         label="Velocity"
         Icon={Gauge}
         testId="factories-nav-velocity"
-        isCurrent={velocityCurrent}
-      />
-      <RailNavLink
-        to={settingsHref}
-        label="Workspace settings"
-        Icon={Settings}
-        testId="factories-workspace-settings-link"
-        isCurrent={settingsCurrent}
+        isCurrent={isVelocityPath(pathname)}
       />
     </nav>
   );

--- a/web_src/src/pages/factories/layout/WorkspacePageHeader.stories.tsx
+++ b/web_src/src/pages/factories/layout/WorkspacePageHeader.stories.tsx
@@ -222,6 +222,7 @@ export const AlignedWithSidebar: Story = {
           factory={REFUND_FACTORY}
           factories={[REFUND_FACTORY, EMPTY_FACTORY, ACME_ONBOARDING_FACTORY]}
           canCreateFactory
+          canOpenSettings
           permissionsLoading={false}
           onCreateFactory={() => console.log("create workspace")}
         />
@@ -229,8 +230,6 @@ export const AlignedWithSidebar: Story = {
           organizationId={FACTORIES_ORGANIZATION_ID}
           factoryKey={REFUND_FACTORY.key!}
           lineId={REFUND_LINE_PLAN_ID}
-          canOpenSettings
-          permissionsLoading={false}
         />
       </aside>
       <div className="min-w-0 flex-1">

--- a/web_src/src/pages/factories/layout/WorkspaceSwitcher.spec.tsx
+++ b/web_src/src/pages/factories/layout/WorkspaceSwitcher.spec.tsx
@@ -18,7 +18,7 @@ function LocationProbe() {
   return <span data-testid="location-path">{`${location.pathname}${location.search}`}</span>;
 }
 
-function renderSwitcher(path = "/") {
+function renderSwitcher(path = "/", { canOpenSettings = true }: { canOpenSettings?: boolean } = {}) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <TooltipProvider>
@@ -32,6 +32,7 @@ function renderSwitcher(path = "/") {
                   factory={REFUND_FACTORY}
                   factories={[REFUND_FACTORY, ACME_ONBOARDING_FACTORY]}
                   canCreateFactory
+                  canOpenSettings={canOpenSettings}
                   permissionsLoading={false}
                   onCreateFactory={() => undefined}
                 />
@@ -57,6 +58,53 @@ describe("WorkspaceSwitcher", () => {
     expect(screen.getByTestId(`factories-workspace-option-${ACME_ONBOARDING_FACTORY.id}`)).toHaveTextContent(
       "Acme onboarding",
     );
+    expect(
+      screen.getByTestId(`factories-workspace-option-${REFUND_FACTORY.id}`).querySelector("svg.lucide-check"),
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId(`factories-workspace-option-${ACME_ONBOARDING_FACTORY.id}`).querySelector("svg.lucide-check"),
+    ).toBeNull();
+    expect(screen.getByTestId("factories-workspace-settings-link")).toHaveAttribute(
+      "href",
+      factorySettingsWorkspaceGeneralPath(FACTORIES_ORGANIZATION_ID, REFUND_FACTORY.key!),
+    );
+    expect(screen.getByTestId(`factories-workspace-settings-${ACME_ONBOARDING_FACTORY.id}`)).toHaveAttribute(
+      "href",
+      factorySettingsWorkspaceGeneralPath(FACTORIES_ORGANIZATION_ID, ACME_ONBOARDING_FACTORY.key!),
+    );
+  });
+
+  it("opens workspace settings from the cog without switching the board", async () => {
+    const user = userEvent.setup();
+    renderSwitcher(`/${FACTORIES_ORGANIZATION_ID}/workspaces/${REFUND_FACTORY.key}/lines/line-plan`);
+
+    await user.click(screen.getByTestId("factories-workspace-switch"));
+    await user.click(screen.getByTestId("factories-workspace-settings-link"));
+
+    expect(screen.getByTestId("location-path")).toHaveTextContent(
+      factorySettingsWorkspaceGeneralPath(FACTORIES_ORGANIZATION_ID, REFUND_FACTORY.key!),
+    );
+  });
+
+  it("opens settings for another workspace from its cog", async () => {
+    const user = userEvent.setup();
+    renderSwitcher();
+
+    await user.click(screen.getByTestId("factories-workspace-switch"));
+    await user.click(screen.getByTestId(`factories-workspace-settings-${ACME_ONBOARDING_FACTORY.id}`));
+
+    expect(screen.getByTestId("location-path")).toHaveTextContent(
+      factorySettingsWorkspaceGeneralPath(FACTORIES_ORGANIZATION_ID, ACME_ONBOARDING_FACTORY.key!),
+    );
+  });
+
+  it("hides workspace settings cogs when the user cannot open them", async () => {
+    const user = userEvent.setup();
+    renderSwitcher("/", { canOpenSettings: false });
+
+    await user.click(screen.getByTestId("factories-workspace-switch"));
+    expect(screen.queryByTestId("factories-workspace-settings-link")).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`factories-workspace-settings-${ACME_ONBOARDING_FACTORY.id}`)).not.toBeInTheDocument();
   });
 
   it("opens the other workspace on its line board without intake query", async () => {

--- a/web_src/src/pages/factories/layout/WorkspaceSwitcher.stories.tsx
+++ b/web_src/src/pages/factories/layout/WorkspaceSwitcher.stories.tsx
@@ -41,6 +41,7 @@ export const Default: Story = {
     factory: REFUND_FACTORY,
     factories: [REFUND_FACTORY, EMPTY_FACTORY, ACME_ONBOARDING_FACTORY],
     canCreateFactory: true,
+    canOpenSettings: true,
     permissionsLoading: false,
     onCreateFactory: () => console.log("create workspace"),
   },

--- a/web_src/src/pages/factories/layout/WorkspaceSwitcher.tsx
+++ b/web_src/src/pages/factories/layout/WorkspaceSwitcher.tsx
@@ -9,9 +9,9 @@ import {
   DropdownMenuTrigger,
 } from "@/ui/dropdownMenu";
 import { cn } from "@/lib/utils";
-import { Check, Plus, Triangle } from "lucide-react";
-import { useLocation, useNavigate } from "react-router";
-import { pathAfterWorkspaceSwitch } from "../lib/factoryPagePaths";
+import { Check, Plus, Settings, Triangle } from "lucide-react";
+import { Link, useLocation, useNavigate } from "react-router";
+import { factorySettingsWorkspaceGeneralPath, pathAfterWorkspaceSwitch } from "../lib/factoryPagePaths";
 import { factoriesRailControlClassName, initialsForName } from "./factoriesRail";
 
 interface WorkspaceSwitcherProps {
@@ -19,6 +19,7 @@ interface WorkspaceSwitcherProps {
   factory: FactoriesFactory;
   factories: FactoriesFactory[];
   canCreateFactory: boolean;
+  canOpenSettings: boolean;
   permissionsLoading: boolean;
   onCreateFactory: () => void;
 }
@@ -28,6 +29,7 @@ export function WorkspaceSwitcher({
   factory,
   factories,
   canCreateFactory,
+  canOpenSettings,
   permissionsLoading,
   onCreateFactory,
 }: WorkspaceSwitcherProps) {
@@ -53,34 +55,31 @@ export function WorkspaceSwitcher({
             {initialsForName(workspaceName)}
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" side="right" className="w-64">
+        <DropdownMenuContent align="start" side="right" className="w-72">
           <DropdownMenuLabel>Switch workspace</DropdownMenuLabel>
-          {factories.map((entry) => {
-            const isCurrent = entry.id === factory.id;
-            return (
-              <DropdownMenuItem
-                key={entry.id}
-                onClick={() => {
-                  if (isCurrent || !entry.key || !currentFactoryKey) {
-                    return;
-                  }
-                  navigate(
-                    pathAfterWorkspaceSwitch({
-                      pathname,
-                      organizationId,
-                      currentFactoryKey,
-                      nextFactory: entry,
-                    }),
-                  );
-                }}
-                data-testid={`factories-workspace-option-${entry.id}`}
-              >
-                <Triangle className="h-3.5 w-3.5" aria-hidden />
-                <span className="truncate">{entry.name}</span>
-                {isCurrent ? <Check className="ml-auto h-3.5 w-3.5" aria-hidden /> : null}
-              </DropdownMenuItem>
-            );
-          })}
+          {factories.map((entry) => (
+            <WorkspaceSwitcherRow
+              key={entry.id}
+              organizationId={organizationId}
+              entry={entry}
+              isCurrent={entry.id === factory.id}
+              currentFactoryKey={currentFactoryKey}
+              canOpenSettings={canOpenSettings}
+              onSwitch={(next) => {
+                if (!currentFactoryKey || !next.key) {
+                  return;
+                }
+                navigate(
+                  pathAfterWorkspaceSwitch({
+                    pathname,
+                    organizationId,
+                    currentFactoryKey,
+                    nextFactory: next,
+                  }),
+                );
+              }}
+            />
+          ))}
           <DropdownMenuSeparator />
           <PermissionTooltip
             allowed={canCreateFactory || permissionsLoading}
@@ -101,6 +100,55 @@ export function WorkspaceSwitcher({
           </PermissionTooltip>
         </DropdownMenuContent>
       </DropdownMenu>
+    </div>
+  );
+}
+
+function WorkspaceSwitcherRow({
+  organizationId,
+  entry,
+  isCurrent,
+  currentFactoryKey,
+  canOpenSettings,
+  onSwitch,
+}: {
+  organizationId: string;
+  entry: FactoriesFactory;
+  isCurrent: boolean;
+  currentFactoryKey?: string;
+  canOpenSettings: boolean;
+  onSwitch: (next: FactoriesFactory) => void;
+}) {
+  const settingsHref = entry.key ? factorySettingsWorkspaceGeneralPath(organizationId, entry.key) : undefined;
+
+  return (
+    <div className="flex items-center gap-0.5">
+      <DropdownMenuItem
+        className="min-w-0 flex-1"
+        onClick={() => {
+          if (isCurrent || !entry.key || !currentFactoryKey) {
+            return;
+          }
+          onSwitch(entry);
+        }}
+        data-testid={`factories-workspace-option-${entry.id}`}
+        aria-current={isCurrent ? "true" : undefined}
+      >
+        <Triangle className="h-3.5 w-3.5" aria-hidden />
+        <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+        {isCurrent ? <Check className="h-3.5 w-3.5 shrink-0" aria-hidden /> : null}
+      </DropdownMenuItem>
+      {canOpenSettings && settingsHref ? (
+        <Link
+          to={settingsHref}
+          aria-label={isCurrent ? "Workspace settings" : `Workspace settings, ${entry.name}`}
+          title="Workspace settings"
+          data-testid={isCurrent ? "factories-workspace-settings-link" : `factories-workspace-settings-${entry.id}`}
+          className="mr-1 flex size-7 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <Settings className="size-3.5" aria-hidden />
+        </Link>
+      ) : null}
     </div>
   );
 }

--- a/web_src/src/pages/factories/layout/factoriesRail.ts
+++ b/web_src/src/pages/factories/layout/factoriesRail.ts
@@ -11,10 +11,6 @@ export function isVelocityPath(pathname: string): boolean {
   return pathname.includes("/velocity");
 }
 
-export function isSettingsPath(pathname: string): boolean {
-  return pathname.includes("/settings");
-}
-
 /** One or two letters from a display name, for the icon rail. */
 export function initialsForName(name: string): string {
   return getNameInitials(name) || "?";

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.spec.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.spec.tsx
@@ -29,7 +29,7 @@ describe("FactorySettingsLayout sidebar", () => {
     const sidebar = await screen.findByTestId("factory-settings-sidebar", {}, { timeout: 8000 });
     expect(screen.getByTestId("factory-settings-main").className).toMatch(/overflow-y-auto/);
     expect(screen.getByTestId("factories-sidebar")).toBeInTheDocument();
-    expect(screen.getByTestId("factories-workspace-settings-link")).toHaveAttribute("aria-current", "page");
+    expect(screen.queryByTestId("factories-workspace-settings-link")).not.toBeInTheDocument();
     expect(within(sidebar).queryByTestId("factory-settings-back")).not.toBeInTheDocument();
     expect(within(sidebar).getByTestId("factory-settings-account-nav")).toHaveTextContent("Account");
     expect(within(sidebar).getByTestId("factory-settings-find")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

The rail cog made settings look like a primary destination next to Board and Velocity.
Settings belong with the workspace they apply to.
This change moves the settings control into the workspace switcher.
Each row shows a check mark for the current workspace and a settings control.

## Test plan

- [ ] Open the workspace switcher on a factory board.
- [ ] Confirm the rail shows Board and Velocity only.
- [ ] Confirm the current workspace has a check mark and a settings control.
- [ ] Open settings from the current workspace cog.
- [ ] Open settings from another workspace cog.
- [ ] Confirm a user without update permission does not see the settings controls.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62076692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/superplane/-/pull-requests/superplanehq/superplane/7305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a></h2>

The PR needs the workspace settings controls integrated into the dropdown's keyboard-managed item model before merging.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Settings links bypass menu focus** <a href="https://github.com/superplanehq/superplane/pull/7305#discussion_r3968104613">▶</a>

<!-- /greptile_comment -->