### PR TITLE
feat: Refocus the Task Footer on Pull Request Review

### DIFF
--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.spec.tsx
@@ -272,12 +272,11 @@ describe("Line board job popup", () => {
 
     await user.click(screen.getByRole("button", { name: "Open Ship idempotent refund retries" }));
     dialog = await screen.findByTestId("work-order-split-run");
-    expect(within(dialog).getByRole("heading", { name: "Waiting for user review" })).toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "The pull request is ready for review" })).toBeInTheDocument();
     expect(within(dialog).getByRole("link", { name: "Review PR #6812" })).toBeInTheDocument();
     const waitingNote = within(dialog).getByTestId("split-run-attention-note");
-    expect(within(waitingNote).getByRole("button", { name: "To Backlog" })).toBeInTheDocument();
-    expect(within(waitingNote).getByRole("button", { name: "Reject" })).toBeInTheDocument();
-    expect(within(waitingNote).getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(within(waitingNote).getByRole("button", { name: "More actions" })).toBeInTheDocument();
+    expect(within(waitingNote).queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: "Open full screen" })).toBeInTheDocument();
     expect(within(dialog).queryByRole("button", { name: "Stop and Close" })).not.toBeInTheDocument();
     expect(within(dialog).queryByRole("button", { name: /Update manually/ })).not.toBeInTheDocument();

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunAttentionNote.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunAttentionNote.tsx
@@ -20,6 +20,8 @@ import { MarkdownContent } from "@/pages/app/Markdown";
 import { WorkOrderPersonMention } from "@/pages/app/markdownMentions";
 
 import type { SplitRunDecisionTone, SplitRunFooterAction, SplitRunFooterNote } from "./splitRunFooter";
