### PR TITLE
feat: Add Admin Price Book Scan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,13 @@
 ## Usage service
 # USAGE_GRPC_URL=
 
+## Price book scan (optional)
+## Admin Settings includes a page that scans OpenRouter model prices and
+## SuperPlane runner VM rates, then writes a new usage_price_books version.
+## Set START_PRICE_BOOK_SYNC_WORKER=yes to run the same scan on an interval.
+# START_PRICE_BOOK_SYNC_WORKER=no
+# PRICE_BOOK_SYNC_EVERY=24h
+
 ## Hosted credit billing (Polar)
 ## Leave blank for self-hosted.
 ## Use an organization access token (OAT), not a personal token.

--- a/docs/prd/token-usage-and-billing.md
+++ b/docs/prd/token-usage-and-billing.md
@@ -144,9 +144,13 @@ because the list holds full model ids. Only `PrepareHostedRun` keeps a
 selected-model gate, because hosted spend debits the wallet.
 
 Rates live in `usage_price_books` / `usage_price_book_rates`. The process loads
-the latest book at start. Compute rows for SuperPlane runner fleets write
-`cost_micros` from `micros_per_second`. Fleet `local` is always 0. Compute
-does not debit the hosted credit wallet and does not use markup.
+the latest book at start. Installation admins can scan OpenRouter model prices
+and SuperPlane runner VM rates from the admin **Price book** page. The same
+scan function can run on a worker interval (`START_PRICE_BOOK_SYNC_WORKER`).
+A scan writes a new catalog version and reloads it in memory. Compute rows for
+SuperPlane runner fleets write `cost_micros` from `micros_per_second`. Fleet
+`local` is always 0. Compute does not debit the hosted credit wallet and does
+not use markup.
 
 ### Phase 5 — Polar prepaid checkout
 

