### PR TITLE
fix: Clarify runner live log states

### DIFF
--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStateNotice.tsx
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStateNotice.tsx
@@ -1,11 +1,14 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { CircleAlert, Loader2, RefreshCw, Terminal } from "lucide-react";
+import { CircleAlert, Loader2, Radio, RefreshCw, Terminal } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
+
+type NonErrorLiveLogState = "loading" | "waiting" | "empty";
 
 type LiveLogStateNoticeProps =
   | {
-      state: "waiting" | "empty";
+      state: NonErrorLiveLogState;
       compact?: boolean;
     }
   | {
@@ -15,6 +18,29 @@ type LiveLogStateNoticeProps =
       onRetry: () => void;
       compact?: boolean;
     };
+
+const liveLogStateContent: Record<
+  NonErrorLiveLogState,
+  { title: string; description: string; Icon: LucideIcon; iconClassName?: string }
+> = {
+  loading: {
+    title: "Loading logs",
+    description: "SuperPlane is loading saved log output.",
+    Icon: Loader2,
+    iconClassName: "animate-spin",
+  },
+  waiting: {
+    title: "Waiting for logs",
+    description: "Logs will appear when the runner sends output.",
+    Icon: Radio,
+    iconClassName: "animate-pulse",
+  },
+  empty: {
+    title: "No logs available",
+    description: "This execution did not produce log output.",
+    Icon: Terminal,
+  },
+};
 
 export function LiveLogStateNotice(props: LiveLogStateNoticeProps) {
   const compact = props.compact ?? false;
@@ -55,39 +81,32 @@ export function LiveLogStateNotice(props: LiveLogStateNoticeProps) {
     );
   }
 
-  const isWaiting = props.state === "waiting";
+  const content = liveLogStateContent[props.state];
   return (
     <div
-      role={isWaiting ? "status" : undefined}
+      role={props.state === "empty" ? undefined : "status"}
       className={cn(
         "flex flex-col items-center justify-center gap-2 px-6 text-center",
         compact ? "py-4" : "min-h-48 py-8",
       )}
     >
-      <StateIcon tone={isWaiting ? "waiting" : "empty"}>
-        {isWaiting ? (
-          <Loader2 className="size-5 animate-spin" aria-hidden />
-        ) : (
-          <Terminal className="size-5" aria-hidden />
-        )}
+      <StateIcon tone={props.state}>
+        <content.Icon className={cn("size-5", content.iconClassName)} aria-hidden />
       </StateIcon>
       <div className="space-y-1">
-        <p className="text-sm font-medium text-slate-700 dark:text-gray-200">
-          {isWaiting ? "Waiting for logs" : "No logs available"}
-        </p>
-        <p className="text-xs text-slate-500 dark:text-gray-400">
-          {isWaiting ? "Logs will appear when the runner sends output." : "This execution did not produce log output."}
-        </p>
+        <p className="text-sm font-medium text-slate-700 dark:text-gray-200">{content.title}</p>
+        <p className="text-xs text-slate-500 dark:text-gray-400">{content.description}</p>
       </div>
     </div>
   );
 }
 