+import { SplitRunPullRequestReviewNote } from "./SplitRunPullRequestReviewNote";
+import { pullRequestReviewNote } from "./splitRunPullRequestReview";
 
 const TONE = {
   draft: {
@@ -56,7 +58,8 @@ const TONE = {
 
 /**
  * Sticky decision note. Actions sit beside the copy. No Update manually,
- * no source time.
+ * no source time. A waiting note that links to a pull request renders as
+ * the pull-request review strip instead.
  */
 function StoppedHeadline({ note }: { note: SplitRunFooterNote }) {
   if (!note.actor) {
@@ -91,6 +94,19 @@ export function SplitRunAttentionNote({
   modelSelect?: ReactNode;
   onAction?: (action: SplitRunFooterAction) => void;
 }) {
+  const pullRequest = tone === "waiting" && note.cta ? pullRequestReviewNote(note) : undefined;
+  if (pullRequest && note.cta) {
+    return (
+      <SplitRunPullRequestReviewNote
+        ctaLabel={note.cta.label}
+        pullRequest={pullRequest}
+        actions={actions}
+        actionBusy={actionBusy}
+        onAction={onAction}
+      />
+    );
+  }
+
   const visual = TONE[tone];
   const Icon = actions.some((action) => action.kind === "reopen") ? RotateCcw : visual.Icon;
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunPullRequestReviewNote.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunPullRequestReviewNote.spec.tsx
@@ -1,0 +1,119 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+import { SplitRunAttentionNote } from "./SplitRunAttentionNote";
+import type { SplitRunFooterAction, SplitRunFooterNote } from "./splitRunFooter";
+
+const PR_NOTE: SplitRunFooterNote = {
+  headline: "Waiting for user review",
+  text: "The pull request is open and waiting for user review. Mention @superplaneagent in a pull request comment or review to request changes.",
+  cta: { label: "Review PR #6812", href: "https://github.com/acme/payments/pull/6812" },
+};
+
+const ACTIONS: SplitRunFooterAction[] = [
+  { id: "back-to-draft", kind: "back-to-draft", label: "To Backlog", emphasis: "quiet", icon: "undo-2" },
+  { id: "reject", kind: "reject", label: "Reject", emphasis: "quiet" },
+  { id: "approve", kind: "approve", label: "Approve", emphasis: "primary" },
+];
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+function renderNote(props: Partial<Parameters<typeof SplitRunAttentionNote>[0]> = {}) {
+  return render(
+    <MemoryRouter>
+      <TooltipProvider>
+        <SplitRunAttentionNote note={PR_NOTE} tone="waiting" actions={ACTIONS} {...props} />
+      </TooltipProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("SplitRunAttentionNote for a pull request", () => {
+  it("says the pull request is ready and lists the three review steps", () => {
+    renderNote();
+
+    const note = screen.getByTestId("split-run-attention-note");
+    expect(note).toHaveAttribute("data-variant", "pull-request");
+    expect(within(note).getByRole("heading", { name: "The pull request is ready for review" })).toBeInTheDocument();
+
+    const steps = within(within(note).getByRole("list", { name: "Next steps" })).getAllByRole("listitem");
+    expect(steps).toHaveLength(3);
+    expect(steps[0]).toHaveTextContent("1");
+    expect(steps[0]).toHaveTextContent("Review the pull request");
+    expect(steps[1]).toHaveTextContent("2");
+    expect(steps[1]).toHaveTextContent("Leave comments");
+    expect(steps[1]).toHaveTextContent("@superplaneagent");
+    expect(steps[2]).toHaveTextContent("3");
+    expect(steps[2]).toHaveTextContent("SuperPlane addresses them");
+
+    expect(note).not.toHaveTextContent("Waiting for user review");
+    expect(note).toHaveTextContent("This task closes when the pull request is merged or closed.");
+  });
+
+  it("makes the pull request link the one large call to action", () => {
+    renderNote();
+
+    const cta = screen.getByTestId("split-run-pull-request-cta");
+    expect(cta).toHaveAccessibleName("Review PR #6812");
+    expect(cta).toHaveAttribute("href", "https://github.com/acme/payments/pull/6812");
+    expect(cta).toHaveAttribute("target", "_blank");
+    expect(cta).toHaveAttribute("rel", "noreferrer");
+
+    const note = screen.getByTestId("split-run-attention-note");
+    expect(within(note).getAllByRole("link")).toHaveLength(1);
+    expect(within(note).queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(within(note).queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(within(note).queryByRole("button", { name: "To Backlog" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the close actions behind a More menu", async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+    renderNote({ onAction });
+
+    await user.click(screen.getByRole("button", { name: "More actions" }));
+    const menu = await screen.findByRole("menu");
+    expect(
+      within(menu)
+        .getAllByRole("menuitem")
+        .map((item) => item.textContent),
+    ).toEqual(["To Backlog", "Reject", "Approve"]);
+
+    await user.click(within(menu).getByRole("menuitem", { name: "Approve" }));
+    expect(onAction).toHaveBeenCalledWith(ACTIONS[2]);
+  });
+
+  it("hides the More menu when there are no actions", () => {
+    renderNote({ actions: [] });
+
+    expect(screen.queryByRole("button", { name: "More actions" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("split-run-pull-request-cta")).toBeInTheDocument();
+  });
+
+  it("disables the More menu while an action is in flight", () => {
+    renderNote({ actionBusy: true });
+
+    expect(screen.getByRole("button", { name: "More actions" })).toBeDisabled();
+  });
+
+  it("keeps the standard note for a link that is not a pull request", () => {
+    renderNote({
+      note: { headline: "Implement did not pass", text: "Fix the error.", cta: { label: "Debug", href: "/runs/1" } },
+      tone: "failed",
+    });
+
+    const note = screen.getByTestId("split-run-attention-note");
+    expect(note).not.toHaveAttribute("data-variant", "pull-request");
+    expect(within(note).getByRole("heading", { name: "Implement did not pass" })).toBeInTheDocument();
+    expect(within(note).getByRole("button", { name: "Approve" })).toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunPullRequestReviewNote.stories.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunPullRequestReviewNote.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "../../__fixtures__/ComponentStoryShell";
+import { withFactoriesTheme } from "../../__fixtures__/factoriesStoryTheme";
+import { OPEN_WORK_ORDER } from "../../__fixtures__/factoryPageResponses";
+import { SplitRunAttentionNote } from "./SplitRunAttentionNote";
+import { splitRunFixtureForWorkOrder } from "./splitRunMocks";
+
+const meta = {
+  title: "Factories/Pages/Task Split Run/Pull request review strip",
+  parameters: {
+    layout: "fullscreen",
+    options: { showPanel: false },
+  },
+  decorators: [
+    withFactoriesTheme,
+    (Story) => (
+      <ComponentStoryShell className="min-h-svh bg-muted/30 p-6">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj;
+
+function PopupShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-[420px] w-full max-w-[750px] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-sm">
+      <header className="flex shrink-0 items-center gap-3 border-b border-border px-5 py-3">
+        <h2 className="min-w-0 flex-1 truncate text-[16px] font-semibold tracking-[-0.02em]">
+          {OPEN_WORK_ORDER.title}
+        </h2>
+      </header>
+      <div className="min-h-0 flex-1 px-5 py-4 text-[13px] text-muted-foreground">Automations log.</div>
+      {children}
+    </div>
+  );
+}
+
+const footer = splitRunFixtureForWorkOrder(OPEN_WORK_ORDER).footer;
+
+export const Default: Story = {
+  name: "Pull request is ready",
+  render: () => (
+    <PopupShell>
+      {footer.note ? (
+        <SplitRunAttentionNote note={footer.note} tone="waiting" actions={footer.actions} onAction={() => {}} />
+      ) : null}
+    </PopupShell>
+  ),
+};
+
+export const ReadOnly: Story = {
+  name: "Pull request is ready — no close actions",
+  render: () => (
+    <PopupShell>
+      {footer.note ? <SplitRunAttentionNote note={footer.note} tone="waiting" actions={[]} /> : null}
+    </PopupShell>
+  ),
+};

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunPullRequestReviewNote.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunPullRequestReviewNote.tsx
@@ -1,0 +1,128 @@
+import { ChevronDown, ExternalLink, GitPullRequest } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
+
+import type { SplitRunFooterAction } from "./splitRunFooter";
+import { PULL_REQUEST_REVIEW_COPY, type PullRequestReviewTarget } from "./splitRunPullRequestReview";
+
+const MARK_CLASSNAME = "flex shrink-0 items-center justify-center rounded-full bg-emerald-600 text-white";
+
+/**
+ * Decision strip for a task whose pull request is open. One message (the
+ * pull request is ready), one large call to action (review it), and a
+ * three-step guide. The automation-authored headline and body are not
+ * shown here; the steps say the same thing in a scannable form. Close
+ * actions stay available behind More so they do not compete with review.
+ */
+export function SplitRunPullRequestReviewNote({
+  ctaLabel,
+  pullRequest,
+  actions = [],
+  actionBusy = false,
+  onAction,
+}: {
+  ctaLabel: string;
+  pullRequest: PullRequestReviewTarget;
+  actions?: SplitRunFooterAction[];
+  actionBusy?: boolean;
+  onAction?: (action: SplitRunFooterAction) => void;
+}) {
+  return (
+    <div
+      className="border-t border-[color:var(--status-completed-border)] bg-[color:var(--status-completed-bg)] px-5 py-5"
+      data-testid="split-run-attention-note"
+      data-variant="pull-request"
+    >
+      <div className="flex items-start gap-3.5">
+        <span className={`${MARK_CLASSNAME} size-10`} aria-hidden>
+          <GitPullRequest className="size-5" />
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <h3 className="text-[18px] font-semibold leading-6 tracking-[-0.02em] text-foreground">
+            {PULL_REQUEST_REVIEW_COPY.headline}
+          </h3>
+          <ReviewSteps />
+          <div className="mt-5 flex flex-wrap items-center gap-x-4 gap-y-2">
+            <Button
+              asChild
+              size="lg"
+              className="h-11 bg-emerald-600 px-6 text-[15px] font-semibold text-white shadow-sm hover:bg-emerald-700"
+            >
+              <a href={pullRequest.href} target="_blank" rel="noreferrer" data-testid="split-run-pull-request-cta">
+                <GitPullRequest className="size-[18px]" aria-hidden />
+                {ctaLabel}
+                <ExternalLink className="size-4" aria-hidden />
+              </a>
+            </Button>
+            <p className="text-[13px] leading-5 text-foreground/70">{PULL_REQUEST_REVIEW_COPY.closing}</p>
+          </div>
+        </div>
+
+        <MoreActionsMenu actions={actions} disabled={actionBusy} onAction={onAction} />
+      </div>
+    </div>
+  );
+}
+
+function ReviewSteps() {
+  return (
+    <ol aria-label={PULL_REQUEST_REVIEW_COPY.stepsLabel} className="mt-3.5 flex flex-col gap-2">
+      {PULL_REQUEST_REVIEW_COPY.steps.map((step, index) => (
+        <li key={step.title} className="flex items-start gap-2.5">
+          <span className={`${MARK_CLASSNAME} mt-px size-6 text-[12px] font-semibold`} aria-hidden>
+            {index + 1}
+          </span>
+          <p className="min-w-0 text-[14px] leading-6">
+            <span className="font-semibold text-foreground">{step.title}</span>
+            <span className="text-foreground/70"> {step.text}</span>
+          </p>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function MoreActionsMenu({
+  actions,
+  disabled,
+  onAction,
+}: {
+  actions: SplitRunFooterAction[];
+  disabled: boolean;
+  onAction?: (action: SplitRunFooterAction) => void;
+}) {
+  if (actions.length === 0) {
+    return null;
+  }
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="shrink-0 text-foreground/70"
+          aria-label={PULL_REQUEST_REVIEW_COPY.moreActions}
+          disabled={disabled}
+          data-testid="split-run-more-actions"
+        >
+          {PULL_REQUEST_REVIEW_COPY.more}
+          <ChevronDown className="size-3.5" aria-hidden />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-40">
+        {actions.map((action) => (
+          <DropdownMenuItem
+            key={action.id}
+            onSelect={() => onAction?.(action)}
+            data-testid={`split-run-footer-${action.id}`}
+          >
+            {action.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -454,14 +454,17 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(screen.getByTestId("split-run-log-scroll")).toBeInTheDocument();
   });
 
-  it("pins a review note and keeps Update manually off the note", () => {
+  it("pins a pull request review strip with one call to action and a More menu", async () => {
+    const user = userEvent.setup();
     renderPopup({ fixture: splitRunFixtureForWorkOrder(OPEN_WORK_ORDER) });
 
     const note = screen.getByTestId("split-run-attention-note");
-    expect(within(note).getByRole("heading", { name: "Waiting for user review" })).toBeInTheDocument();
-    expect(note).toHaveTextContent("The pull request is open and waiting for user review.");
-    expect(note).toHaveTextContent("Mention @superplaneagent in a pull request comment or review to request changes.");
-    expect(note).toHaveTextContent("Task will automatically close when the pull request is closed or merged.");
+    expect(note).toHaveAttribute("data-variant", "pull-request");
+    expect(within(note).getByRole("heading", { name: "The pull request is ready for review" })).toBeInTheDocument();
+    expect(within(note).queryByText("Waiting for user review")).not.toBeInTheDocument();
+    expect(within(note).getAllByRole("listitem")).toHaveLength(3);
+    expect(note).toHaveTextContent("Mention @superplaneagent");
+    expect(note).toHaveTextContent("This task closes when the pull request is merged or closed.");
     expect(within(note).getByRole("link", { name: "Review PR #6812" })).toHaveAttribute(
       "href",
       "https://github.com/superplanehq/superplane/pull/6812",
@@ -469,9 +472,13 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(within(note).queryByText("PR Closure")).not.toBeInTheDocument();
     expect(within(note).queryByText(/ago/)).not.toBeInTheDocument();
     expect(within(note).queryByRole("button", { name: /Update manually/ })).not.toBeInTheDocument();
-    expect(within(note).getByRole("button", { name: "To Backlog" })).toBeInTheDocument();
-    expect(within(note).getByRole("button", { name: "Reject" })).toBeInTheDocument();
-    expect(within(note).getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(within(note).queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+
+    await user.click(within(note).getByRole("button", { name: "More actions" }));
+    const menu = await screen.findByRole("menu");
+    expect(within(menu).getByRole("menuitem", { name: "To Backlog" })).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: "Reject" })).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: "Approve" })).toBeInTheDocument();
     expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Stop and Close" })).not.toBeInTheDocument();
   });

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunStop.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunStop.spec.tsx
@@ -84,15 +84,17 @@ describe("WorkOrderSplitRunPopup decision footer", () => {
     expect(screen.queryByTestId("split-run-review")).not.toBeInTheDocument();
   });
 
-  it("rejects and approves a waiting task from the note", async () => {
+  it("rejects and approves a waiting pull request task from the More menu", async () => {
     const user = userEvent.setup();
     renderPopup(splitRunFixtureForWorkOrder(OPEN_WORK_ORDER));
 
     const note = screen.getByTestId("split-run-attention-note");
     expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
-    await user.click(within(note).getByRole("button", { name: "Reject" }));
+    await user.click(within(note).getByRole("button", { name: "More actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Reject" }));
     expect(handleRejectMock).toHaveBeenCalledTimes(1);
-    await user.click(within(note).getByRole("button", { name: "Approve" }));
+    await user.click(within(note).getByRole("button", { name: "More actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Approve" }));
     expect(handleStopMock).toHaveBeenCalledWith(
       "completed",
       expect.objectContaining({ kind: "waiting", status: "waiting" }),

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunPullRequestReview.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunPullRequestReview.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { pullRequestReviewNote } from "./splitRunPullRequestReview";
+
+describe("pullRequestReviewNote", () => {
+  it("recognizes a note whose call to action opens a GitHub pull request", () => {
+    expect(
+      pullRequestReviewNote({
+        headline: "Waiting for user review",
+        cta: { label: "Review PR #6812", href: "https://github.com/acme/payments/pull/6812" },
+      }),
+    ).toEqual({ href: "https://github.com/acme/payments/pull/6812", number: 6812 });
+  });
+
+  it("accepts a pull request link with a trailing path or query", () => {
+    expect(
+      pullRequestReviewNote({
+        headline: "Review",
+        cta: { label: "Review", href: "https://github.com/acme/payments/pull/12/files?diff=split" },
+      }),
+    ).toEqual({ href: "https://github.com/acme/payments/pull/12/files?diff=split", number: 12 });
+  });
+
+  it("ignores notes without a link", () => {
+    expect(pullRequestReviewNote({ headline: "Implement did not pass", cta: { label: "Debug" } })).toBeUndefined();
+    expect(pullRequestReviewNote({ headline: "This task needs a decision" })).toBeUndefined();
+  });
+
+  it("ignores links that are not pull requests", () => {
+    expect(
+      pullRequestReviewNote({
+        headline: "Review",
+        cta: { label: "Open issue", href: "https://github.com/acme/payments/issues/6812" },
+      }),
+    ).toBeUndefined();
+    expect(
+      pullRequestReviewNote({
+        headline: "Debug",
+        cta: { label: "Debug", href: "/org/workspaces/key/apps/app-1/runs/run-1" },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunPullRequestReview.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunPullRequestReview.ts
@@ -1,0 +1,44 @@
+import type { SplitRunFooterNote } from "./splitRunFooter";
+
+/** `https://github.com/<owner>/<repo>/pull/<number>` with an optional tail. */
+const PULL_REQUEST_URL = /^https?:\/\/[^/]+\/[^/]+\/[^/]+\/pull\/(\d+)(?:[/?#]|$)/;
+
+export interface PullRequestReviewTarget {
+  href: string;
+  number: number;
+}
+
+/**
+ * A status note whose call to action opens a pull request. The Implement
+ * line sets one when it opens or updates the pull request for a task.
+ * The popup renders such a note as the pull-request review strip.
+ */
+export function pullRequestReviewNote(note: SplitRunFooterNote): PullRequestReviewTarget | undefined {
+  const href = note.cta?.href;
+  if (!href) {
+    return undefined;
+  }
+  const match = PULL_REQUEST_URL.exec(href);
+  if (!match) {
+    return undefined;
+  }
+  return { href, number: Number(match[1]) };
+}
+
+export interface PullRequestReviewStep {
+  title: string;
+  text: string;
+}
+
+export const PULL_REQUEST_REVIEW_COPY = {
+  headline: "The pull request is ready for review",
+  steps: [
+    { title: "Review the pull request.", text: "Open it on GitHub and read the changes." },
+    { title: "Leave comments.", text: "Mention @superplaneagent in a comment or review to request changes." },
+    { title: "SuperPlane addresses them.", text: "It updates the pull request and asks you to review again." },
+  ] satisfies PullRequestReviewStep[],
+  stepsLabel: "Next steps",
+  closing: "This task closes when the pull request is merged or closed.",
+  moreActions: "More actions",
+  more: "More",
+} as const;


### PR DESCRIPTION
## Summary

When a task waits on an open pull request, the footer showed a long note and four buttons of equal weight.
Users did not see the one action that matters: review the pull request.

The footer now renders a dedicated strip for a status note that links to a pull request.
It states that the pull request is ready and lists three numbered steps: review, leave comments, SuperPlane addresses them.
One large call to action opens the pull request.
To Backlog, Reject, and Approve move into a More menu. They stay available but do not compete with review.

Other footer states (draft, failed, stopped, done) are unchanged.

Preview in Storybook: **Factories / Pages / Task Split Run / Pull request review strip**.

## Test plan

- [ ] Open a task that waits on an open pull request.
- [ ] Confirm the footer says the pull request is ready for review.
- [ ] Confirm the footer lists three numbered steps.
- [ ] Click the large Review PR button and confirm it opens the pull request in a new tab.
- [ ] Open More and confirm To Backlog, Reject, and Approve are present.
- [ ] Approve from More and confirm the task closes as completed.
- [ ] Open a failed task and confirm the footer is unchanged.
- [ ] Open a draft task and confirm the footer is unchanged.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62102992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/superplane/-/pull-requests/superplanehq/superplane/7310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge, with non-blocking fixes recommended for overly broad pull-request URL recognition and the silent Storybook callback.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**PR matcher accepts unrelated hosts** <a href="https://github.com/superplanehq/superplane/pull/7310#discussion_r3968925270">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Story action callback is silent** <a href="https://github.com/superplanehq/superplane/pull/7310#discussion_r3968925305">▶</a>

<!-- /greptile_comment -->