--- a/pkg/models/usage_price_book.go
+++ b/pkg/models/usage_price_book.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -76,6 +78,11 @@ func LoadCurrentPriceBook(tx *gorm.DB) error {
 				Reasoning:  row.ReasoningCentsPerMillion,
 			}
 			switch row.MatchMode {
+			case UsagePriceBookMatchExact:
+				loaded.ExactRates = append(loaded.ExactRates, pricebook.ExactRate{
+					Key:  row.MatchKey,
+					Rate: rate,
+				})
 			case UsagePriceBookMatchPrefix:
 				loaded.PrefixRates = append(loaded.PrefixRates, pricebook.PrefixRate{
 					Prefix: row.MatchKey,
@@ -94,4 +101,76 @@ func LoadCurrentPriceBook(tx *gorm.DB) error {
 
 	pricebook.Replace(loaded)
 	return nil
+}
+
+// FindLatestPriceBook returns the newest catalog version by effective_at.
+func FindLatestPriceBook(tx *gorm.DB) (*UsagePriceBook, error) {
+	var book UsagePriceBook
+	err := tx.Order("effective_at DESC").First(&book).Error
+	if err != nil {
+		return nil, err
+	}
+	return &book, nil
+}
+
+// ListPriceBookRates returns every match rule for one catalog version.
+func ListPriceBookRates(tx *gorm.DB, version string) ([]UsagePriceBookRate, error) {
+	var rows []UsagePriceBookRate
+	err := tx.Where("version = ?", version).
+		Order("usage_kind ASC, match_mode ASC, match_key ASC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// NextPriceBookVersion returns date.N for today in UTC, starting at .1.
+func NextPriceBookVersion(tx *gorm.DB, now time.Time) (string, error) {
+	prefix := now.UTC().Format("2006-01-02") + "."
+	var versions []string
+	err := tx.Model(&UsagePriceBook{}).
+		Where("version LIKE ?", prefix+"%").
+		Pluck("version", &versions).Error
+	if err != nil {
+		return "", err
+	}
+
+	max := 0
+	for _, version := range versions {
+		n, parseErr := strconv.Atoi(strings.TrimPrefix(version, prefix))
+		if parseErr != nil {
+			continue
+		}
+		if n > max {
+			max = n
+		}
+	}
+	return fmt.Sprintf("%s%d", prefix, max+1), nil
+}
+
+// InsertPriceBook writes one catalog version and its rates in the caller transaction.
+func InsertPriceBook(tx *gorm.DB, book UsagePriceBook, rates []UsagePriceBookRate) error {
+	if strings.TrimSpace(book.Version) == "" {
+		return fmt.Errorf("price book version is required")
+	}
+	if book.EffectiveAt.IsZero() {
+		book.EffectiveAt = time.Now().UTC()
+	}
+	if book.CreatedAt.IsZero() {
+		book.CreatedAt = book.EffectiveAt
+	}
+	if err := tx.Create(&book).Error; err != nil {
+		return err
+	}
+	if len(rates) == 0 {
+		return nil
+	}
+	for i := range rates {
+		if rates[i].ID == uuid.Nil {
+			rates[i].ID = uuid.New()
+		}
+		rates[i].Version = book.Version
+	}
+	return tx.Create(&rates).Error
 }

--- a/pkg/models/usage_price_book_test.go
+++ b/pkg/models/usage_price_book_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,4 +23,31 @@ func Test__LoadCurrentPriceBook__MatchesHardcodedRates(t *testing.T) {
 	assert.Equal(t, int64(15_000_000), pricebook.EstimateMicros("anthropic", "claude-3-opus-20240229", 1_000_000, 0, 0, 0, 0))
 	assert.Equal(t, 10*pricebook.MicrosPerSecondE1Large, pricebook.EstimateComputeMicros("e1-large-amd64", "e1-large-amd64", 10))
 	assert.Equal(t, int64(0), pricebook.EstimateComputeMicros("e1-large-amd64", "local", 10))
+}
+
+func Test__LoadCurrentPriceBook__LoadsExactModelRates(t *testing.T) {
+	_ = support.Setup(t)
+	t.Cleanup(pricebook.Reset)
+
+	now := time.Now().UTC()
+	version, err := models.NextPriceBookVersion(database.Conn(), now)
+	require.NoError(t, err)
+	err = models.InsertPriceBook(database.Conn(), models.UsagePriceBook{
+		Version:     version,
+		EffectiveAt: now,
+	}, []models.UsagePriceBookRate{{
+		UsageKind:            models.UsageKindModel,
+		MatchKey:             "openai/gpt-test-exact",
+		MatchMode:            models.UsagePriceBookMatchExact,
+		InputCentsPerMillion: 42,
+	}})
+	require.NoError(t, err)
+	require.NoError(t, models.LoadCurrentPriceBook(database.Conn()))
+
+	assert.Equal(t, int64(420_000), pricebook.EstimateMicros("openrouter", "openai/gpt-test-exact", 1_000_000, 0, 0, 0, 0))
+
+	t.Cleanup(func() {
+		_ = database.Conn().Where("version = ?", version).Delete(&models.UsagePriceBookRate{})
+		_ = database.Conn().Where("version = ?", version).Delete(&models.UsagePriceBook{})
+	})
 }

--- a/pkg/public/admin_price_book.go
+++ b/pkg/public/admin_price_book.go
@@ -1,0 +1,119 @@
+package public
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/usage/pricesync"
+	"gorm.io/gorm"
+)
+
+type priceBookResponse struct {
+	Version          string                  `json:"version"`
+	PreviousVersion  string                  `json:"previous_version,omitempty"`
+	EffectiveAt      *time.Time              `json:"effective_at"`
+	ModelRateCount   int                     `json:"model_rate_count"`
+	ComputeRateCount int                     `json:"compute_rate_count"`
+	Sources          []string                `json:"sources,omitempty"`
+	Rates            []priceBookRateResponse `json:"rates"`
+}
+
+type priceBookRateResponse struct {
+	UsageKind                 string `json:"usage_kind"`
+	MatchKey                  string `json:"match_key"`
+	MatchMode                 string `json:"match_mode"`
+	InputCentsPerMillion      int64  `json:"input_cents_per_million"`
+	OutputCentsPerMillion     int64  `json:"output_cents_per_million"`
+	CacheReadCentsPerMillion  int64  `json:"cache_read_cents_per_million"`
+	CacheWriteCentsPerMillion int64  `json:"cache_write_cents_per_million"`
+	ReasoningCentsPerMillion  int64  `json:"reasoning_cents_per_million"`
+	MicrosPerSecond           int64  `json:"micros_per_second"`
+}
+
+func (s *Server) priceBookScanner() pricesync.Scanner {
+	if s.newPriceBookScanner != nil {
+		return s.newPriceBookScanner()
+	}
+	return pricesync.NewScanner(pricesync.Options{HTTP: s.registry.HTTPContext()})
+}
+
+func (s *Server) adminGetPriceBook(w http.ResponseWriter, r *http.Request) {
+	tx := database.DB(r.Context())
+	book, err := models.FindLatestPriceBook(tx)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		respondJSON(w, priceBookResponse{Rates: []priceBookRateResponse{}})
+		return
+	}
+	if err != nil {
+		log.Errorf("admin: failed to load price book: %v", err)
+		http.Error(w, "Failed to load the price book", http.StatusInternalServerError)
+		return
+	}
+
+	rows, err := models.ListPriceBookRates(tx, book.Version)
+	if err != nil {
+		log.Errorf("admin: failed to load price book rates: %v", err)
+		http.Error(w, "Failed to load the price book", http.StatusInternalServerError)
+		return
+	}
+
+	respondJSON(w, buildPriceBookResponse(book.Version, "", book.EffectiveAt, nil, rows))
+}
+
+func (s *Server) adminScanPriceBook(w http.ResponseWriter, r *http.Request) {
+	result, err := pricesync.ScanAndPublish(r.Context(), database.DB(r.Context()), s.priceBookScanner())
+	if err != nil {
+		log.Errorf("admin: failed to scan price book: %v", err)
+		http.Error(w, "SuperPlane could not scan provider prices. Try again.", http.StatusBadGateway)
+		return
+	}
+
+	rows, err := models.ListPriceBookRates(database.DB(r.Context()), result.Version)
+	if err != nil {
+		log.Errorf("admin: failed to load scanned price book rates: %v", err)
+		http.Error(w, "Failed to load the price book", http.StatusInternalServerError)
+		return
+	}
+
+	respondJSON(w, buildPriceBookResponse(result.Version, result.PreviousVersion, result.EffectiveAt, result.Sources, rows))
+}
+
+func buildPriceBookResponse(
+	version, previous string,
+	effectiveAt time.Time,
+	sources []string,
+	rows []models.UsagePriceBookRate,
+) priceBookResponse {
+	response := priceBookResponse{
+		Version:         version,
+		PreviousVersion: previous,
+		Sources:         sources,
+		Rates:           make([]priceBookRateResponse, 0, len(rows)),
+	}
+	if !effectiveAt.IsZero() {
+		response.EffectiveAt = &effectiveAt
+	}
+	for _, row := range rows {
+		if row.UsageKind == models.UsageKindCompute {
+			response.ComputeRateCount++
+		} else {
+			response.ModelRateCount++
+		}
+		response.Rates = append(response.Rates, priceBookRateResponse{
+			UsageKind:                 row.UsageKind,
+			MatchKey:                  row.MatchKey,
+			MatchMode:                 row.MatchMode,
+			InputCentsPerMillion:      row.InputCentsPerMillion,
+			OutputCentsPerMillion:     row.OutputCentsPerMillion,
+			CacheReadCentsPerMillion:  row.CacheReadCentsPerMillion,
+			CacheWriteCentsPerMillion: row.CacheWriteCentsPerMillion,
+			ReasoningCentsPerMillion:  row.ReasoningCentsPerMillion,
+			MicrosPerSecond:           row.MicrosPerSecond,
+		})
+	}
+	return response
+}

--- a/pkg/public/admin_price_book_test.go
+++ b/pkg/public/admin_price_book_test.go
@@ -1,0 +1,101 @@
+package public
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/jwt"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/usage/pricebook"
+	"github.com/superplanehq/superplane/pkg/usage/pricesync"
+)
+
+func TestAdminPriceBook(t *testing.T) {
+	server, _, token := setupAdminTestServer(t)
+	t.Cleanup(pricebook.Reset)
+
+	t.Run("non-admin gets 404", func(t *testing.T) {
+		account, err := models.CreateAccount("Regular User", "regular-price-book@example.com")
+		require.NoError(t, err)
+		signer := jwt.NewSigner("test-client-secret")
+		regularToken, err := authentication.GenerateAccountToken(signer, account.ID.String(), time.Now(), time.Hour)
+		require.NoError(t, err)
+
+		response := execRequest(server, requestParams{
+			method:     "GET",
+			path:       "/admin/api/installation/price-book",
+			authCookie: regularToken,
+		})
+		assert.Equal(t, http.StatusNotFound, response.Code)
+	})
+
+	t.Run("admin can load the current price book", func(t *testing.T) {
+		response := execRequest(server, requestParams{
+			method:     "GET",
+			path:       "/admin/api/installation/price-book",
+			authCookie: token,
+		})
+		assert.Equal(t, http.StatusOK, response.Code)
+
+		var book priceBookResponse
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &book))
+		assert.NotEmpty(t, book.Version)
+		assert.Greater(t, book.ModelRateCount, 0)
+		assert.Greater(t, book.ComputeRateCount, 0)
+		assert.Equal(t, book.ModelRateCount+book.ComputeRateCount, len(book.Rates))
+	})
+
+	t.Run("admin can scan and publish a new price book", func(t *testing.T) {
+		now := time.Date(2099, 1, 2, 16, 0, 0, 0, time.UTC)
+		server.newPriceBookScanner = func() pricesync.Scanner {
+			return pricesync.NewScanner(pricesync.Options{
+				Now: func() time.Time { return now },
+				Models: []pricesync.ModelSource{
+					stubAdminModelSource{rates: []pricesync.ModelRate{{
+						MatchKey:  "openai/gpt-scan",
+						MatchMode: models.UsagePriceBookMatchExact,
+						Rate:      pricebook.Rate{Input: 12, Output: 24},
+					}}},
+				},
+				Compute: pricesync.CatalogSource{},
+			})
+		}
+		t.Cleanup(func() { server.newPriceBookScanner = nil })
+
+		response := execRequest(server, requestParams{
+			method:     "POST",
+			path:       "/admin/api/installation/price-book/scan",
+			authCookie: token,
+		})
+		assert.Equal(t, http.StatusOK, response.Code)
+
+		var book priceBookResponse
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &book))
+		assert.Equal(t, "2099-01-02.1", book.Version)
+		assert.Equal(t, 1, book.ModelRateCount)
+		assert.Greater(t, book.ComputeRateCount, 0)
+		assert.Contains(t, book.Sources, "superplane-catalog")
+		assert.Equal(t, int64(120_000), pricebook.EstimateMicros("openrouter", "openai/gpt-scan", 1_000_000, 0, 0, 0, 0))
+		t.Cleanup(func() {
+			_ = database.Conn().Where("version LIKE ?", "2099-01-02.%").Delete(&models.UsagePriceBookRate{})
+			_ = database.Conn().Where("version LIKE ?", "2099-01-02.%").Delete(&models.UsagePriceBook{})
+		})
+	})
+}
+
+type stubAdminModelSource struct {
+	rates []pricesync.ModelRate
+}
+
+func (stubAdminModelSource) Name() string { return "openrouter" }
+
+func (s stubAdminModelSource) ScanModels(context.Context) ([]pricesync.ModelRate, error) {
+	return s.rates, nil
+}

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -63,6 +63,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/public/ws"
 	"github.com/superplanehq/superplane/pkg/telemetry"
 	"github.com/superplanehq/superplane/pkg/usage"