-function StateIcon({ tone, children }: { tone: "waiting" | "empty" | "error"; children: ReactNode }) {
+function StateIcon({ tone, children }: { tone: "loading" | "waiting" | "empty" | "error"; children: ReactNode }) {
   return (
     <div
       className={cn("flex size-10 items-center justify-center rounded-full", {
-        "bg-blue-100 text-blue-600 dark:bg-blue-950/50 dark:text-blue-300": tone === "waiting",
+        "bg-blue-100 text-blue-600 dark:bg-blue-950/50 dark:text-blue-300": tone === "loading",
+        "bg-amber-100 text-amber-600 dark:bg-amber-950/50 dark:text-amber-300": tone === "waiting",
         "bg-slate-200 text-slate-500 dark:bg-gray-800 dark:text-gray-400": tone === "empty",
         "bg-red-100 text-red-600 dark:bg-red-950/50 dark:text-red-300": tone === "error",
       })}

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStateNotice.tsx
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStateNotice.tsx
@@ -37,7 +37,7 @@ const liveLogStateContent: Record<
   },
   empty: {
     title: "No logs available",
-    description: "This execution did not produce log output.",
+    description: "Run the task again to produce new log output.",
     Icon: Terminal,
   },
 };

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStateNotice.tsx
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStateNotice.tsx
@@ -1,0 +1,98 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { CircleAlert, Loader2, RefreshCw, Terminal } from "lucide-react";
+import type { ReactNode } from "react";
+
+type LiveLogStateNoticeProps =
+  | {
+      state: "waiting" | "empty";
+      compact?: boolean;
+    }
+  | {
+      state: "error";
+      error: string;
+      willRetry: boolean;
+      onRetry: () => void;
+      compact?: boolean;
+    };
+
+export function LiveLogStateNotice(props: LiveLogStateNoticeProps) {
+  const compact = props.compact ?? false;
+
+  if (props.state === "error") {
+    return (
+      <div
+        role="alert"
+        className={cn(
+          "flex flex-col items-center justify-center gap-2 px-6 text-center",
+          compact ? "py-4" : "min-h-48 py-8",
+        )}
+      >
+        <StateIcon tone="error">
+          <CircleAlert className="size-5" aria-hidden />
+        </StateIcon>
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-red-700 dark:text-red-300">
+            {props.willRetry ? "Logs are temporarily unavailable" : "Could not load logs"}
+          </p>
+          <p className="text-xs text-slate-500 dark:text-gray-400">
+            {props.willRetry ? "SuperPlane will try again automatically." : "Check your connection and try again."}
+          </p>
+        </div>
+        <details className="max-w-xl text-left text-xs text-slate-500 dark:text-gray-400">
+          <summary className="cursor-pointer select-none text-center hover:text-slate-700 dark:hover:text-gray-200">
+            Error details
+          </summary>
+          <p className="mt-2 max-h-28 overflow-auto rounded-md bg-red-50 px-3 py-2 font-mono break-words text-red-700 dark:bg-red-950/30 dark:text-red-300">
+            {props.error}
+          </p>
+        </details>
+        <Button type="button" variant="outline" size="sm" onClick={props.onRetry}>
+          <RefreshCw className="size-3.5" aria-hidden />
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  const isWaiting = props.state === "waiting";
+  return (
+    <div
+      role={isWaiting ? "status" : undefined}
+      className={cn(
+        "flex flex-col items-center justify-center gap-2 px-6 text-center",
+        compact ? "py-4" : "min-h-48 py-8",
+      )}
+    >
+      <StateIcon tone={isWaiting ? "waiting" : "empty"}>
+        {isWaiting ? (
+          <Loader2 className="size-5 animate-spin" aria-hidden />
+        ) : (
+          <Terminal className="size-5" aria-hidden />
+        )}
+      </StateIcon>
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-slate-700 dark:text-gray-200">
+          {isWaiting ? "Waiting for logs" : "No logs available"}
+        </p>
+        <p className="text-xs text-slate-500 dark:text-gray-400">
+          {isWaiting ? "Logs will appear when the runner sends output." : "This execution did not produce log output."}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function StateIcon({ tone, children }: { tone: "waiting" | "empty" | "error"; children: ReactNode }) {
+  return (
+    <div
+      className={cn("flex size-10 items-center justify-center rounded-full", {
+        "bg-blue-100 text-blue-600 dark:bg-blue-950/50 dark:text-blue-300": tone === "waiting",
+        "bg-slate-200 text-slate-500 dark:bg-gray-800 dark:text-gray-400": tone === "empty",
+        "bg-red-100 text-red-600 dark:bg-red-950/50 dark:text-red-300": tone === "error",
+      })}
+    >
+      {children}
+    </div>
+  );
+}

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.spec.tsx
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.spec.tsx
@@ -60,6 +60,7 @@ describe("LiveLogStreamView", () => {
     render(<LiveLogStreamView execution={finishedExecution} />);
 
     expect(screen.getByText("No logs available")).toBeInTheDocument();
+    expect(screen.getByText("Run the task again to produce new log output.")).toBeInTheDocument();
     expect(screen.queryByText("Waiting for logs")).not.toBeInTheDocument();
   });
 

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.spec.tsx
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.spec.tsx
@@ -26,6 +26,7 @@ beforeEach(() => {
     sections: [],
     orphanLines: [],
     error: null,
+    isLoading: false,
     isStreaming: false,
     telemetry: { num_turns: 0, usage: {}, tool_counts: {}, turns: [] },
     usageSeries: [],
@@ -36,11 +37,12 @@ beforeEach(() => {
 });
 
 describe("LiveLogStreamView", () => {
-  it("does not wait for more logs after an execution finishes", () => {
+  it("shows loading while it fetches logs for a finished execution", () => {
     useLiveLogStreamMock.mockReturnValue({
       sections: [],
       orphanLines: [],
       error: null,
+      isLoading: true,
       isStreaming: true,
       toggleSection: vi.fn(),
       retry: vi.fn(),
@@ -49,9 +51,9 @@ describe("LiveLogStreamView", () => {
 
     render(<LiveLogStreamView execution={finishedExecution} />);
 
-    expect(screen.getByText("No logs available")).toBeInTheDocument();
-    expect(screen.getByText("This execution did not produce log output.")).toBeInTheDocument();
+    expect(screen.getByText("Loading logs")).toBeInTheDocument();
     expect(screen.queryByText("Waiting for logs")).not.toBeInTheDocument();
+    expect(screen.queryByText("No logs available")).not.toBeInTheDocument();
   });
 
   it("shows the empty state when a finished execution has no logs", () => {
@@ -75,6 +77,7 @@ describe("LiveLogStreamView", () => {
       sections: [],
       orphanLines: [],
       error: "Failed to fetch",
+      isLoading: false,
       isStreaming: false,
       toggleSection: vi.fn(),
       retry,
@@ -94,6 +97,7 @@ describe("LiveLogStreamView", () => {
       sections: [],
       orphanLines: [],
       error: "The log stream is not available yet",
+      isLoading: false,
       isStreaming: false,
       toggleSection: vi.fn(),
       retry: vi.fn(),
@@ -152,6 +156,7 @@ describe("LiveLogStreamView", () => {
       ],
       orphanLines: [],
       error: null,
+      isLoading: false,
       isStreaming: false,
       toggleSection: vi.fn(),
       retry: vi.fn(),

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.spec.tsx
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExecutionInfo } from "@/pages/app/mappers/types";
 import { LiveLogStreamView } from "./LiveLogStreamView";
@@ -30,39 +30,81 @@ beforeEach(() => {
     telemetry: { num_turns: 0, usage: {}, tool_counts: {}, turns: [] },
     usageSeries: [],
     toggleSection: vi.fn(),
+    retry: vi.fn(),
     scrollRef: { current: null },
   });
 });
 
 describe("LiveLogStreamView", () => {
-  it("shows a loading message while the stream is connecting for a finished execution", () => {
+  it("does not wait for more logs after an execution finishes", () => {
     useLiveLogStreamMock.mockReturnValue({
       sections: [],
       orphanLines: [],
       error: null,
       isStreaming: true,
       toggleSection: vi.fn(),
+      retry: vi.fn(),
       scrollRef: { current: null },
     });
 
     render(<LiveLogStreamView execution={finishedExecution} />);
 
-    expect(screen.getByText("Waiting for logs…")).toBeInTheDocument();
-    expect(screen.queryByText("No log lines yet.")).not.toBeInTheDocument();
+    expect(screen.getByText("No logs available")).toBeInTheDocument();
+    expect(screen.getByText("This execution did not produce log output.")).toBeInTheDocument();
+    expect(screen.queryByText("Waiting for logs")).not.toBeInTheDocument();
   });
 
-  it("shows the empty message only after the stream settles with no lines", () => {
+  it("shows the empty state when a finished execution has no logs", () => {
     render(<LiveLogStreamView execution={finishedExecution} />);
 
-    expect(screen.getByText("No log lines yet.")).toBeInTheDocument();
-    expect(screen.queryByText("Waiting for logs…")).not.toBeInTheDocument();
+    expect(screen.getByText("No logs available")).toBeInTheDocument();
+    expect(screen.queryByText("Waiting for logs")).not.toBeInTheDocument();
   });
 
   it("keeps waiting while an in-flight execution has no lines yet", () => {
     render(<LiveLogStreamView execution={startedExecution} />);
 
-    expect(screen.getByText("Waiting for logs…")).toBeInTheDocument();
-    expect(screen.queryByText("No log lines yet.")).not.toBeInTheDocument();
+    expect(screen.getByText("Waiting for logs")).toBeInTheDocument();
+    expect(screen.getByText("Logs will appear when the runner sends output.")).toBeInTheDocument();
+    expect(screen.queryByText("No logs available")).not.toBeInTheDocument();
+  });
+
+  it("shows the error and lets the user retry after an execution finishes", () => {
+    const retry = vi.fn();
+    useLiveLogStreamMock.mockReturnValue({
+      sections: [],
+      orphanLines: [],
+      error: "Failed to fetch",
+      isStreaming: false,
+      toggleSection: vi.fn(),
+      retry,
+      scrollRef: { current: null },
+    });
+
+    render(<LiveLogStreamView execution={finishedExecution} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Could not load logs");
+    expect(screen.getByText("Failed to fetch")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(retry).toHaveBeenCalledOnce();
+  });
+
+  it("shows a retrying error while the execution is in flight", () => {
+    useLiveLogStreamMock.mockReturnValue({
+      sections: [],
+      orphanLines: [],
+      error: "The log stream is not available yet",
+      isStreaming: false,
+      toggleSection: vi.fn(),
+      retry: vi.fn(),
+      scrollRef: { current: null },
+    });
+
+    render(<LiveLogStreamView execution={startedExecution} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Logs are temporarily unavailable");
+    expect(screen.getByText("SuperPlane will try again automatically.")).toBeInTheDocument();
+    expect(screen.queryByText("Waiting for logs")).not.toBeInTheDocument();
   });
 
   it("passes canvas session ids into the live log hook", () => {
@@ -112,6 +154,7 @@ describe("LiveLogStreamView", () => {
       error: null,
       isStreaming: false,
       toggleSection: vi.fn(),
+      retry: vi.fn(),
       scrollRef: { current: null },
     });
 

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.tsx
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.tsx
@@ -6,6 +6,7 @@ import type { ExecutionInfo } from "../../../pages/app/mappers/types";
 import { sectionTitle } from "./liveLogSections";
 import { isExecutionInFlight, type CommandSection } from "./types";
 import { terminalCommandStatusForExecution, terminalTimeMsForExecution, useLiveLogStream } from "./useLiveLogStream";
+import { LiveLogStateNotice } from "./LiveLogStateNotice";
 
 export function LiveLogStreamView({
   execution,
@@ -15,7 +16,7 @@ export function LiveLogStreamView({
   session?: { organizationId?: string; canvasId?: string };
 }) {
   const executionInFlight = isExecutionInFlight(execution);
-  const { sections, orphanLines, error, isStreaming, toggleSection, scrollRef } = useLiveLogStream(
+  const { sections, orphanLines, error, retry, toggleSection, scrollRef } = useLiveLogStream(
     execution.id,
     executionInFlight,
     terminalCommandStatusForExecution(execution),
@@ -24,14 +25,20 @@ export function LiveLogStreamView({
   );
   const hasAnyLogs = orphanLines.length > 0 || sections.length > 0;
   const lastSectionIndex = sections.length - 1;
-  const waitingForLogs = !hasAnyLogs && !error && (executionInFlight || isStreaming);
-  const showError = Boolean(error) && !executionInFlight;
 
   return (
     <div ref={scrollRef} className="h-full min-h-0 overflow-y-auto bg-slate-50 dark:bg-gray-900">
-      {showError ? <ErrorMessage /> : null}
-      {waitingForLogs ? <WaitingForLogsMessage /> : null}
-      {!showError && !waitingForLogs && !hasAnyLogs ? <NoLogsMessage /> : null}
+      {error ? (
+        <LiveLogStateNotice
+          state="error"
+          error={error}
+          willRetry={executionInFlight}
+          onRetry={retry}
+          compact={hasAnyLogs}
+        />
+      ) : null}
+      {!error && !hasAnyLogs && executionInFlight ? <LiveLogStateNotice state="waiting" /> : null}
+      {!error && !hasAnyLogs && !executionInFlight ? <LiveLogStateNotice state="empty" /> : null}
 
       {sections.map((section, index) => (
         <CommandSectionView
@@ -41,22 +48,6 @@ export function LiveLogStreamView({
           isLast={index === lastSectionIndex}
         />
       ))}
-    </div>
-  );
-}
-
-function NoLogsMessage() {
-  return <div className="px-4 py-3 text-left text-muted-foreground">No log lines yet.</div>;
-}
-
-function WaitingForLogsMessage() {
-  return <div className="px-4 py-3 text-left text-muted-foreground">Waiting for logs…</div>;
-}
-
-function ErrorMessage() {
-  return (
-    <div className="px-4 py-3 text-left text-destructive">
-      Something went wrong while fetching logs. Please try again later.
     </div>
   );
 }

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.tsx
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.tsx
@@ -16,7 +16,7 @@ export function LiveLogStreamView({
   session?: { organizationId?: string; canvasId?: string };
 }) {
   const executionInFlight = isExecutionInFlight(execution);
-  const { sections, orphanLines, error, retry, toggleSection, scrollRef } = useLiveLogStream(
+  const { sections, orphanLines, error, isLoading, retry, toggleSection, scrollRef } = useLiveLogStream(
     execution.id,
     executionInFlight,
     terminalCommandStatusForExecution(execution),
@@ -37,8 +37,9 @@ export function LiveLogStreamView({
           compact={hasAnyLogs}
         />
       ) : null}
-      {!error && !hasAnyLogs && executionInFlight ? <LiveLogStateNotice state="waiting" /> : null}
-      {!error && !hasAnyLogs && !executionInFlight ? <LiveLogStateNotice state="empty" /> : null}
+      {!error && !hasAnyLogs && isLoading ? <LiveLogStateNotice state="loading" /> : null}
+      {!error && !hasAnyLogs && !isLoading && executionInFlight ? <LiveLogStateNotice state="waiting" /> : null}
+      {!error && !hasAnyLogs && !isLoading && !executionInFlight ? <LiveLogStateNotice state="empty" /> : null}
 
       {sections.map((section, index) => (
         <CommandSectionView

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.spec.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.spec.ts
@@ -11,7 +11,7 @@ import {
 import type { LogState } from "./types";
 
 function emptyState(): LogState {
-  return { sections: [], orphanLines: [], error: null, isStreaming: false };
+  return { sections: [], orphanLines: [], error: null, isLoading: false, isStreaming: false };
 }
 
 describe("liveLogSections", () => {

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogStream.ts
@@ -30,6 +30,7 @@ type LiveLogSessionResponse = {
 };
 
 export type LiveLogStreamHandlers = {
+  onOpen?: () => void;
   onLogLine: (text: string) => void;
   onStreamError: (message: string) => void;
   onCmdStart?: (index: number, text: string, startedAtMs: number | null, kind?: string, preview?: string) => void;
@@ -312,6 +313,7 @@ export class LiveLogStream {
     const { streamUrl, token } = requireLiveLogSession(session);
     const res = await fetchRunnerLiveLogResponse(streamUrl, token, this.abortController.signal);
     const reader = requireBodyReader(res);
+    handlers.onOpen?.();
     await pumpReaderNdjson(reader, handlers);
   }
 }

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/types.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/types.ts
@@ -50,5 +50,6 @@ export type LogState = {
   sections: CommandSection[];
   orphanLines: string[];
   error: string | null;
+  isLoading: boolean;
   isStreaming: boolean;
 };

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.spec.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.spec.ts
@@ -1,11 +1,46 @@
-import { describe, expect, it } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExecutionInfo } from "../../../pages/app/mappers/types";
 import type { LogState } from "./types";
 import {
   finalizeRunningCommandSections,
   terminalCommandStatusForExecution,
   terminalTimeMsForExecution,
+  useLiveLogStream,
 } from "./useLiveLogStream";
+
+const { captureExceptionMock, pumpMock, stopMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+  pumpMock: vi.fn(),
+  stopMock: vi.fn(),
+}));
+
+vi.mock("@/sentry", () => ({
+  Sentry: { captureException: captureExceptionMock },
+}));
+
+vi.mock("./liveLogStream", () => {
+  class LiveLogStreamMock {
+    pump = pumpMock;
+    stop = stopMock;
+  }
+
+  return { LiveLogStream: LiveLogStreamMock };
+});
+
+vi.mock("@/hooks/useOrganizationId", () => ({
+  useOrganizationId: () => undefined,
+}));
+
+vi.mock("@/hooks/useCanvasId", () => ({
+  useCanvasId: () => undefined,
+}));
+
+beforeEach(() => {
+  captureExceptionMock.mockReset();
+  pumpMock.mockReset();
+  stopMock.mockReset();
+});
 
 function baseLogState(): LogState {
   return {
@@ -145,5 +180,35 @@ describe("runner live log state", () => {
         }),
       ),
     ).toBeNull();
+  });
+});
+
+describe("useLiveLogStream", () => {
+  it("reports a request error and retries the terminal log session on demand", async () => {
+    pumpMock.mockRejectedValue(new Error("Failed to fetch"));
+    const { result } = renderHook(() =>
+      useLiveLogStream("execution-1", false, "failed", null, {
+        organizationId: "organization-1",
+        canvasId: "canvas-1",
+      }),
+    );
+
+    await waitFor(() => expect(result.current.error).toBe("Failed to fetch"));
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Failed to fetch" }),
+      expect.objectContaining({
+        fingerprint: ["runner-live-logs", "request"],
+        extra: {
+          organizationId: "organization-1",
+          canvasId: "canvas-1",
+          executionId: "execution-1",
+        },
+      }),
+    );
+
+    act(() => result.current.retry());
+
+    await waitFor(() => expect(pumpMock).toHaveBeenCalledTimes(2));
   });
 });

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.spec.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.spec.ts
@@ -68,6 +68,7 @@ function baseLogState(): LogState {
     ],
     orphanLines: [],
     error: null,
+    isLoading: false,
     isStreaming: false,
   };
 }
@@ -184,6 +185,30 @@ describe("runner live log state", () => {
 });
 
 describe("useLiveLogStream", () => {
+  it("stops loading after the live log response opens", async () => {
+    let openStream: (() => void) | undefined;
+    pumpMock.mockImplementation(
+      (handlers: { onOpen?: () => void }) =>
+        new Promise<void>((resolve) => {
+          openStream = () => {
+            handlers.onOpen?.();
+            resolve();
+          };
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      useLiveLogStream("execution-1", false, "passed", null, {
+        organizationId: "organization-1",
+        canvasId: "canvas-1",
+      }),
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    act(() => openStream?.());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
   it("reports a request error and retries the terminal log session on demand", async () => {
     pumpMock.mockRejectedValue(new Error("Failed to fetch"));
     const { result } = renderHook(() =>

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.spec.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.spec.ts
@@ -237,8 +237,12 @@ describe("useLiveLogStream", () => {
     await waitFor(() => expect(pumpMock).toHaveBeenCalledTimes(2));
   });
 
-  it("clears a stale error when a retry opens a healthy stream", async () => {
-    pumpMock.mockRejectedValueOnce(new Error("Failed to fetch"));
+  it("preserves existing logs when a retry opens a healthy stream", async () => {
+    pumpMock.mockImplementationOnce(async (handlers: { onOpen?: () => void; onLogLine: (line: string) => void }) => {
+      handlers.onOpen?.();
+      handlers.onLogLine("existing output");
+      throw new Error("Failed to fetch");
+    });
     pumpMock.mockImplementationOnce((handlers: { onOpen?: () => void }) => {
       handlers.onOpen?.();
       return new Promise<void>(() => undefined);
@@ -251,9 +255,11 @@ describe("useLiveLogStream", () => {
     );
 
     await waitFor(() => expect(result.current.error).toBe("Failed to fetch"));
+    expect(result.current.orphanLines).toEqual(["existing output"]);
     act(() => result.current.retry());
 
     await waitFor(() => expect(result.current.error).toBeNull());
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.orphanLines).toEqual(["existing output"]);
   });
 });

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.spec.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.spec.ts
@@ -236,4 +236,24 @@ describe("useLiveLogStream", () => {
 
     await waitFor(() => expect(pumpMock).toHaveBeenCalledTimes(2));
   });
+
+  it("clears a stale error when a retry opens a healthy stream", async () => {
+    pumpMock.mockRejectedValueOnce(new Error("Failed to fetch"));
+    pumpMock.mockImplementationOnce((handlers: { onOpen?: () => void }) => {
+      handlers.onOpen?.();
+      return new Promise<void>(() => undefined);
+    });
+    const { result } = renderHook(() =>
+      useLiveLogStream("execution-1", true, null, null, {
+        organizationId: "organization-1",
+        canvasId: "canvas-1",
+      }),
+    );
+
+    await waitFor(() => expect(result.current.error).toBe("Failed to fetch"));
+    act(() => result.current.retry());
+
+    await waitFor(() => expect(result.current.error).toBeNull());
+    expect(result.current.isLoading).toBe(false);
+  });
 });

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
@@ -325,15 +325,19 @@ export function useLiveLogStream(
   }, []);
 
   useEffect(() => {
+    const canLoad = Boolean(organizationId && canvasId && executionId);
+    setState({ ...initialLogState, isLoading: canLoad, isStreaming: canLoad });
+    setUsage(emptyPromptUsageState());
+  }, [organizationId, canvasId, executionId]);
+
+  useEffect(() => {
     if (!organizationId || !canvasId || !executionId) {
-      setState((prev) => ({ ...prev, isLoading: false, isStreaming: false }));
       return;
     }
 
     const sessionAbort = new AbortController();
     let activeStream: LiveLogStream | null = null;
-    setState({ ...initialLogState, isLoading: true, isStreaming: true });
-    setUsage(emptyPromptUsageState());
+    setState((prev) => ({ ...prev, error: null, isLoading: true, isStreaming: true }));
 
     void runLiveLogSession({
       organizationId,

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
@@ -13,6 +13,7 @@ import {
 import type { CommandSection, LogState } from "./types";
 import { useScrollToBottom } from "./useScrollToBottom";
 import type { ExecutionInfo } from "../../../pages/app/mappers/types";
+import { Sentry } from "@/sentry";
 import {
   applyPromptUsageRecord,
   emptyAgentRunTelemetry,
@@ -23,6 +24,14 @@ import {
 } from "@/lib/agentRunTelemetry";
 
 const RECONNECT_DELAY_MS = 2000;
+
+type LiveLogFailureSource = "broker" | "request";
+
+type LiveLogFailureContext = {
+  organizationId: string;
+  canvasId: string;
+  executionId: string;
+};
 
 const initialLogState: LogState = {
   sections: [],
@@ -87,34 +96,24 @@ function commandSectionFinalDuration(section: CommandSection, endedAtMs: number 
   return Math.max(0, endedAtMs - section.started_at);
 }
 
-function applyStreamFailure(state: LogState, message: string, executionInFlight: boolean): LogState {
-  if (
-    hasRunningCommand(state) ||
-    (executionInFlight && state.sections.length === 0 && state.orphanLines.length === 0)
-  ) {
-    return {
-      ...state,
-      error: null,
-    };
-  }
-
-  if (state.sections.length === 0 && state.orphanLines.length === 0) {
-    return { ...state, error: message };
-  }
-
-  return state;
+function applyStreamFailure(state: LogState, message: string): LogState {
+  return { ...state, error: message, isStreaming: false };
 }
 
 function createStreamHandlers(
   reconnecting: boolean,
   replayLineSkip: Map<number, number>,
-  executionInFlight: boolean,
   setState: Dispatch<SetStateAction<LogState>>,
   setUsage: Dispatch<SetStateAction<AgentPromptUsageState>>,
+  onFailure: (message: string) => void,
 ): LiveLogStreamHandlers {
   return {
-    onLogLine: (text) => setState((prev) => appendLineToLatestSection(prev, text, replayLineSkip)),
-    onStreamError: (message) => setState((prev) => applyStreamFailure(prev, message, executionInFlight)),
+    onLogLine: (text) =>
+      setState((prev) => ({ ...appendLineToLatestSection(prev, text, replayLineSkip), error: null })),
+    onStreamError: (message) => {
+      onFailure(message);
+      setState((prev) => applyStreamFailure(prev, message));
+    },
     onCmdStart: (index, text, startedAtMs, kind, preview) => {
       setState((prev) => {
         const existing = prev.sections.find((section) => section.index === index);
@@ -122,25 +121,26 @@ function createStreamHandlers(
           if (reconnecting) {
             replayLineSkip.set(index, existing.lines.length);
           }
-          return prev;
+          return { ...prev, error: null };
         }
-        return startCommandSection(prev, { index, text, startedAtMs, kind, preview });
+        return { ...startCommandSection(prev, { index, text, startedAtMs, kind, preview }), error: null };
       });
       if (kind === "prompt") {
         setUsage((prev) => startPromptUsageSeries(prev, text, index));
       }
     },
     onCmdEnd: (index, status, durationMs) =>
-      setState((prev) => completeCommandSection(prev, index, status, durationMs)),
+      setState((prev) => ({ ...completeCommandSection(prev, index, status, durationMs), error: null })),
     onToolStart: (kind, text, id, turn) => {
-      setState((prev) => startToolOnLatestSection(prev, kind, text, id));
+      setState((prev) => ({ ...startToolOnLatestSection(prev, kind, text, id), error: null }));
       setUsage((prev) => applyPromptUsageRecord(prev, { type: "tool_start", kind, text, id, turn }));
     },
     onToolEnd: (status, durationMs, id, turn) => {
-      setState((prev) => endToolOnLatestSection(prev, status, durationMs, id));
+      setState((prev) => ({ ...endToolOnLatestSection(prev, status, durationMs, id), error: null }));
       setUsage((prev) => applyPromptUsageRecord(prev, { type: "tool_end", status, duration_ms: durationMs, id, turn }));
     },
     onTurn: (turn, usage, message) => {
+      setState((prev) => ({ ...prev, error: null }));
       setUsage((prev) => applyPromptUsageRecord(prev, { type: "turn", turn, usage, message }));
     },
   };
@@ -180,6 +180,44 @@ type LiveLogSessionParams = {
   setActiveStream: (stream: LiveLogStream | null) => void;
 };
 
+function createLiveLogFailureReporter(context: LiveLogFailureContext) {
+  const reportedFailures = new Set<LiveLogFailureSource>();
+
+  return (source: LiveLogFailureSource, error: Error): void => {
+    if (reportedFailures.has(source)) {
+      return;
+    }
+    reportedFailures.add(source);
+
+    Sentry.captureException(error, {
+      fingerprint: ["runner-live-logs", source],
+      tags: {
+        feature: "runner-live-logs",
+        source,
+      },
+      extra: context,
+    });
+  };
+}
+
+function errorFromUnknown(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+async function waitForLiveLogReconnect(
+  sessionAbort: AbortController,
+  setState: Dispatch<SetStateAction<LogState>>,
+): Promise<boolean> {
+  setState((prev) => ({ ...prev, isStreaming: false }));
+  try {
+    await sleep(RECONNECT_DELAY_MS, sessionAbort.signal);
+  } catch {
+    return false;
+  }
+  setState((prev) => ({ ...prev, isStreaming: true }));
+  return true;
+}
+
 async function runLiveLogSession({
   organizationId,
   canvasId,
@@ -193,6 +231,7 @@ async function runLiveLogSession({
   setActiveStream,
 }: LiveLogSessionParams): Promise<void> {
   let reconnecting = false;
+  const reportFailure = createLiveLogFailureReporter({ organizationId, canvasId, executionId });
 
   while (!sessionAbort.signal.aborted) {
     const stream = new LiveLogStream(organizationId, canvasId, executionId);
@@ -200,13 +239,19 @@ async function runLiveLogSession({
     const replayLineSkip = new Map<number, number>();
 
     try {
-      await stream.pump(createStreamHandlers(reconnecting, replayLineSkip, executionInFlight, setState, setUsage));
+      await stream.pump(
+        createStreamHandlers(reconnecting, replayLineSkip, setState, setUsage, (message) => {
+          reportFailure("broker", new Error(message));
+        }),
+      );
     } catch (error) {
-      if ((error as Error).name === "AbortError") {
+      const streamError = errorFromUnknown(error);
+      if (streamError.name === "AbortError") {
         return;
       }
       if (!sessionAbort.signal.aborted) {
-        setState((prev) => applyStreamFailure(prev, (error as Error).message, executionInFlight));
+        reportFailure("request", streamError);
+        setState((prev) => applyStreamFailure(prev, streamError.message));
       }
     } finally {
       stream.stop();
@@ -225,18 +270,9 @@ async function runLiveLogSession({
     }
 
     reconnecting = true;
-    setState((prev) => ({
-      ...prev,
-      isStreaming: false,
-    }));
-
-    try {
-      await sleep(RECONNECT_DELAY_MS, sessionAbort.signal);
-    } catch {
+    if (!(await waitForLiveLogReconnect(sessionAbort, setState))) {
       return;
     }
-
-    setState((prev) => ({ ...prev, isStreaming: true }));
   }
 }
 
@@ -258,6 +294,7 @@ export function useLiveLogStream(
   const canvasId = session?.canvasId || routeCanvasId;
   const [state, setState] = useState<LogState>(() => ({ ...initialLogState, isStreaming: true }));
   const [usage, setUsage] = useState(emptyPromptUsageState);
+  const [sessionAttempt, setSessionAttempt] = useState(0);
 
   const scrollTrigger = useMemo(() => {
     const lineCount = state.sections.reduce((count, section) => count + section.lines.length, 0);
@@ -279,6 +316,10 @@ export function useLiveLogStream(
         };
       }),
     }));
+  }, []);
+
+  const retry = useCallback(() => {
+    setSessionAttempt((attempt) => attempt + 1);
   }, []);
 
   useEffect(() => {
@@ -315,9 +356,9 @@ export function useLiveLogStream(
       sessionAbort.abort();
       activeStream?.stop();
     };
-  }, [organizationId, canvasId, executionId, executionInFlight, terminalCommandStatus, terminalAtMs]);
+  }, [organizationId, canvasId, executionId, executionInFlight, terminalCommandStatus, terminalAtMs, sessionAttempt]);
 
   const usageSeries = useMemo(() => promptUsageSeries(usage), [usage]);
   const telemetry = usageSeries.at(-1)?.telemetry ?? emptyAgentRunTelemetry();
-  return { ...state, telemetry, usageSeries, toggleSection, scrollRef };
+  return { ...state, telemetry, usageSeries, retry, toggleSection, scrollRef };
 }

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
@@ -37,6 +37,7 @@ const initialLogState: LogState = {
   sections: [],
   orphanLines: [],
   error: null,
+  isLoading: false,
   isStreaming: false,
 };
 
@@ -97,7 +98,7 @@ function commandSectionFinalDuration(section: CommandSection, endedAtMs: number 
 }
 
 function applyStreamFailure(state: LogState, message: string): LogState {
-  return { ...state, error: message, isStreaming: false };
+  return { ...state, error: message, isLoading: false, isStreaming: false };
 }
 
 function createStreamHandlers(
@@ -108,6 +109,7 @@ function createStreamHandlers(
   onFailure: (message: string) => void,
 ): LiveLogStreamHandlers {
   return {
+    onOpen: () => setState((prev) => ({ ...prev, error: null, isLoading: false, isStreaming: true })),
     onLogLine: (text) =>
       setState((prev) => ({ ...appendLineToLatestSection(prev, text, replayLineSkip), error: null })),
     onStreamError: (message) => {
@@ -208,7 +210,7 @@ async function waitForLiveLogReconnect(
   sessionAbort: AbortController,
   setState: Dispatch<SetStateAction<LogState>>,
 ): Promise<boolean> {
-  setState((prev) => ({ ...prev, isStreaming: false }));
+  setState((prev) => ({ ...prev, isLoading: true, isStreaming: false }));
   try {
     await sleep(RECONNECT_DELAY_MS, sessionAbort.signal);
   } catch {
@@ -292,7 +294,7 @@ export function useLiveLogStream(
   const routeCanvasId = useCanvasId();
   const organizationId = session?.organizationId || routeOrganizationId;
   const canvasId = session?.canvasId || routeCanvasId;
-  const [state, setState] = useState<LogState>(() => ({ ...initialLogState, isStreaming: true }));
+  const [state, setState] = useState<LogState>(() => ({ ...initialLogState, isLoading: true, isStreaming: true }));
   const [usage, setUsage] = useState(emptyPromptUsageState);
   const [sessionAttempt, setSessionAttempt] = useState(0);
 
@@ -324,13 +326,13 @@ export function useLiveLogStream(
 
   useEffect(() => {
     if (!organizationId || !canvasId || !executionId) {
-      setState((prev) => ({ ...prev, isStreaming: false }));
+      setState((prev) => ({ ...prev, isLoading: false, isStreaming: false }));
       return;
     }
 
     const sessionAbort = new AbortController();
     let activeStream: LiveLogStream | null = null;
-    setState({ ...initialLogState, isStreaming: true });
+    setState({ ...initialLogState, isLoading: true, isStreaming: true });
     setUsage(emptyPromptUsageState());
 
     void runLiveLogSession({
@@ -348,7 +350,7 @@ export function useLiveLogStream(
       },
     }).finally(() => {
       if (!sessionAbort.signal.aborted) {
-        setState((prev) => ({ ...prev, isStreaming: false }));
+        setState((prev) => ({ ...prev, isLoading: false, isStreaming: false }));
       }
     });
 

--- a/web_src/src/ui/Runs/RunInspectorRunnerLogs.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRunnerLogs.spec.tsx
@@ -133,6 +133,25 @@ describe("RunInspector runner logs", () => {
     expect(screen.getByText("No logs available")).toBeInTheDocument();
     expect(screen.queryByText("Waiting for logs")).not.toBeInTheDocument();
   });
+
+  it("keeps existing logs visible when the stream fails", () => {
+    useLiveLogStreamMock.mockReturnValue({
+      sections: [{ index: 0, text: "npm run build", lines: ["vite build"], events: [], status: "running" }],
+      orphanLines: [],
+      error: "Failed to fetch",
+      isLoading: false,
+      isStreaming: false,
+      toggleSection: vi.fn(),
+      retry: vi.fn(),
+      scrollRef: { current: null },
+    });
+
+    renderRunnerInspector();
+    fireEvent.click(screen.getByRole("button", { name: /Logs.*Run Bash/i }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Could not load logs");
+    expect(screen.getByText(/vite build/)).toBeInTheDocument();
+  });
 });
 
 function renderRunnerInspector() {

--- a/web_src/src/ui/Runs/RunInspectorRunnerLogs.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRunnerLogs.spec.tsx
@@ -51,6 +51,7 @@ beforeEach(() => {
     sections: [{ index: 0, text: "npm run build", lines: ["> build", "vite build"], events: [], status: "passed" }],
     orphanLines: [],
     error: null,
+    isLoading: false,
     isStreaming: false,
     toggleSection: vi.fn(),
     retry: vi.fn(),
@@ -94,11 +95,12 @@ describe("RunInspector runner logs", () => {
     expect(useLiveLogStreamMock).not.toHaveBeenCalled();
   });
 
-  it("does not wait for more logs after an execution finishes", () => {
+  it("shows loading while it fetches logs for a finished execution", () => {
     useLiveLogStreamMock.mockReturnValue({
       sections: [],
       orphanLines: [],
       error: null,
+      isLoading: true,
       isStreaming: true,
       toggleSection: vi.fn(),
       retry: vi.fn(),
@@ -108,8 +110,9 @@ describe("RunInspector runner logs", () => {
     renderRunnerInspector();
     fireEvent.click(screen.getByRole("button", { name: /Logs.*Run Bash/i }));
 
-    expect(screen.getByText("No logs available")).toBeInTheDocument();
+    expect(screen.getByText("Loading logs")).toBeInTheDocument();
     expect(screen.queryByText("Waiting for logs")).not.toBeInTheDocument();
+    expect(screen.queryByText("No logs available")).not.toBeInTheDocument();
   });
 
   it("shows the empty state when a finished execution has no logs", () => {
@@ -117,6 +120,7 @@ describe("RunInspector runner logs", () => {
       sections: [],
       orphanLines: [],
       error: null,
+      isLoading: false,
       isStreaming: false,
       toggleSection: vi.fn(),
       retry: vi.fn(),

--- a/web_src/src/ui/Runs/RunInspectorRunnerLogs.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRunnerLogs.spec.tsx
@@ -53,6 +53,7 @@ beforeEach(() => {
     error: null,
     isStreaming: false,
     toggleSection: vi.fn(),
+    retry: vi.fn(),
     scrollRef: { current: null },
   });
 });
@@ -93,38 +94,40 @@ describe("RunInspector runner logs", () => {
     expect(useLiveLogStreamMock).not.toHaveBeenCalled();
   });
 
-  it("shows a loading message while finished-execution logs are still streaming in", () => {
+  it("does not wait for more logs after an execution finishes", () => {
     useLiveLogStreamMock.mockReturnValue({
       sections: [],
       orphanLines: [],
       error: null,
       isStreaming: true,
       toggleSection: vi.fn(),
+      retry: vi.fn(),
       scrollRef: { current: null },
     });
 
     renderRunnerInspector();
     fireEvent.click(screen.getByRole("button", { name: /Logs.*Run Bash/i }));
 
-    expect(screen.getByText("Waiting for logs...")).toBeInTheDocument();
-    expect(screen.queryByText("No log lines yet.")).not.toBeInTheDocument();
+    expect(screen.getByText("No logs available")).toBeInTheDocument();
+    expect(screen.queryByText("Waiting for logs")).not.toBeInTheDocument();
   });
 
-  it("shows the empty message only after streaming settles with no lines", () => {
+  it("shows the empty state when a finished execution has no logs", () => {
     useLiveLogStreamMock.mockReturnValue({
       sections: [],
       orphanLines: [],
       error: null,
       isStreaming: false,
       toggleSection: vi.fn(),
+      retry: vi.fn(),
       scrollRef: { current: null },
     });
 
     renderRunnerInspector();
     fireEvent.click(screen.getByRole("button", { name: /Logs.*Run Bash/i }));
 
-    expect(screen.getByText("No log lines yet.")).toBeInTheDocument();
-    expect(screen.queryByText("Waiting for logs...")).not.toBeInTheDocument();
+    expect(screen.getByText("No logs available")).toBeInTheDocument();
+    expect(screen.queryByText("Waiting for logs")).not.toBeInTheDocument();
   });
 });
 

--- a/web_src/src/ui/Runs/RunInspectorRunnerLogs.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRunnerLogs.tsx
@@ -49,7 +49,7 @@ function RunnerLogsTerminal({ execution }: { execution: CanvasesCanvasNodeExecut
   );
   const lines = runnerLogLines(orphanLines, sections);
 
-  if (error) {
+  if (error && lines.length === 0) {
     return <LiveLogStateNotice state="error" error={error} willRetry={executionInFlight} onRetry={retry} compact />;
   }
 
@@ -66,13 +66,18 @@ function RunnerLogsTerminal({ execution }: { execution: CanvasesCanvasNodeExecut
   }
 
   return (
-    <div
-      ref={scrollRef}
-      data-testid="run-inspector-runner-logs-terminal"
-      className="max-h-80 overflow-y-auto rounded-sm bg-slate-950 px-4 py-3 text-slate-100 shadow-inner ring-1 ring-slate-900/10 dark:bg-black dark:ring-gray-800"
-    >
-      <pre className="whitespace-pre-wrap font-mono text-[12px] leading-relaxed">{lines.join("\n")}</pre>
-    </div>
+    <>
+      {error ? (
+        <LiveLogStateNotice state="error" error={error} willRetry={executionInFlight} onRetry={retry} compact />
+      ) : null}
+      <div
+        ref={scrollRef}
+        data-testid="run-inspector-runner-logs-terminal"
+        className="max-h-80 overflow-y-auto rounded-sm bg-slate-950 px-4 py-3 text-slate-100 shadow-inner ring-1 ring-slate-900/10 dark:bg-black dark:ring-gray-800"
+      >
+        <pre className="whitespace-pre-wrap font-mono text-[12px] leading-relaxed">{lines.join("\n")}</pre>
+      </div>
+    </>
   );
 }
 

--- a/web_src/src/ui/Runs/RunInspectorRunnerLogs.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRunnerLogs.tsx
@@ -7,6 +7,7 @@ import {
   useLiveLogStream,
 } from "@/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream";
 import { isRawAgentTurnLiveLogText } from "@/lib/agentRunTelemetry";
+import { LiveLogStateNotice } from "@/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStateNotice";
 import { EmptySectionText, TimelineAccordionCard } from "./RunInspectorTimelineCard";
 import type { StatusPill } from "./RunInspectorTimelineTypes";
 import type { RunInspectorNodeSection } from "./types";
@@ -40,26 +41,24 @@ export function RunnerLogsTimelineCard({ section, isOpen }: { section: RunInspec
 function RunnerLogsTerminal({ execution }: { execution: CanvasesCanvasNodeExecution }) {
   const executionInfo = buildExecutionInfo(execution);
   const executionInFlight = isExecutionInFlight(executionInfo);
-  const { sections, orphanLines, error, isStreaming, scrollRef } = useLiveLogStream(
+  const { sections, orphanLines, error, retry, scrollRef } = useLiveLogStream(
     executionInfo.id,
     executionInFlight,
     terminalCommandStatusForExecution(executionInfo),
     terminalTimeMsForExecution(executionInfo),
   );
   const lines = runnerLogLines(orphanLines, sections);
-  const isWaiting = lines.length === 0 && !error && (executionInFlight || isStreaming);
-  const hasError = Boolean(error) && !executionInFlight;
 
-  if (hasError) {
-    return <EmptySectionText>Something went wrong while fetching logs. Please try again later.</EmptySectionText>;
+  if (error) {
+    return <LiveLogStateNotice state="error" error={error} willRetry={executionInFlight} onRetry={retry} compact />;
   }
 
-  if (isWaiting) {
-    return <EmptySectionText>Waiting for logs...</EmptySectionText>;
+  if (lines.length === 0 && executionInFlight) {
+    return <LiveLogStateNotice state="waiting" compact />;
   }
 
   if (lines.length === 0) {
-    return <EmptySectionText>No log lines yet.</EmptySectionText>;
+    return <LiveLogStateNotice state="empty" compact />;
   }
 
   return (

--- a/web_src/src/ui/Runs/RunInspectorRunnerLogs.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRunnerLogs.tsx
@@ -41,7 +41,7 @@ export function RunnerLogsTimelineCard({ section, isOpen }: { section: RunInspec
 function RunnerLogsTerminal({ execution }: { execution: CanvasesCanvasNodeExecution }) {
   const executionInfo = buildExecutionInfo(execution);
   const executionInFlight = isExecutionInFlight(executionInfo);
-  const { sections, orphanLines, error, retry, scrollRef } = useLiveLogStream(
+  const { sections, orphanLines, error, isLoading, retry, scrollRef } = useLiveLogStream(
     executionInfo.id,
     executionInFlight,
     terminalCommandStatusForExecution(executionInfo),
@@ -51,6 +51,10 @@ function RunnerLogsTerminal({ execution }: { execution: CanvasesCanvasNodeExecut
 
   if (error) {
     return <LiveLogStateNotice state="error" error={error} willRetry={executionInFlight} onRetry={retry} compact />;
+  }
+
+  if (lines.length === 0 && isLoading) {
+    return <LiveLogStateNotice state="loading" compact />;
   }
 
   if (lines.length === 0 && executionInFlight) {


### PR DESCRIPTION
## Summary

Stopped runner executions can show a waiting state indefinitely when no log output exists.

This change separates loading saved logs from waiting for new output. Terminal executions show an empty state after loading completes.

Stream failures show retry controls and report deduplicated errors to Sentry.

## Test plan

- [x] Run `make format.js`.
- [x] Run `make check.format.js`.
- [x] Run `make check.lint.ui`.
- [x] Run `make check.build.ui`.
- [x] Run the targeted runner live-log tests.
- [x] Run `make check.generated.artifacts`.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62177446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/superplane/-/pull-requests/superplanehq/superplane/7321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge.

<!-- /greptile_comment -->