### PR TITLE
fix: Soften Hosted Credit Banner Colors

### DIFF
--- a/web_src/src/pages/factories/HostedCreditEmptyBanner.spec.tsx
+++ b/web_src/src/pages/factories/HostedCreditEmptyBanner.spec.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router";
 import { describe, expect, it } from "vitest";
 
 import { HostedCreditEmptyBanner } from "./HostedCreditEmptyBanner";
+import { HOSTED_CREDIT_RUNS_STOP_HINT } from "./lib/hostedCreditEmpty";
 
 const billingHref = "/org/workspaces/RF/settings/organization/billing";
 
@@ -59,7 +60,28 @@ describe("HostedCreditEmptyBanner", () => {
     expect(banner).toHaveTextContent("$41.24 remaining");
     expect(banner).toHaveTextContent("14 days remaining");
     expect(banner).toHaveAttribute("data-tone", "info");
+    expect(banner).not.toHaveTextContent(HOSTED_CREDIT_RUNS_STOP_HINT);
     expect(screen.getByRole("link", { name: "Add credits" })).toHaveAttribute("href", billingHref);
+  });
+
+  it("warns that tasks stop when remaining trial credit is low", () => {
+    render(
+      <MemoryRouter>
+        <HostedCreditEmptyBanner
+          billingEnabled
+          kind="trial"
+          remainingCreditCents={432}
+          welcomeCreditExpiresAt={new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString()}
+          spendingHref={billingHref}
+        />
+      </MemoryRouter>,
+    );
+
+    const banner = screen.getByTestId("hosted-credit-empty-banner");
+    expect(banner).toHaveTextContent("Trial");
+    expect(banner).toHaveTextContent("$4.32 remaining");
+    expect(banner).toHaveTextContent(HOSTED_CREDIT_RUNS_STOP_HINT);
+    expect(banner).toHaveAttribute("data-tone", "warning");
   });
 
   it("warns when the trial expires today", () => {
@@ -111,6 +133,7 @@ describe("HostedCreditEmptyBanner", () => {
     const banner = screen.getByTestId("hosted-credit-empty-banner");
     expect(banner).toHaveTextContent("Hosted credit is low");
     expect(banner).toHaveTextContent("$15.00 remaining");
+    expect(banner).toHaveTextContent(HOSTED_CREDIT_RUNS_STOP_HINT);
     expect(banner).toHaveAttribute("data-tone", "warning");
     expect(screen.getByRole("link", { name: "Add credits" })).toHaveAttribute("href", billingHref);
   });

--- a/web_src/src/pages/factories/HostedCreditEmptyBanner.stories.tsx
+++ b/web_src/src/pages/factories/HostedCreditEmptyBanner.stories.tsx
@@ -6,9 +6,10 @@ import { HostedCreditEmptyBanner } from "./HostedCreditEmptyBanner";
 
 /**
  * Status banner for hosted credit. A healthy trial uses quiet chrome.
- * Low, empty, or expired credit uses an amber warning. Tasks and the
- * workspace board show this in the page header. The action opens
- * Organization Billing.
+ * Low remaining credit keeps the same surface and adds a short stop hint.
+ * Empty or expired credit uses a waiting accent, not a full amber wash.
+ * Tasks and the workspace board show this in the page header. The action
+ * opens Organization Billing.
  */
 const meta = {
   title: "Factories/Components/HostedCreditEmptyBanner",
@@ -54,7 +55,7 @@ export const Trial: Story = {
   },
 };
 
-/** Welcome credit expires today. The banner uses warning chrome. */
+/** Welcome credit expires today. The banner uses a waiting accent. */
 export const TrialEndsToday: Story = {
   name: "Trial ends today",
   args: {
@@ -62,6 +63,17 @@ export const TrialEndsToday: Story = {
     kind: "trial",
     remainingCreditCents: 4124,
     welcomeCreditExpiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+  },
+};
+
+/** Welcome credit is low. The banner names that tasks stop when credit runs out. */
+export const TrialLowCredit: Story = {
+  name: "Trial low credit",
+  args: {
+    billingEnabled: true,
+    kind: "trial",
+    remainingCreditCents: 432,
+    welcomeCreditExpiresAt: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString(),
   },
 };
 

--- a/web_src/src/pages/factories/HostedCreditEmptyBanner.tsx
+++ b/web_src/src/pages/factories/HostedCreditEmptyBanner.tsx
@@ -22,6 +22,16 @@ interface HostedCreditEmptyBannerProps {
   welcomeCreditExpiresAt?: string;
 }
 
+const BANNER_TONE_CLASS = {
+  info: "border-border bg-muted/40 text-foreground",
+  warning: "border-border bg-muted/40 text-foreground shadow-[inset_3px_0_0_0_var(--status-waiting-dot)]",
+} as const;
+
+const BANNER_ICON_CLASS = {
+  info: "text-muted-foreground",
+  warning: "text-[color:var(--status-waiting-fg)]",
+} as const;
+
 export function HostedCreditEmptyBanner({
   billingEnabled,
   spendingHref,
@@ -38,6 +48,7 @@ export function HostedCreditEmptyBanner({
   });
   const isWarning = copy.tone === "warning";
   const Icon = isWarning ? TriangleAlert : Sparkles;
+  const hasHint = Boolean(copy.consequenceHint);
 
   return (
     <div
@@ -46,23 +57,18 @@ export function HostedCreditEmptyBanner({
       data-tone={copy.tone}
       className={cn(
         "flex w-full flex-wrap items-center justify-between gap-3 rounded-lg border px-3.5 py-2 text-sm",
-        isWarning
-          ? "border-amber-200 bg-amber-50/90 text-amber-950 dark:border-amber-700/50 dark:bg-amber-950/30 dark:text-amber-100"
-          : "border-border bg-muted/40 text-foreground",
+        BANNER_TONE_CLASS[copy.tone],
         className,
       )}
     >
-      <div className="flex min-w-0 items-center gap-2.5">
-        <Icon
-          className={cn("h-4 w-4 shrink-0", isWarning ? "text-amber-700 dark:text-amber-300" : "text-muted-foreground")}
-          aria-hidden
-        />
+      <div className={cn("flex min-w-0 gap-2.5", hasHint ? "items-start" : "items-center")}>
+        <Icon className={cn("h-4 w-4 shrink-0", hasHint && "mt-0.5", BANNER_ICON_CLASS[copy.tone])} aria-hidden />
         {copy.remainingLabel ? (
           <TrialCreditSummary
             title={copy.title}
             remainingLabel={copy.remainingLabel}
             expiryLabel={copy.expiryLabel}
-            isWarning={isWarning}
+            consequenceHint={copy.consequenceHint}
           />
         ) : (
           <p>
@@ -71,16 +77,7 @@ export function HostedCreditEmptyBanner({
           </p>
         )}
       </div>
-      <Button
-        asChild
-        variant="outline"
-        size="sm"
-        className={
-          isWarning
-            ? "border-amber-300 bg-amber-100/70 text-amber-950 hover:bg-amber-100 dark:border-amber-600 dark:bg-amber-900/40 dark:text-amber-50 dark:hover:bg-amber-900/60"
-            : undefined
-        }
-      >
+      <Button asChild variant="outline" size="sm">
         <Link to={spendingHref}>{copy.actionLabel}</Link>
       </Button>
     </div>
@@ -91,38 +88,32 @@ function TrialCreditSummary({
   title,
   remainingLabel,
   expiryLabel,
-  isWarning,
+  consequenceHint,
 }: {
   title: string;
   remainingLabel: string;
   expiryLabel?: string;
-  isWarning: boolean;
+  consequenceHint?: string;
 }) {
-  const mutedClass = isWarning ? "text-amber-900/80 dark:text-amber-100/80" : "text-muted-foreground";
   return (
-    <div className="flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1">
-      <Badge
-        variant="outline"
-        className={cn(
-          "font-medium",
-          isWarning
-            ? "border-amber-300/80 bg-amber-100/50 text-amber-950 dark:border-amber-600 dark:bg-amber-900/40 dark:text-amber-50"
-            : "text-muted-foreground",
-        )}
-      >
-        {title}
-      </Badge>
-      <p className="flex min-w-0 flex-wrap items-baseline gap-x-2 text-sm">
-        <span className="font-medium tabular-nums">{remainingLabel}</span>
-        {expiryLabel ? (
-          <>
-            <span className={cn("select-none", mutedClass)} aria-hidden>
-              ·
-            </span>
-            <span className={mutedClass}>{expiryLabel}</span>
-          </>
-        ) : null}
-      </p>
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1">
+        <Badge variant="outline" className="font-medium text-muted-foreground">
+          {title}
+        </Badge>
+        <p className="flex min-w-0 flex-wrap items-baseline gap-x-2 text-sm">
+          <span className="font-medium tabular-nums">{remainingLabel}</span>
+          {expiryLabel ? (
+            <>
+              <span className="select-none text-muted-foreground" aria-hidden>
+                ·
+              </span>
+              <span className="text-muted-foreground">{expiryLabel}</span>
+            </>
+          ) : null}
+        </p>
+      </div>
+      {consequenceHint ? <p className="text-xs text-muted-foreground">{consequenceHint}</p> : null}
     </div>
   );
 }

--- a/web_src/src/pages/factories/__fixtures__/usageReportFixtures.ts
+++ b/web_src/src/pages/factories/__fixtures__/usageReportFixtures.ts
@@ -95,6 +95,14 @@ export const SPENT_CREDIT_USAGE_REPORT: StorybookUsageReport = {
   hasBillingCustomer: true,
 };
 
+/** Welcome credit remains, but the balance is at or below $20. */
+export const LOW_TRIAL_USAGE_REPORT: StorybookUsageReport = {
+  ...DEFAULT_FACTORY_USAGE,
+  remainingCreditCents: "432",
+  hostedBilledCents: "4568",
+  remainingCreditWarning: true,
+};
+
 export const EXPIRED_WELCOME_USAGE_REPORT: StorybookUsageReport = {
   ...SPENT_CREDIT_USAGE_REPORT,
   welcomeCreditExpiresAt: "2026-08-15T12:00:00.000Z",

--- a/web_src/src/pages/factories/lib/hostedCreditEmpty.spec.ts
+++ b/web_src/src/pages/factories/lib/hostedCreditEmpty.spec.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  HOSTED_CREDIT_RUNS_STOP_HINT,
   hostedCreditBannerCopy,
   hostedCreditBannerKind,
   hostedCreditBannerTone,
   hostedCreditBillingBalanceCopy,
   hostedCreditEmptyBannerCopy,
+  hostedCreditRunsStopHint,
   isHostedCreditTrialOrg,
+  isLowHostedCreditRemaining,
   shouldShowHostedCreditEmptyBanner,
   welcomeCreditExpiryLabel,
   welcomeCreditExpirySentence,
@@ -310,6 +313,24 @@ describe("hostedCreditBannerTone", () => {
   });
 });
 
+describe("isLowHostedCreditRemaining", () => {
+  it("is true at or below $20 while credit remains", () => {
+    expect(isLowHostedCreditRemaining(2000)).toBe(true);
+    expect(isLowHostedCreditRemaining(432)).toBe(true);
+    expect(isLowHostedCreditRemaining(2001)).toBe(false);
+    expect(isLowHostedCreditRemaining(0)).toBe(false);
+    expect(isLowHostedCreditRemaining(undefined)).toBe(false);
+  });
+});
+
+describe("hostedCreditRunsStopHint", () => {
+  it("names the stop outcome only while remaining credit is low", () => {
+    expect(hostedCreditRunsStopHint(432)).toBe(HOSTED_CREDIT_RUNS_STOP_HINT);
+    expect(hostedCreditRunsStopHint(4124)).toBeUndefined();
+    expect(hostedCreditRunsStopHint(0)).toBeUndefined();
+  });
+});
+
 describe("hostedCreditBannerCopy", () => {
   it("names remaining trial credit and the expiry window", () => {
     expect(
@@ -327,6 +348,26 @@ describe("hostedCreditBannerCopy", () => {
       expiryLabel: "14 days remaining",
       actionLabel: "Add credits",
       tone: "info",
+    });
+  });
+
+  it("tells the user that tasks stop when trial credit is low", () => {
+    expect(
+      hostedCreditBannerCopy({
+        kind: "trial",
+        billingEnabled: true,
+        remainingCreditCents: 432,
+        welcomeCreditExpiresAt: new Date(inFourteenDays),
+        now,
+      }),
+    ).toEqual({
+      title: "Trial",
+      description: "You have $4.32 of free hosted credit. It expires in 14 days.",
+      remainingLabel: "$4.32 remaining",
+      expiryLabel: "14 days remaining",
+      consequenceHint: HOSTED_CREDIT_RUNS_STOP_HINT,
+      actionLabel: "Add credits",
+      tone: "warning",
     });
   });
 
@@ -359,6 +400,7 @@ describe("hostedCreditBannerCopy", () => {
       title: "Hosted credit is low",
       description: "Less than $20.00 remains. Add hosted credit to keep SuperPlane-hosted runs.",
       remainingLabel: "$15.00 remaining",
+      consequenceHint: HOSTED_CREDIT_RUNS_STOP_HINT,
       actionLabel: "Add credits",
       tone: "warning",
     });
@@ -369,6 +411,7 @@ describe("hostedCreditBannerCopy", () => {
       title: "Hosted credit is low",
       description: "Less than $20.00 remains. Ask an installation admin to add hosted credit.",
       remainingLabel: "$15.00 remaining",
+      consequenceHint: HOSTED_CREDIT_RUNS_STOP_HINT,
       actionLabel: "Add credits",
       tone: "warning",
     });

--- a/web_src/src/pages/factories/lib/hostedCreditEmpty.ts
+++ b/web_src/src/pages/factories/lib/hostedCreditEmpty.ts
@@ -5,6 +5,20 @@ export type HostedCreditBannerKind = "trial" | "trial-empty" | "trial-expired" |
 /** At or below this remaining balance, paid organizations see a low-credit warning. */
 export const LOW_HOSTED_CREDIT_THRESHOLD_CENTS = 2000;
 
+/** Compact helper shown next to remaining credit when the balance is low. */
+export const HOSTED_CREDIT_RUNS_STOP_HINT = "Tasks stop when credit runs out.";
+
+export function isLowHostedCreditRemaining(remainingCents: number | undefined): boolean {
+  return remainingCents != null && remainingCents > 0 && remainingCents <= LOW_HOSTED_CREDIT_THRESHOLD_CENTS;
+}
+
+export function hostedCreditRunsStopHint(remainingCents: number | undefined): string | undefined {
+  if (!isLowHostedCreditRemaining(remainingCents)) {
+    return undefined;
+  }
+  return HOSTED_CREDIT_RUNS_STOP_HINT;
+}
+
 export interface HostedCreditBannerInput {
   remainingCreditCents?: string | number;
   grantTotalCents?: string | number;
@@ -88,6 +102,7 @@ export interface HostedCreditBannerCopy {
   actionLabel: string;
   remainingLabel?: string;
   expiryLabel?: string;
+  consequenceHint?: string;
   tone: HostedCreditBannerTone;
 }
 
@@ -163,14 +178,17 @@ export function hostedCreditBannerCopy(args: {
     const expiryLabel = args.welcomeCreditExpiresAt
       ? welcomeCreditExpiryLabel(args.welcomeCreditExpiresAt, now)
       : "14 days remaining";
-    return {
-      title: "Trial",
-      description: `You have ${remaining} of free hosted credit. ${expirySentence}`,
-      remainingLabel: `${remaining} remaining`,
-      expiryLabel,
-      actionLabel: "Add credits",
-      tone,
-    };
+    return withRunsStopHint(
+      {
+        title: "Trial",
+        description: `You have ${remaining} of free hosted credit. ${expirySentence}`,
+        remainingLabel: `${remaining} remaining`,
+        expiryLabel,
+        actionLabel: "Add credits",
+        tone,
+      },
+      args.remainingCreditCents,
+    );
   }
 
   if (args.kind === "trial-empty") {
@@ -198,21 +216,27 @@ export function hostedCreditBannerCopy(args: {
         ? `${formatUsdCents(args.remainingCreditCents)} remaining`
         : undefined;
     if (args.billingEnabled) {
-      return {
+      return withRunsStopHint(
+        {
+          title: "Hosted credit is low",
+          description: `Less than ${lowCreditBudget} remains. Add hosted credit to keep SuperPlane-hosted runs.`,
+          remainingLabel,
+          actionLabel: "Add credits",
+          tone,
+        },
+        args.remainingCreditCents,
+      );
+    }
+    return withRunsStopHint(
+      {
         title: "Hosted credit is low",
-        description: `Less than ${lowCreditBudget} remains. Add hosted credit to keep SuperPlane-hosted runs.`,
+        description: `Less than ${lowCreditBudget} remains. Ask an installation admin to add hosted credit.`,
         remainingLabel,
         actionLabel: "Add credits",
         tone,
-      };
-    }
-    return {
-      title: "Hosted credit is low",
-      description: `Less than ${lowCreditBudget} remains. Ask an installation admin to add hosted credit.`,
-      remainingLabel,
-      actionLabel: "Add credits",
-      tone,
-    };
+      },
+      args.remainingCreditCents,
+    );
   }
 
   if (args.billingEnabled) {
@@ -309,4 +333,12 @@ function emptyHostedCreditDescription(billingEnabled: boolean): string {
     return "Hosted credit is empty. Click Buy more to purchase hosted credit.";
   }
   return "Hosted credit is empty. SuperPlane-hosted runs cannot start until an installation admin adds credit.";
+}
+
+function withRunsStopHint(copy: HostedCreditBannerCopy, remainingCents: number | undefined): HostedCreditBannerCopy {
+  const consequenceHint = hostedCreditRunsStopHint(remainingCents);
+  if (!consequenceHint) {
+    return copy;
+  }
+  return { ...copy, consequenceHint };
 }

--- a/web_src/src/pages/factories/pages/LinesPage.hostedCreditBanner.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.hostedCreditBanner.spec.tsx
@@ -14,6 +14,7 @@ import {
   PURCHASED_CREDIT_USAGE_REPORT,
   SPENT_CREDIT_USAGE_REPORT,
 } from "../__fixtures__/usageReportFixtures";
+import { HOSTED_CREDIT_RUNS_STOP_HINT } from "../lib/hostedCreditEmpty";
 
 describe("LinesPage hosted credit banner", () => {
   beforeAll(() => {
@@ -69,6 +70,7 @@ describe("LinesPage hosted credit banner", () => {
     const banner = await screen.findByTestId("hosted-credit-empty-banner", {}, { timeout: 8000 });
     expect(banner).toHaveTextContent("Hosted credit is low");
     expect(banner).toHaveTextContent("$15.00 remaining");
+    expect(banner).toHaveTextContent(HOSTED_CREDIT_RUNS_STOP_HINT);
     expect(banner).toHaveAttribute("data-tone", "warning");
     expect(screen.getByRole("link", { name: "Add credits" })).toHaveAttribute(
       "href",

--- a/web_src/src/pages/factories/pages/WorkOrdersPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrdersPage.spec.tsx
@@ -11,10 +11,12 @@ import {
 } from "../__fixtures__/factoryPageResponses";
 import {
   EXPIRED_WELCOME_USAGE_REPORT,
+  LOW_TRIAL_USAGE_REPORT,
   PURCHASED_CREDIT_USAGE_REPORT,
   SPENT_CREDIT_USAGE_REPORT,
 } from "../__fixtures__/usageReportFixtures";
 import { factorySettingsSectionPath } from "../lib/factoryPagePaths";
+import { HOSTED_CREDIT_RUNS_STOP_HINT } from "../lib/hostedCreditEmpty";
 import { WorkOrdersPage } from "./WorkOrdersPage";
 
 describe("WorkOrdersPage hosted credit banner", () => {
@@ -33,10 +35,29 @@ describe("WorkOrdersPage hosted credit banner", () => {
     const banner = await screen.findByTestId("hosted-credit-empty-banner", {}, { timeout: 8000 });
     expect(banner).toHaveTextContent("Trial");
     expect(banner).toHaveTextContent("$41.24");
+    expect(banner).not.toHaveTextContent(HOSTED_CREDIT_RUNS_STOP_HINT);
     expect(screen.getByRole("link", { name: "Add credits" })).toHaveAttribute(
       "href",
       factorySettingsSectionPath(FACTORIES_ORGANIZATION_ID, PRIMARY_FACTORY_KEY, "organization", "billing"),
     );
+  }, 10000);
+
+  it("tells the user that tasks stop when remaining trial credit is low", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/work-orders`}
+        factoriesFixture={{
+          ...defaultFactoriesFixture,
+          organizationWorkspaceUsage: LOW_TRIAL_USAGE_REPORT,
+        }}
+      />,
+    );
+
+    const banner = await screen.findByTestId("hosted-credit-empty-banner", {}, { timeout: 8000 });
+    expect(banner).toHaveTextContent("Trial");
+    expect(banner).toHaveTextContent("$4.32 remaining");
+    expect(banner).toHaveTextContent(HOSTED_CREDIT_RUNS_STOP_HINT);
+    expect(banner).toHaveAttribute("data-tone", "warning");
   }, 10000);
 
   it("hides the trial banner after the organization buys credit", async () => {

--- a/web_src/src/pages/factories/pages/organizationSettings/HostedCreditEmpty.stories.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/HostedCreditEmpty.stories.tsx
@@ -4,6 +4,7 @@ import { FactoriesHarness } from "../../__fixtures__/FactoriesHarness";
 import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../../__fixtures__/factoryPageResponses";
 import {
   EXPIRED_WELCOME_USAGE_REPORT,
+  LOW_TRIAL_USAGE_REPORT,
   SPENT_CREDIT_USAGE_REPORT,
   STORYBOOK_HOSTED_CREDIT_PRODUCTS,
 } from "../../__fixtures__/usageReportFixtures";
@@ -47,6 +48,23 @@ export const Trial: Story = {
       <FactoriesHarness
         pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/work-orders`}
         factoriesFixture={defaultFactoriesFixture}
+      />
+    );
+  },
+};
+
+/** Tasks list when remaining trial credit is low. The banner names the stop outcome. */
+export const TrialLowCredit: Story = {
+  name: "Trial low credit",
+  render: () => {
+    window.localStorage.setItem("sp:work-orders:layout", "board");
+    return (
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/work-orders`}
+        factoriesFixture={{
+          ...defaultFactoriesFixture,
+          organizationWorkspaceUsage: LOW_TRIAL_USAGE_REPORT,
+        }}
       />
     );
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The hosted credit banner used a full amber wash on the dark factories board. That color clashed with the page and made the remaining balance hard to read.

This change keeps the board surface and a waiting accent on the icon and left edge. When remaining credit is at or below $20, the banner also names the outcome: tasks stop when credit runs out.

Palette references: [Vercel usage](https://mobbin.com/screens/5bb75d66-7572-4f2e-a229-ebc54627343b), [Grok credits missing](https://mobbin.com/screens/911ffa0a-6916-44e3-a06e-a513195676c1), [Dialpad info banner](https://mobbin.com/screens/a6065cb2-e6bc-4042-afdb-3004f52e0f07).

## Test plan

- [ ] Open Tasks on a trial organization with more than $20 remaining. Confirm the quiet Trial banner has no stop hint.
- [ ] Open Tasks with remaining credit at or below $20. Confirm the banner shows "Tasks stop when credit runs out."
- [ ] Confirm the warning banner uses the board surface, not a full amber fill.
- [ ] Open Tasks after credit is empty. Confirm the empty-credit copy still appears.
- [ ] Click Add credits and confirm it opens Organization Billing.

[Low trial credit banner with stop hint](https://cursor.com/agents/bc-7d337e90-f246-4b25-9eb3-287e1a5444b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbanner_trial_low_credit_board.webp)
[Healthy trial banner without stop hint](https://cursor.com/agents/bc-7d337e90-f246-4b25-9eb3-287e1a5444b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbanner_trial_healthy_board.webp)
[hosted_credit_banner_dark_board.mp4](https://cursor.com/agents/bc-7d337e90-f246-4b25-9eb3-287e1a5444b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhosted_credit_banner_dark_board.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d337e90-f246-4b25-9eb3-287e1a5444b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d337e90-f246-4b25-9eb3-287e1a5444b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62086015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/superplane/-/pull-requests/superplanehq/superplane/7307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge with no actionable defects identified.

<!-- /greptile_comment -->