+	"github.com/superplanehq/superplane/pkg/usage/pricesync"
 	"github.com/superplanehq/superplane/pkg/web"
 	"github.com/superplanehq/superplane/pkg/web/assets"
 	"google.golang.org/grpc/codes"
@@ -100,6 +101,7 @@ type Server struct {
 	authHandler           *authentication.Handler
 	isDev                 bool
 	usageService          usage.Service
+	newPriceBookScanner   func() pricesync.Scanner
 }
 
 // WebsocketHub returns the websocket hub for this server
@@ -729,6 +731,8 @@ func (s *Server) InitRouter(additionalMiddlewares ...mux.MiddlewareFunc) {
 	adminRoute.HandleFunc("/installation/llm-settings", s.adminUpdateInstallationLLMSettings).Methods("PATCH")
 	adminRoute.HandleFunc("/installation/llm-providers/{provider}", s.adminUpdateHostedLLMProvider).Methods("PATCH")
 	adminRoute.HandleFunc("/installation/llm-providers/{provider}/models", s.adminListHostedLLMProviderModels).Methods("POST")
+	adminRoute.HandleFunc("/installation/price-book", s.adminGetPriceBook).Methods("GET")
+	adminRoute.HandleFunc("/installation/price-book/scan", s.adminScanPriceBook).Methods("POST")
 	adminRoute.HandleFunc("/organizations/{orgId}/llm-credit", s.adminGetOrganizationLLMCredit).Methods("GET")
 	adminRoute.HandleFunc("/organizations/{orgId}/llm-credit/grants", s.adminAddOrganizationLLMCredit).Methods("POST")
 	adminRoute.HandleFunc("/organizations/{orgId}/llm-settings", s.adminUpdateOrganizationLLMMarkup).Methods("PATCH")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -305,6 +305,12 @@ func startWorkers(
 		go w.Start(context.Background())
 	}
 
+	if os.Getenv("START_PRICE_BOOK_SYNC_WORKER") == "yes" {
+		log.Println("Starting Price Book Sync Worker")
+		w := workers.NewPriceBookSyncWorker(registry.HTTPContext())
+		go w.Start(context.Background())
+	}
+
 	if os.Getenv("START_PLANNING_SESSION_CLEANUP_WORKER") == "yes" {
 		log.Println("Starting Planning Session Cleanup Worker")
 

--- a/pkg/usage/pricebook/pricebook.go
+++ b/pkg/usage/pricebook/pricebook.go
@@ -31,6 +31,11 @@ type Rate struct {
 	Reasoning  int64
 }
 
+type ExactRate struct {
+	Key  string
+	Rate Rate
+}
+
 type PrefixRate struct {
 	Prefix string
 	Rate   Rate
@@ -44,6 +49,7 @@ type FamilyRate struct {
 // Book is one versioned catalog of model and compute rates.
 type Book struct {
 	Version      string
+	ExactRates   []ExactRate
 	PrefixRates  []PrefixRate
 	FamilyRates  []FamilyRate
 	ComputeRates map[string]int64
@@ -106,6 +112,7 @@ func defaultComputeRates() map[string]int64 {
 
 type bookState struct {
 	version      string
+	exact        map[string]Rate
 	rates        []entry
 	familyRates  []familyEntry
 	computeRates map[string]int64
@@ -114,20 +121,48 @@ type bookState struct {
 func defaultBook() bookState {
 	return bookState{
 		version:      FallbackVersion,
+		exact:        map[string]Rate{},
 		rates:        defaultPrefixRates(),
 		familyRates:  defaultFamilyRates(),
 		computeRates: defaultComputeRates(),
 	}
 }
 
+// CatalogFallbacks returns the compiled-in prefix, family, and compute rates.
+// Scans overlay exact vendor rates on top of this catalog.
+func CatalogFallbacks() Book {
+	prefixes := defaultPrefixRates()
+	families := defaultFamilyRates()
+	book := Book{
+		PrefixRates:  make([]PrefixRate, 0, len(prefixes)),
+		FamilyRates:  make([]FamilyRate, 0, len(families)),
+		ComputeRates: defaultComputeRates(),
+	}
+	for _, item := range prefixes {
+		book.PrefixRates = append(book.PrefixRates, PrefixRate{Prefix: item.prefix, Rate: item.rate})
+	}
+	for _, item := range families {
+		book.FamilyRates = append(book.FamilyRates, FamilyRate{Token: item.token, Rate: item.rate})
+	}
+	return book
+}
+
 // Replace installs a database-backed book as the in-memory catalog.
 func Replace(book Book) {
 	next := bookState{
 		version:      strings.TrimSpace(book.Version),
+		exact:        map[string]Rate{},
 		computeRates: map[string]int64{},
 	}
 	if next.version == "" {
 		next.version = FallbackVersion
+	}
+	for _, item := range book.ExactRates {
+		key := strings.ToLower(strings.TrimSpace(item.Key))
+		if key == "" {
+			continue
+		}
+		next.exact[key] = item.Rate
 	}
 	for _, item := range book.PrefixRates {
 		prefix := strings.ToLower(strings.TrimSpace(item.Prefix))
@@ -246,11 +281,30 @@ func MicrosToCents(micros int64) int64 {
 }
 
 func lookup(model string) (Rate, bool) {
+	full := strings.ToLower(strings.TrimSpace(model))
+	if rate, ok := lookupExact(full); ok {
+		return rate, true
+	}
 	normalized := normalizeModelID(model)
+	if normalized != full {
+		if rate, ok := lookupExact(normalized); ok {
+			return rate, true
+		}
+	}
 	if rate, ok := lookupPrefix(normalized); ok {
 		return rate, true
 	}
 	return lookupFamilyToken(normalized)
+}
+
+func lookupExact(key string) (Rate, bool) {
+	if key == "" {
+		return Rate{}, false
+	}
+	mu.RLock()
+	defer mu.RUnlock()
+	rate, ok := current.exact[key]
+	return rate, ok
 }
 
 func normalizeModelID(model string) string {

--- a/pkg/usage/pricebook/pricebook_test.go
+++ b/pkg/usage/pricebook/pricebook_test.go
@@ -48,6 +48,25 @@ func TestEstimateMicros_UnknownModelIsZero(t *testing.T) {
 	assert.Equal(t, int64(0), got)
 }
 
+func TestEstimateMicros_ExactMatchBeatsPrefix(t *testing.T) {
+	t.Cleanup(Reset)
+	Replace(Book{
+		Version: "test-exact",
+		ExactRates: []ExactRate{
+			{Key: "anthropic/claude-sonnet-4", Rate: Rate{Input: 999}},
+		},
+		PrefixRates: []PrefixRate{
+			{Prefix: "claude-sonnet", Rate: rateClaudeSonnet},
+		},
+		FamilyRates:  CatalogFallbacks().FamilyRates,
+		ComputeRates: CatalogFallbacks().ComputeRates,
+	})
+
+	assert.Equal(t, int64(9_990_000), EstimateMicros("openrouter", "anthropic/claude-sonnet-4", 1_000_000, 0, 0, 0, 0))
+	assert.Equal(t, int64(3_000_000), EstimateMicros("anthropic", "claude-sonnet-4-6", 1_000_000, 0, 0, 0, 0))
+	assert.True(t, IsPriced("anthropic/claude-sonnet-4"))
+}
+
 func TestIsPriced(t *testing.T) {
 	assert.True(t, IsPriced("claude-sonnet-4-6"))
 	assert.False(t, IsPriced("unknown-lab-model"))

--- a/pkg/usage/pricesync/catalog.go
+++ b/pkg/usage/pricesync/catalog.go
@@ -1,0 +1,45 @@
+package pricesync
+
+import (
+	"context"
+
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/usage/pricebook"
+)
+
+// CatalogSource republishes SuperPlane prefix, family, and runner VM rates.
+type CatalogSource struct{}
+
+func (CatalogSource) Name() string { return "superplane-catalog" }
+
+func (CatalogSource) ScanModels(context.Context) ([]ModelRate, error) {
+	fallbacks := pricebook.CatalogFallbacks()
+	rates := make([]ModelRate, 0, len(fallbacks.PrefixRates)+len(fallbacks.FamilyRates))
+	for _, item := range fallbacks.PrefixRates {
+		rates = append(rates, ModelRate{
+			MatchKey:  item.Prefix,
+			MatchMode: models.UsagePriceBookMatchPrefix,
+			Rate:      item.Rate,
+		})
+	}
+	for _, item := range fallbacks.FamilyRates {
+		rates = append(rates, ModelRate{
+			MatchKey:  item.Token,
+			MatchMode: models.UsagePriceBookMatchFamily,
+			Rate:      item.Rate,
+		})
+	}
+	return rates, nil
+}
+
+func (CatalogSource) ScanCompute(context.Context) ([]ComputeRate, error) {
+	fallbacks := pricebook.CatalogFallbacks()
+	rates := make([]ComputeRate, 0, len(fallbacks.ComputeRates))
+	for machineType, micros := range fallbacks.ComputeRates {
+		rates = append(rates, ComputeRate{
+			MachineType:     machineType,
+			MicrosPerSecond: micros,
+		})
+	}
+	return rates, nil
+}

--- a/pkg/usage/pricesync/convert.go
+++ b/pkg/usage/pricesync/convert.go
@@ -1,0 +1,30 @@
+package pricesync
+
+import (
+	"math"
+	"strconv"
+	"strings"
+)
+
+const usdPerTokenToCentsPerMillion = 100_000_000
+
+// USDPerTokenToCentsPerMillion converts vendor USD-per-token prices into
+// SuperPlane cents per million tokens.
+func USDPerTokenToCentsPerMillion(usdPerToken float64) int64 {
+	if usdPerToken <= 0 || math.IsNaN(usdPerToken) || math.IsInf(usdPerToken, 0) {
+		return 0
+	}
+	return int64(math.Round(usdPerToken * usdPerTokenToCentsPerMillion))
+}
+
+func parseUSDPerToken(value string) int64 {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0
+	}
+	parsed, err := strconv.ParseFloat(trimmed, 64)
+	if err != nil {
+		return 0
+	}
+	return USDPerTokenToCentsPerMillion(parsed)
+}

--- a/pkg/usage/pricesync/convert_test.go
+++ b/pkg/usage/pricesync/convert_test.go
@@ -1,0 +1,21 @@
+package pricesync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUSDPerTokenToCentsPerMillion(t *testing.T) {
+	assert.Equal(t, int64(300), USDPerTokenToCentsPerMillion(0.000003))
+	assert.Equal(t, int64(1500), USDPerTokenToCentsPerMillion(0.000015))
+	assert.Equal(t, int64(30), USDPerTokenToCentsPerMillion(0.0000003))
+	assert.Equal(t, int64(0), USDPerTokenToCentsPerMillion(0))
+	assert.Equal(t, int64(0), USDPerTokenToCentsPerMillion(-1))
+}
+
+func TestParseUSDPerToken(t *testing.T) {
+	assert.Equal(t, int64(300), parseUSDPerToken("0.000003"))
+	assert.Equal(t, int64(0), parseUSDPerToken(""))
+	assert.Equal(t, int64(0), parseUSDPerToken("not-a-number"))
+}

--- a/pkg/usage/pricesync/openrouter.go
+++ b/pkg/usage/pricesync/openrouter.go
@@ -1,0 +1,117 @@
+package pricesync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/usage/pricebook"
+)
+
+const defaultOpenRouterModelsURL = "https://openrouter.ai/api/v1/models"
+
+type openRouterModelsResponse struct {
+	Data []openRouterModel `json:"data"`
+}
+
+type openRouterModel struct {
+	ID      string            `json:"id"`
+	Pricing openRouterPricing `json:"pricing"`
+}
+
+type openRouterPricing struct {
+	Prompt            string `json:"prompt"`
+	Completion        string `json:"completion"`
+	InputCacheRead    string `json:"input_cache_read"`
+	InputCacheWrite   string `json:"input_cache_write"`
+	InternalReasoning string `json:"internal_reasoning"`
+}
+
+// OpenRouterSource loads exact model rates from the OpenRouter catalog.
+type OpenRouterSource struct {
+	HTTP core.HTTPContext
+	URL  string
+}
+
+func (s OpenRouterSource) Name() string { return "openrouter" }
+
+func (s OpenRouterSource) ScanModels(ctx context.Context) ([]ModelRate, error) {
+	if s.HTTP == nil {
+		return nil, fmt.Errorf("openrouter scan requires an HTTP client")
+	}
+
+	url := strings.TrimSpace(s.URL)
+	if url == "" {
+		url = defaultOpenRouterModelsURL
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build openrouter models request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("HTTP-Referer", "https://superplane.com")
+	req.Header.Set("X-Title", "SuperPlane")
+
+	res, err := s.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch openrouter models: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		msg, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("fetch openrouter models failed (%d): %s", res.StatusCode, strings.TrimSpace(string(msg)))
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read openrouter models: %w", err)
+	}
+
+	rates, err := parseOpenRouterModels(body)
+	if err != nil {
+		return nil, err
+	}
+	if len(rates) == 0 {
+		return nil, fmt.Errorf("openrouter catalog returned no model rates")
+	}
+	return rates, nil
+}
+
+func parseOpenRouterModels(body []byte) ([]ModelRate, error) {
+	var response openRouterModelsResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("decode openrouter models: %w", err)
+	}
+
+	rates := make([]ModelRate, 0, len(response.Data))
+	seen := map[string]struct{}{}
+	for _, item := range response.Data {
+		id := strings.ToLower(strings.TrimSpace(item.ID))
+		if id == "" {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		rates = append(rates, ModelRate{
+			MatchKey:  id,
+			MatchMode: models.UsagePriceBookMatchExact,
+			Rate: pricebook.Rate{
+				Input:      parseUSDPerToken(item.Pricing.Prompt),
+				Output:     parseUSDPerToken(item.Pricing.Completion),
+				CacheRead:  parseUSDPerToken(item.Pricing.InputCacheRead),
+				CacheWrite: parseUSDPerToken(item.Pricing.InputCacheWrite),
+				Reasoning:  parseUSDPerToken(item.Pricing.InternalReasoning),
+			},
+		})
+	}
+	return rates, nil
+}

--- a/pkg/usage/pricesync/openrouter_test.go
+++ b/pkg/usage/pricesync/openrouter_test.go
@@ -1,0 +1,72 @@
+package pricesync
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+func TestParseOpenRouterModels(t *testing.T) {
+	body := []byte(`{
+		"data": [
+			{
+				"id": "anthropic/claude-sonnet-4",
+				"pricing": {
+					"prompt": "0.000003",
+					"completion": "0.000015",
+					"input_cache_read": "0.0000003",
+					"input_cache_write": "0.00000375"
+				}
+			},
+			{"id": "", "pricing": {"prompt": "0.000001"}},
+			{
+				"id": "anthropic/claude-sonnet-4",
+				"pricing": {"prompt": "0.000009"}
+			}
+		]
+	}`)
+
+	rates, err := parseOpenRouterModels(body)
+	require.NoError(t, err)
+	require.Len(t, rates, 1)
+	assert.Equal(t, "anthropic/claude-sonnet-4", rates[0].MatchKey)
+	assert.Equal(t, models.UsagePriceBookMatchExact, rates[0].MatchMode)
+	assert.Equal(t, int64(300), rates[0].Rate.Input)
+	assert.Equal(t, int64(1500), rates[0].Rate.Output)
+	assert.Equal(t, int64(30), rates[0].Rate.CacheRead)
+	assert.Equal(t, int64(375), rates[0].Rate.CacheWrite)
+}
+
+func TestOpenRouterSourceScanModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"openai/gpt-4o","pricing":{"prompt":"0.0000025","completion":"0.00001"}}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	source := OpenRouterSource{HTTP: http.DefaultClient, URL: server.URL}
+	rates, err := source.ScanModels(context.Background())
+	require.NoError(t, err)
+	require.Len(t, rates, 1)
+	assert.Equal(t, "openai/gpt-4o", rates[0].MatchKey)
+	assert.Equal(t, int64(250), rates[0].Rate.Input)
+	assert.Equal(t, int64(1000), rates[0].Rate.Output)
+}
+
+func TestOpenRouterSourceScanModels_EmptyCatalog(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	source := OpenRouterSource{HTTP: http.DefaultClient, URL: server.URL}
+	_, err := source.ScanModels(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no model rates")
+}

--- a/pkg/usage/pricesync/scan.go
+++ b/pkg/usage/pricesync/scan.go
@@ -1,0 +1,222 @@
+package pricesync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/usage/pricebook"
+	"gorm.io/gorm"
+)
+
+// ModelRate is one scanned LLM match rule.
+type ModelRate struct {
+	MatchKey  string
+	MatchMode string
+	Rate      pricebook.Rate
+}
+
+// ComputeRate is one scanned runner VM rate.
+type ComputeRate struct {
+	MachineType     string
+	MicrosPerSecond int64
+}
+
+// Snapshot is the merged catalog a scan is ready to publish.
+type Snapshot struct {
+	ModelRates   []ModelRate
+	ComputeRates []ComputeRate
+	Sources      []string
+}
+
+// Result is the published catalog version after a scan.
+type Result struct {
+	Version          string
+	PreviousVersion  string
+	ModelRateCount   int
+	ComputeRateCount int
+	Sources          []string
+	EffectiveAt      time.Time
+}
+
+// ModelSource fetches LLM rates from one vendor or catalog.
+type ModelSource interface {
+	Name() string
+	ScanModels(ctx context.Context) ([]ModelRate, error)
+}
+
+// ComputeSource fetches SuperPlane runner VM rates.
+type ComputeSource interface {
+	Name() string
+	ScanCompute(ctx context.Context) ([]ComputeRate, error)
+}
+
+// Options configure a scan. HTTP is required for OpenRouter.
+type Options struct {
+	HTTP          core.HTTPContext
+	OpenRouterURL string
+	Now           func() time.Time
+	Models        []ModelSource
+	Compute       ComputeSource
+}
+
+// Scanner merges vendor and catalog sources, then publishes a new version.
+type Scanner struct {
+	models  []ModelSource
+	compute ComputeSource
+	now     func() time.Time
+}
+
+// NewScanner builds the default OpenRouter + SuperPlane catalog scanner.
+func NewScanner(opts Options) Scanner {
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	models := opts.Models
+	if models == nil {
+		models = []ModelSource{
+			CatalogSource{},
+			OpenRouterSource{HTTP: opts.HTTP, URL: opts.OpenRouterURL},
+		}
+	}
+	compute := opts.Compute
+	if compute == nil {
+		compute = CatalogSource{}
+	}
+	return Scanner{models: models, compute: compute, now: now}
+}
+
+// Scan fetches every source and merges exact vendor rates over catalog fallbacks.
+func (s Scanner) Scan(ctx context.Context) (Snapshot, error) {
+	if s.compute == nil {
+		return Snapshot{}, fmt.Errorf("compute source is required")
+	}
+	if len(s.models) == 0 {
+		return Snapshot{}, fmt.Errorf("model source is required")
+	}
+
+	snapshot := Snapshot{}
+	merged := map[string]ModelRate{}
+	for _, source := range s.models {
+		rates, err := source.ScanModels(ctx)
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("scan models from %s: %w", source.Name(), err)
+		}
+		snapshot.Sources = appendUnique(snapshot.Sources, source.Name())
+		for _, rate := range rates {
+			key := rate.MatchMode + ":" + rate.MatchKey
+			merged[key] = rate
+		}
+	}
+
+	snapshot.ModelRates = make([]ModelRate, 0, len(merged))
+	for _, rate := range merged {
+		snapshot.ModelRates = append(snapshot.ModelRates, rate)
+	}
+
+	computeRates, err := s.compute.ScanCompute(ctx)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("scan compute from %s: %w", s.compute.Name(), err)
+	}
+	if len(computeRates) == 0 {
+		return Snapshot{}, fmt.Errorf("compute catalog returned no VM rates")
+	}
+	snapshot.ComputeRates = computeRates
+	snapshot.Sources = appendUnique(snapshot.Sources, s.compute.Name())
+	return snapshot, nil
+}
+
+// ScanAndPublish writes a new price book version and loads it in memory.
+func ScanAndPublish(ctx context.Context, tx *gorm.DB, scanner Scanner) (*Result, error) {
+	snapshot, err := scanner.Scan(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	if scanner.now != nil {
+		now = scanner.now().UTC()
+	}
+
+	var result *Result
+	err = tx.WithContext(ctx).Transaction(func(inner *gorm.DB) error {
+		previous := ""
+		current, findErr := models.FindLatestPriceBook(inner)
+		if findErr == nil {
+			previous = current.Version
+		} else if !errors.Is(findErr, gorm.ErrRecordNotFound) {
+			return findErr
+		}
+
+		version, versionErr := models.NextPriceBookVersion(inner, now)
+		if versionErr != nil {
+			return versionErr
+		}
+
+		insertErr := models.InsertPriceBook(inner, models.UsagePriceBook{
+			Version:     version,
+			EffectiveAt: now,
+		}, snapshotRates(snapshot))
+		if insertErr != nil {
+			return insertErr
+		}
+		if loadErr := models.LoadCurrentPriceBook(inner); loadErr != nil {
+			return loadErr
+		}
+
+		result = &Result{
+			Version:          version,
+			PreviousVersion:  previous,
+			ModelRateCount:   len(snapshot.ModelRates),
+			ComputeRateCount: len(snapshot.ComputeRates),
+			Sources:          snapshot.Sources,
+			EffectiveAt:      now,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func snapshotRates(snapshot Snapshot) []models.UsagePriceBookRate {
+	rows := make([]models.UsagePriceBookRate, 0, len(snapshot.ModelRates)+len(snapshot.ComputeRates))
+	for _, rate := range snapshot.ModelRates {
+		rows = append(rows, models.UsagePriceBookRate{
+			ID:                        uuid.New(),
+			UsageKind:                 models.UsageKindModel,
+			MatchKey:                  rate.MatchKey,
+			MatchMode:                 rate.MatchMode,
+			InputCentsPerMillion:      rate.Rate.Input,
+			OutputCentsPerMillion:     rate.Rate.Output,
+			CacheReadCentsPerMillion:  rate.Rate.CacheRead,
+			CacheWriteCentsPerMillion: rate.Rate.CacheWrite,
+			ReasoningCentsPerMillion:  rate.Rate.Reasoning,
+		})
+	}
+	for _, rate := range snapshot.ComputeRates {
+		rows = append(rows, models.UsagePriceBookRate{
+			ID:              uuid.New(),
+			UsageKind:       models.UsageKindCompute,
+			MatchKey:        rate.MachineType,
+			MatchMode:       models.UsagePriceBookMatchExact,
+			MicrosPerSecond: rate.MicrosPerSecond,
+		})
+	}
+	return rows
+}
+
+func appendUnique(items []string, value string) []string {
+	for _, item := range items {
+		if item == value {
+			return items
+		}
+	}
+	return append(items, value)
+}

--- a/pkg/usage/pricesync/scan_test.go
+++ b/pkg/usage/pricesync/scan_test.go
@@ -1,0 +1,130 @@
+package pricesync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/usage/pricebook"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+type stubModelSource struct {
+	name  string
+	rates []ModelRate
+	err   error
+}
+
+func (s stubModelSource) Name() string { return s.name }
+
+func (s stubModelSource) ScanModels(context.Context) ([]ModelRate, error) {
+	return s.rates, s.err
+}
+
+type stubComputeSource struct {
+	name  string
+	rates []ComputeRate
+	err   error
+}
+
+func (s stubComputeSource) Name() string { return s.name }
+
+func (s stubComputeSource) ScanCompute(context.Context) ([]ComputeRate, error) {
+	return s.rates, s.err
+}
+
+func TestScannerScan_MergesExactOverCatalog(t *testing.T) {
+	scanner := NewScanner(Options{
+		Models: []ModelSource{
+			CatalogSource{},
+			stubModelSource{
+				name: "openrouter",
+				rates: []ModelRate{{
+					MatchKey:  "anthropic/claude-sonnet-4",
+					MatchMode: models.UsagePriceBookMatchExact,
+					Rate:      pricebook.Rate{Input: 321},
+				}},
+			},
+		},
+		Compute: CatalogSource{},
+	})
+
+	snapshot, err := scanner.Scan(context.Background())
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"superplane-catalog", "openrouter"}, snapshot.Sources)
+	require.NotEmpty(t, snapshot.ComputeRates)
+
+	var exact *ModelRate
+	var prefix *ModelRate
+	for i := range snapshot.ModelRates {
+		rate := snapshot.ModelRates[i]
+		if rate.MatchKey == "anthropic/claude-sonnet-4" && rate.MatchMode == models.UsagePriceBookMatchExact {
+			exact = &rate
+		}
+		if rate.MatchKey == "claude-sonnet" && rate.MatchMode == models.UsagePriceBookMatchPrefix {
+			prefix = &rate
+		}
+	}
+	require.NotNil(t, exact)
+	require.NotNil(t, prefix)
+	assert.Equal(t, int64(321), exact.Rate.Input)
+	assert.Equal(t, int64(300), prefix.Rate.Input)
+}
+
+func TestScannerScan_FailsWhenOpenRouterFails(t *testing.T) {
+	scanner := NewScanner(Options{
+		Models: []ModelSource{
+			CatalogSource{},
+			stubModelSource{name: "openrouter", err: assert.AnError},
+		},
+		Compute: CatalogSource{},
+	})
+
+	_, err := scanner.Scan(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "openrouter")
+}
+
+func TestScanAndPublish_WritesVersionAndReloads(t *testing.T) {
+	_ = support.Setup(t)
+	t.Cleanup(pricebook.Reset)
+
+	now := time.Date(2098, 6, 1, 15, 0, 0, 0, time.UTC)
+	scanner := NewScanner(Options{
+		Now: func() time.Time { return now },
+		Models: []ModelSource{
+			stubModelSource{
+				name: "openrouter",
+				rates: []ModelRate{{
+					MatchKey:  "openai/gpt-4o",
+					MatchMode: models.UsagePriceBookMatchExact,
+					Rate:      pricebook.Rate{Input: 250, Output: 1000},
+				}},
+			},
+		},
+		Compute: CatalogSource{},
+	})
+
+	tx := database.Conn()
+	result, err := ScanAndPublish(context.Background(), tx, scanner)
+	require.NoError(t, err)
+	assert.Equal(t, "2098-06-01.1", result.Version)
+	assert.Equal(t, 1, result.ModelRateCount)
+	assert.Greater(t, result.ComputeRateCount, 0)
+	assert.Equal(t, int64(2_500_000), pricebook.EstimateMicros("openrouter", "openai/gpt-4o", 1_000_000, 0, 0, 0, 0))
+	assert.Equal(t, 10*pricebook.MicrosPerSecondE1Large, pricebook.EstimateComputeMicros("e1-large-amd64", "e1-large-amd64", 10))
+
+	second, err := ScanAndPublish(context.Background(), tx, scanner)
+	require.NoError(t, err)
+	assert.Equal(t, "2098-06-01.2", second.Version)
+	assert.Equal(t, result.Version, second.PreviousVersion)
+
+	t.Cleanup(func() {
+		_ = tx.Where("version LIKE ?", "2098-06-01.%").Delete(&models.UsagePriceBookRate{})
+		_ = tx.Where("version LIKE ?", "2098-06-01.%").Delete(&models.UsagePriceBook{})
+	})
+}

--- a/pkg/workers/price_book_sync_worker.go
+++ b/pkg/workers/price_book_sync_worker.go
@@ -1,0 +1,82 @@
+package workers
+
+import (
+	"context"
+	"os"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/usage/pricesync"
+)
+
+const defaultPriceBookSyncEvery = 24 * time.Hour
+
+type PriceBookSyncWorker struct {
+	logger   *log.Entry
+	interval time.Duration
+	scan     func(ctx context.Context, tx *gorm.DB) (*pricesync.Result, error)
+}
+
+func NewPriceBookSyncWorker(httpClient core.HTTPContext) *PriceBookSyncWorker {
+	return &PriceBookSyncWorker{
+		logger:   log.WithFields(log.Fields{"worker": "PriceBookSyncWorker"}),
+		interval: priceBookSyncInterval(),
+		scan: func(ctx context.Context, tx *gorm.DB) (*pricesync.Result, error) {
+			return pricesync.ScanAndPublish(ctx, tx, pricesync.NewScanner(pricesync.Options{HTTP: httpClient}))
+		},
+	}
+}
+
+func (w *PriceBookSyncWorker) Start(ctx context.Context) {
+	w.tick(ctx)
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.tick(ctx)
+		}
+	}
+}
+
+func (w *PriceBookSyncWorker) tick(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+
+	startedAt := time.Now()
+	result, err := w.scan(ctx, database.DB(ctx))
+	if err != nil {
+		w.logger.Errorf("Price book scan failed: %v", err)
+		return
+	}
+
+	w.logger.WithFields(log.Fields{
+		"version":       result.Version,
+		"previous":      result.PreviousVersion,
+		"model_rates":   result.ModelRateCount,
+		"compute_rates": result.ComputeRateCount,
+		"sources":       result.Sources,
+		"duration":      time.Since(startedAt).String(),
+	}).Info("Price book scan published a new catalog")
+}
+
+func priceBookSyncInterval() time.Duration {
+	raw := os.Getenv("PRICE_BOOK_SYNC_EVERY")
+	if raw == "" {
+		return defaultPriceBookSyncEvery
+	}
+	parsed, err := time.ParseDuration(raw)
+	if err != nil || parsed <= 0 {
+		return defaultPriceBookSyncEvery
+	}
+	return parsed
+}

--- a/pkg/workers/price_book_sync_worker_test.go
+++ b/pkg/workers/price_book_sync_worker_test.go
@@ -1,0 +1,39 @@
+package workers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/usage/pricesync"
+	"gorm.io/gorm"
+)
+
+func TestPriceBookSyncInterval(t *testing.T) {
+	t.Setenv("PRICE_BOOK_SYNC_EVERY", "")
+	assert.Equal(t, defaultPriceBookSyncEvery, priceBookSyncInterval())
+
+	t.Setenv("PRICE_BOOK_SYNC_EVERY", "not-a-duration")
+	assert.Equal(t, defaultPriceBookSyncEvery, priceBookSyncInterval())
+
+	t.Setenv("PRICE_BOOK_SYNC_EVERY", "15m")
+	assert.Equal(t, 15*time.Minute, priceBookSyncInterval())
+}
+
+func TestPriceBookSyncWorkerTick_PublishesScan(t *testing.T) {
+	called := false
+	worker := &PriceBookSyncWorker{
+		logger:   log.NewEntry(log.New()),
+		interval: time.Hour,
+		scan: func(context.Context, *gorm.DB) (*pricesync.Result, error) {
+			called = true
+			return &pricesync.Result{Version: "2099-01-02.1"}, nil
+		},
+	}
+
+	worker.tick(context.Background())
+	require.True(t, called)
+}

--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -75,6 +75,7 @@ import OrganizationDetailAdmin from "./pages/admin/OrganizationDetail";
 import AccountsListAdmin from "./pages/admin/AccountsList";
 import InstallationSettingsAdmin from "./pages/admin/InstallationSettings";
 import RunnerTasksAdmin from "./pages/admin/RunnerTasks";
+import PriceBookPageAdmin from "./pages/admin/PriceBookPage";
 import ImpersonationBanner from "./components/ImpersonationBanner";
 import { usePageObservability } from "./hooks/usePageObservability";
 
@@ -226,6 +227,7 @@ function AppRouter() {
                 <Route path="accounts" element={<AccountsListAdmin />} />
                 <Route path="settings" element={<InstallationSettingsAdmin />} />
                 <Route path="runner-tasks" element={<RunnerTasksAdmin />} />
+                <Route path="price-book" element={<PriceBookPageAdmin />} />
                 <Route path="organizations/:orgId" element={<OrganizationDetailAdmin />} />
               </Route>
               <Route path="" element={withAuthOnly(RootOrganizationRedirect)} />

--- a/web_src/src/components/GlobalCommandPalette/constants.ts
+++ b/web_src/src/components/GlobalCommandPalette/constants.ts
@@ -1,4 +1,5 @@
 import {
+  BookOpen,
   Building2,
   CircleUser,
   Gauge,
@@ -133,5 +134,12 @@ export const ADMIN_LINKS: Array<{
     description: "Inspect runner task activity",
     href: "/admin/runner-tasks",
     icon: Terminal,
+  },
+  {
+    id: "price-book",
+    label: "Price book",
+    description: "Scan and update model and VM rates",
+    href: "/admin/price-book",
+    icon: BookOpen,
   },
 ];

--- a/web_src/src/lib/priceBookRates.spec.ts
+++ b/web_src/src/lib/priceBookRates.spec.ts
@@ -1,0 +1,10 @@
+import { formatCentsPerMillion, formatMicrosPerHour } from "@/lib/priceBookRates";
+
+import { describe, expect, it } from "vitest";
+
+describe("priceBookRates", () => {
+  it("formats model and VM prices", () => {
+    expect(formatCentsPerMillion(300)).toBe("$3.00 / MTok");
+    expect(formatMicrosPerHour(556)).toBe("$2.00 / hour");
+  });
+});

--- a/web_src/src/lib/priceBookRates.ts
+++ b/web_src/src/lib/priceBookRates.ts
@@ -1,0 +1,7 @@
+export function formatCentsPerMillion(cents: number): string {
+  return `$${(cents / 100).toFixed(2)} / MTok`;
+}
+
+export function formatMicrosPerHour(microsPerSecond: number): string {
+  return `$${((microsPerSecond * 3600) / 1_000_000).toFixed(2)} / hour`;
+}

--- a/web_src/src/pages/admin/AdminLayout.tsx
+++ b/web_src/src/pages/admin/AdminLayout.tsx
@@ -1,7 +1,7 @@
 import SuperplaneLogo from "@/assets/superplane.svg";
 import { Text } from "@/components/Text/text";
 import { useAccount } from "@/contexts/useAccount";
-import { ArrowLeft, Building, Network, Shield, Terminal, Users } from "lucide-react";
+import { ArrowLeft, BookOpen, Building, Network, Shield, Terminal, Users } from "lucide-react";
 import React from "react";
 import { Link, Navigate, NavLink, Outlet } from "react-router";
 
@@ -64,6 +64,10 @@ const AdminLayout: React.FC = () => {
               <NavLink to="/admin/runner-tasks" className={navLinkClass}>
                 <Terminal size={14} />
                 Runner Tasks
+              </NavLink>
+              <NavLink to="/admin/price-book" className={navLinkClass}>
+                <BookOpen size={14} />
+                Price book
               </NavLink>
             </nav>
           </div>

--- a/web_src/src/pages/admin/PriceBookPage.spec.tsx
+++ b/web_src/src/pages/admin/PriceBookPage.spec.tsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+
+import PriceBookPage from "./PriceBookPage";
+
+const book = {
+  version: "2026-08-31.2",
+  effective_at: "2026-08-31T12:00:00Z",
+  model_rate_count: 1,
+  compute_rate_count: 1,
+  rates: [
+    {
+      usage_kind: "model",
+      match_key: "claude-sonnet",
+      match_mode: "prefix",
+      input_cents_per_million: 300,
+      output_cents_per_million: 1500,
+      cache_read_cents_per_million: 30,
+      cache_write_cents_per_million: 375,
+      reasoning_cents_per_million: 0,
+      micros_per_second: 0,
+    },
+    {
+      usage_kind: "compute",
+      match_key: "e1-large-amd64",
+      match_mode: "exact",
+      input_cents_per_million: 0,
+      output_cents_per_million: 0,
+      cache_read_cents_per_million: 0,
+      cache_write_cents_per_million: 0,
+      reasoning_cents_per_million: 0,
+      micros_per_second: 556,
+    },
+  ],
+};
+
+const mockFetch = (handler: (url: string, init?: RequestInit) => Promise<Response> | Response) => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      return handler(String(input), init);
+    }),
+  );
+};
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={["/admin/price-book"]}>
+      <PriceBookPage />
+    </MemoryRouter>,
+  );
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("PriceBookPage", () => {
+  it("loads the current catalog and filters rates", async () => {
+    mockFetch(async () => {
+      return new Response(JSON.stringify(book), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(await screen.findByTestId("admin-price-book-version")).toHaveTextContent("2026-08-31.2");
+    expect(screen.getByText("claude-sonnet")).toBeInTheDocument();
+    expect(screen.getByText("e1-large-amd64")).toBeInTheDocument();
+
+    await user.type(screen.getByTestId("admin-price-book-search"), "e1-large");
+    expect(screen.queryByText("claude-sonnet")).not.toBeInTheDocument();
+    expect(screen.getByText("e1-large-amd64")).toBeInTheDocument();
+  });
+
+  it("scans and updates the catalog", async () => {
+    mockFetch(async (url, init) => {
+      if (url.endsWith("/scan") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            ...book,
+            version: "2026-09-09.1",
+            previous_version: "2026-08-31.2",
+            model_rate_count: 2,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify(book), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const user = userEvent.setup();
+
+    renderPage();
+    expect(await screen.findByTestId("admin-price-book-version")).toHaveTextContent("2026-08-31.2");
+
+    await user.click(screen.getByTestId("admin-price-book-scan"));
+    await waitFor(() => {
+      expect(screen.getByTestId("admin-price-book-version")).toHaveTextContent("2026-09-09.1");
+    });
+  });
+});

--- a/web_src/src/pages/admin/PriceBookPage.tsx
+++ b/web_src/src/pages/admin/PriceBookPage.tsx
@@ -1,0 +1,235 @@
+import { Text } from "@/components/Text/text";
+import { Input, InputGroup } from "@/components/Input/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Timestamp } from "@/components/Timestamp";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
+import { showErrorToast, showSuccessToast } from "@/lib/toast";
+import { formatCentsPerMillion, formatMicrosPerHour } from "@/lib/priceBookRates";
+import { BookOpen, Search } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type PriceBookRate = {
+  usage_kind: string;
+  match_key: string;
+  match_mode: string;
+  input_cents_per_million: number;
+  output_cents_per_million: number;
+  cache_read_cents_per_million: number;
+  cache_write_cents_per_million: number;
+  reasoning_cents_per_million: number;
+  micros_per_second: number;
+};
+
+type PriceBookResponse = {
+  version: string;
+  previous_version?: string;
+  effective_at?: string | null;
+  model_rate_count: number;
+  compute_rate_count: number;
+  sources?: string[];
+  rates: PriceBookRate[];
+};
+
+const loadErrorMessage = "SuperPlane could not load the price book.";
+const scanErrorMessage = "SuperPlane could not scan provider prices. Try again.";
+
+function PriceBookPage() {
+  const [book, setBook] = useState<PriceBookResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [scanning, setScanning] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const applyBook = useCallback((data: PriceBookResponse) => {
+    setBook({
+      ...data,
+      rates: data.rates ?? [],
+    });
+  }, []);
+
+  const loadBook = useCallback(async () => {
+    try {
+      const response = await fetch("/admin/api/installation/price-book", { credentials: "include" });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text.trim() || loadErrorMessage);
+      }
+      applyBook((await response.json()) as PriceBookResponse);
+    } catch (error) {
+      showErrorToast(error instanceof Error ? error.message : loadErrorMessage);
+    } finally {
+      setLoading(false);
+    }
+  }, [applyBook]);
+
+  const scanBook = useCallback(async () => {
+    setScanning(true);
+    try {
+      const response = await fetch("/admin/api/installation/price-book/scan", {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text.trim() || scanErrorMessage);
+      }
+      const data = (await response.json()) as PriceBookResponse;
+      applyBook(data);
+      showSuccessToast(`Price book updated to version ${data.version}.`);
+    } catch (error) {
+      showErrorToast(error instanceof Error ? error.message : scanErrorMessage);
+    } finally {
+      setScanning(false);
+    }
+  }, [applyBook]);
+
+  useEffect(() => {
+    void loadBook();
+  }, [loadBook]);
+
+  useReportPageReady(!loading);
+
+  const filteredRates = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    const rates = book?.rates ?? [];
+    if (query === "") {
+      return rates;
+    }
+    return rates.filter((rate) => {
+      return (
+        rate.match_key.toLowerCase().includes(query) ||
+        rate.usage_kind.toLowerCase().includes(query) ||
+        rate.match_mode.toLowerCase().includes(query)
+      );
+    });
+  }, [book, search]);
+
+  if (loading && book == null) {
+    return (
+      <div className="flex flex-col items-center space-y-4 py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-b border-gray-500 dark:border-gray-400"></div>
+        <Text className="text-gray-500 dark:text-gray-400">Loading price book...</Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Price book</h1>
+          <Text className="mt-1 max-w-2xl text-sm text-gray-500 dark:text-gray-400">
+            Scan OpenRouter model prices and SuperPlane runner VM rates. SuperPlane writes a new catalog version and
+            loads it without a restart.
+          </Text>
+        </div>
+        <Button type="button" data-testid="admin-price-book-scan" onClick={() => void scanBook()} disabled={scanning}>
+          {scanning ? "Scanning..." : "Scan and update"}
+        </Button>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <SummaryCard label="Version" value={book?.version || "—"} testId="admin-price-book-version" />
+        <SummaryCard
+          label="Model rates"
+          value={String(book?.model_rate_count ?? 0)}
+          testId="admin-price-book-model-count"
+        />
+        <SummaryCard
+          label="VM rates"
+          value={String(book?.compute_rate_count ?? 0)}
+          testId="admin-price-book-compute-count"
+        />
+      </div>
+
+      <Text className="text-sm text-gray-500 dark:text-gray-400">
+        Effective{" "}
+        <Timestamp
+          date={book?.effective_at ?? undefined}
+          className="text-gray-700 dark:text-gray-300"
+          fallback={<span>—</span>}
+        />
+      </Text>
+
+      <div className="max-w-md">
+        <Label htmlFor="admin-price-book-search">Search rates</Label>
+        <InputGroup className="relative mt-1">
+          <Search
+            size={14}
+            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+          />
+          <Input
+            id="admin-price-book-search"
+            data-testid="admin-price-book-search"
+            type="search"
+            className="pl-9"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Model or machine type"
+          />
+        </InputGroup>
+      </div>
+
+      {filteredRates.length === 0 ? (
+        <div className="rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-gray-700 dark:bg-gray-900">
+          <BookOpen size={24} className="mx-auto text-gray-400 dark:text-gray-500" />
+          <Text className="mt-3 text-sm text-gray-600 dark:text-gray-400">
+            {search.trim() === "" ? "No price book rates are stored yet." : "No rates match this search."}
+          </Text>
+        </div>
+      ) : (
+        <PriceBookRatesTable rates={filteredRates} />
+      )}
+    </div>
+  );
+}
+
+function SummaryCard({ label, value, testId }: { label: string; value: string; testId: string }) {
+  return (
+    <div className="rounded-md bg-white px-4 py-3 shadow-sm outline outline-slate-950/10 dark:bg-gray-900 dark:outline-gray-700/70">
+      <p className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{label}</p>
+      <p className="mt-1 font-mono text-sm text-gray-900 dark:text-gray-100" data-testid={testId}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function PriceBookRatesTable({ rates }: { rates: PriceBookRate[] }) {
+  return (
+    <div className="overflow-hidden rounded-md bg-white shadow-sm outline outline-slate-950/10 dark:bg-gray-900 dark:outline-gray-700/70">
+      <table className="w-full text-sm" data-testid="admin-price-book-rates">
+        <thead>
+          <tr className="border-b border-slate-100 dark:border-gray-700/70">
+            <th className="px-4 py-2.5 text-left font-medium text-gray-500 dark:text-gray-400">Kind</th>
+            <th className="px-4 py-2.5 text-left font-medium text-gray-500 dark:text-gray-400">Match</th>
+            <th className="px-4 py-2.5 text-left font-medium text-gray-500 dark:text-gray-400">Mode</th>
+            <th className="px-4 py-2.5 text-left font-medium text-gray-500 dark:text-gray-400">Price</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rates.map((rate) => (
+            <tr
+              key={`${rate.usage_kind}:${rate.match_mode}:${rate.match_key}`}
+              className="border-b border-slate-50 last:border-0 dark:border-gray-800"
+            >
+              <td className="px-4 py-2.5 text-gray-700 dark:text-gray-300">{rate.usage_kind}</td>
+              <td className="px-4 py-2.5 font-mono text-gray-900 dark:text-gray-100">{rate.match_key}</td>
+              <td className="px-4 py-2.5 text-gray-700 dark:text-gray-300">{rate.match_mode}</td>
+              <td className="px-4 py-2.5 text-gray-700 dark:text-gray-300">{ratePriceLabel(rate)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ratePriceLabel(rate: PriceBookRate): string {
+  if (rate.usage_kind === "compute") {
+    return formatMicrosPerHour(rate.micros_per_second);
+  }
+  return `in ${formatCentsPerMillion(rate.input_cents_per_million)}, out ${formatCentsPerMillion(rate.output_cents_per_million)}`;
+}
+
+export default PriceBookPage;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Installation admins could not refresh LLM and runner VM rates without a SQL migration and a restart.

This change adds a unified scan that fetches OpenRouter model prices, republishes SuperPlane runner VM rates, and loads the new catalog in memory.

The admin Price book page triggers that scan. A worker can call the same function on an interval.

Closes #7235

## Test plan

- [x] Open Installation Admin and go to Price book.
- [x] Confirm the current version and rate counts load.
- [x] Click Scan and update.
- [x] Confirm SuperPlane writes a new version and shows OpenRouter model rates.
- [x] Search for a machine type and confirm the VM rate remains.

[Price book before scan](https://cursor.com/agents/bc-8b755159-1f99-4707-8a0a-06a502a3886f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprice-book-before-scan.webp)
[Price book after scan](https://cursor.com/agents/bc-8b755159-1f99-4707-8a0a-06a502a3886f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprice-book-after-scan.webp)
[Price book search for e1-large](https://cursor.com/agents/bc-8b755159-1f99-4707-8a0a-06a502a3886f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprice-book-search-filter.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b755159-1f99-4707-8a0a-06a502a3886f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b755159-1f99-4707-8a0a-06a502a3886f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- greptile_comment -->

<sub>Reviews (3): Last reviewed commit: ["feat: Add admin price book scan"](https://github.com/superplanehq/superplane/commit/f758cf9a6b5c38baf63bdd1ca87947f17a39c08b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62177139)</sub>

<!-- /greptile_comment -->