### PR TITLE
fix: Keep OpenCode planning sessions alive

### DIFF
--- a/pkg/components/runner/claude/run.js
+++ b/pkg/components/runner/claude/run.js
@@ -21,7 +21,7 @@ const SYSTEM_PROMPT =
   "Prefer plain paths, shell commands, and simple indentation.";
 
 const PLANNING_SYSTEM_PROMPT =
-  " This is a SuperPlane planning session. Call mcp__superplane__propose_draft only when the user asked for a task in this turn. Call mcp__superplane__propose_draft with a title and a description. The description must include the user's request and constraints. After you show a draft, tell the user it is on the right and ask them to review it. Call mcp__superplane__survey to ask questions. SuperPlane waits after you stop. Do not create work orders yourself. When the user creates or skips a draft, acknowledge that in one short sentence and ask what they want to do next. Do not call propose_draft unless they ask for a task. When the user starts a refine, read the current task, tell them you are ready, and ask what they want to change. Do not call propose_draft until they say what to change. Write to the user in plain text.";
+  " This is a SuperPlane planning session. Call mcp__superplane__propose_draft only when the user asked for a task in this turn. Call mcp__superplane__survey to ask questions. SuperPlane waits after you stop. Do not create work orders yourself. When the user creates or skips a draft, acknowledge that in one short sentence and ask what they want to do next. Do not call propose_draft unless they ask for a task. When the user starts a refine, read the current task, tell them you are ready, and ask what they want to change. Do not call propose_draft until they say what to change. Write to the user in plain text.";
 
 const BASE_ALLOWED_TOOLS = "Bash,Read,Edit,Write";
 // Planning sessions may only explore the repo (Read/Bash) and use the planning

--- a/pkg/components/runner/claude/run.js
+++ b/pkg/components/runner/claude/run.js
@@ -21,7 +21,7 @@ const SYSTEM_PROMPT =
   "Prefer plain paths, shell commands, and simple indentation.";
 
 const PLANNING_SYSTEM_PROMPT =
-  " This is a SuperPlane planning session. Call mcp__superplane__propose_draft only when the user asked for a task in this turn. Call mcp__superplane__survey to ask questions. SuperPlane waits after you stop. Do not create work orders yourself. When the user creates or skips a draft, acknowledge that in one short sentence and ask what they want to do next. Do not call propose_draft unless they ask for a task. When the user starts a refine, read the current task, tell them you are ready, and ask what they want to change. Do not call propose_draft until they say what to change. Write to the user in plain text.";
+  " This is a SuperPlane planning session. Call mcp__superplane__propose_draft only when the user asked for a task in this turn. Call mcp__superplane__propose_draft with a title and a description. The description must include the user's request and constraints. After you show a draft, tell the user it is on the right and ask them to review it. Call mcp__superplane__survey to ask questions. SuperPlane waits after you stop. Do not create work orders yourself. When the user creates or skips a draft, acknowledge that in one short sentence and ask what they want to do next. Do not call propose_draft unless they ask for a task. When the user starts a refine, read the current task, tell them you are ready, and ask what they want to change. Do not call propose_draft until they say what to change. Write to the user in plain text.";
 
 const BASE_ALLOWED_TOOLS = "Bash,Read,Edit,Write";
 // Planning sessions may only explore the repo (Read/Bash) and use the planning

--- a/pkg/components/runner/codex/run.js
+++ b/pkg/components/runner/codex/run.js
@@ -14,6 +14,8 @@ const { spawn } = require("child_process");
 
 const PLANNING_SYSTEM_PROMPT =
   "This is a SuperPlane planning session. Call the propose_draft tool only when the user asked for a task in this turn. " +
+  "Call propose_draft with a title and a description. The description must include the user's request and constraints. " +
+  "After you show a draft, tell the user it is on the right and ask them to review it. " +
   "Call the survey tool to ask questions. SuperPlane waits after you stop. Do not create work orders yourself. " +
   "When the user creates or skips a draft, acknowledge that in one short sentence and ask what they want to do next. " +
   "Do not call propose_draft unless they ask for a task. When the user starts a refine, read the current task, tell " +

--- a/pkg/components/runner/codex/run.js
+++ b/pkg/components/runner/codex/run.js
@@ -14,8 +14,6 @@ const { spawn } = require("child_process");
 
 const PLANNING_SYSTEM_PROMPT =
   "This is a SuperPlane planning session. Call the propose_draft tool only when the user asked for a task in this turn. " +
-  "Call propose_draft with a title and a description. The description must include the user's request and constraints. " +
-  "After you show a draft, tell the user it is on the right and ask them to review it. " +
   "Call the survey tool to ask questions. SuperPlane waits after you stop. Do not create work orders yourself. " +
   "When the user creates or skips a draft, acknowledge that in one short sentence and ask what they want to do next. " +
   "Do not call propose_draft unless they ask for a task. When the user starts a refine, read the current task, tell " +

--- a/pkg/components/runner/follow_up_loop.js
+++ b/pkg/components/runner/follow_up_loop.js
@@ -81,13 +81,17 @@ async function requestJSON(method, urlPath) {
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: "application/json",
+        "ngrok-skip-browser-warning": "1",
       },
     }),
   );
 }
 
 function isTransientWaitFailure(status, parsed) {
-  if (status === 429 || status === 502 || status === 503 || status === 504) {
+  if (status === 401) {
+    return false;
+  }
+  if (status >= 400) {
     return true;
   }
   return Boolean(parsed && (parsed.retryable === true || parsed.cloudflare_error === true));

--- a/pkg/components/runner/follow_up_loop.js
+++ b/pkg/components/runner/follow_up_loop.js
@@ -87,8 +87,19 @@ async function requestJSON(method, urlPath) {
   );
 }
 
+function waitResponseMessage(parsed, text) {
+  return String((parsed && (parsed.message || parsed.error)) || text || "");
+}
+
+function isPlanningSessionGone(status, parsed, text) {
+  if (status !== 404) {
+    return false;
+  }
+  return /planning session not found/i.test(waitResponseMessage(parsed, text));
+}
+
 function isTransientWaitFailure(status, parsed) {
-  if (status === 401) {
+  if (status === 401 || status === 400) {
     return false;
   }
   if (status >= 400) {
@@ -98,7 +109,7 @@ function isTransientWaitFailure(status, parsed) {
 }
 
 function interpretWaitResponse(status, parsed, text) {
-  if (status === 409) {
+  if (status === 409 || isPlanningSessionGone(status, parsed, text)) {
     return { status: "ended" };
   }
   if (status >= 200 && status < 300) {
@@ -107,7 +118,7 @@ function interpretWaitResponse(status, parsed, text) {
   if (isTransientWaitFailure(status, parsed)) {
     return { status: "pending" };
   }
-  throw new Error((parsed && (parsed.message || parsed.error)) || text || `HTTP ${status}`);
+  throw new Error(waitResponseMessage(parsed, text) || `HTTP ${status}`);
 }
 
 async function waitOnce() {

--- a/pkg/components/runner/follow_up_loop_test.js
+++ b/pkg/components/runner/follow_up_loop_test.js
@@ -120,6 +120,15 @@ test("interpretWaitResponse throws on 401", () => {
   assert.throws(() => interpretWaitResponse(401, { message: "unauthorized" }), /unauthorized/);
 });
 
+test("interpretWaitResponse retries 404 and 403 as idle pending", () => {
+  assert.deepEqual(interpretWaitResponse(404, { message: "ngrok" }), { status: "pending" });
+  assert.deepEqual(interpretWaitResponse(403, { message: "forbidden" }), { status: "pending" });
+});
+
+test("interpretWaitResponse retries a generic 500 as idle pending", () => {
+  assert.deepEqual(interpretWaitResponse(500, { message: "oops" }), { status: "pending" });
+});
+
 test("runLoop sleeps 1s with no log after a Cloudflare 502, then runs the next message", async () => {
   const sleeps = [];
   const logs = [];
@@ -229,6 +238,14 @@ test("safeWaitRequest keeps a delivered user message", async () => {
     text: async () => JSON.stringify({ status: "message", text: "hello" }),
   }));
   assert.deepEqual(got, { status: "message", text: "hello" });
+});
+
+test("safeWaitRequest treats 404 as pending", async () => {
+  const got = await safeWaitRequest(async () => ({
+    status: 404,
+    text: async () => "ERR_NGROK_3200",
+  }));
+  assert.deepEqual(got, { status: "pending" });
 });
 
 test("safeWaitRequest still throws on 401", async () => {

--- a/pkg/components/runner/follow_up_loop_test.js
+++ b/pkg/components/runner/follow_up_loop_test.js
@@ -122,7 +122,17 @@ test("interpretWaitResponse throws on 401", () => {
 
 test("interpretWaitResponse retries 404 and 403 as idle pending", () => {
   assert.deepEqual(interpretWaitResponse(404, { message: "ngrok" }), { status: "pending" });
+  assert.deepEqual(interpretWaitResponse(404, {}, "ERR_NGROK_3200"), { status: "pending" });
   assert.deepEqual(interpretWaitResponse(403, { message: "forbidden" }), { status: "pending" });
+});
+
+test("interpretWaitResponse ends when the planning session is gone", () => {
+  assert.deepEqual(interpretWaitResponse(404, { message: "planning session not found" }), { status: "ended" });
+  assert.deepEqual(interpretWaitResponse(404, {}, "planning session not found\n"), { status: "ended" });
+});
+
+test("interpretWaitResponse throws on 400", () => {
+  assert.throws(() => interpretWaitResponse(400, { message: "invalid" }), /invalid/);
 });
 
 test("interpretWaitResponse retries a generic 500 as idle pending", () => {

--- a/pkg/components/runner/openrouter/run.js
+++ b/pkg/components/runner/openrouter/run.js
@@ -409,9 +409,12 @@ function defaultSpawnOpenCode(args, options) {
   });
 }
 
-function spawnHasAssistantReply(formatter) {
+function spawnHasCompleteAssistantTurn(spawnResult, formatter) {
   const text = formatter && typeof formatter.lastText === "function" ? formatter.lastText() : "";
-  return Boolean(String(text || "").trim());
+  if (!String(text || "").trim()) {
+    return false;
+  }
+  return tokenTotal(spawnResult && spawnResult.usage) > 0;
 }
 
 function spawnTurnFailed(spawnResult, formatter, allowSoftExitWithReply) {
@@ -428,7 +431,7 @@ function spawnTurnFailed(spawnResult, formatter, allowSoftExitWithReply) {
   if (!allowSoftExitWithReply) {
     return true;
   }
-  return !spawnHasAssistantReply(formatter);
+  return !spawnHasCompleteAssistantTurn(spawnResult, formatter);
 }
 
 async function spawnOpenCodeTurn(args, env, cwd, formatter, helpers) {
@@ -633,6 +636,8 @@ function createOpenCodeFormatter(telemetry, onSession) {
       errorText = "";
       announcedStart = false;
       lastText = "";
+      usage = emptyUsage();
+      cost = 0;
     },
     handleLine(raw) {
       const line = String(raw || "").trim();

--- a/pkg/components/runner/openrouter/run.js
+++ b/pkg/components/runner/openrouter/run.js
@@ -414,6 +414,9 @@ function spawnHasCompleteAssistantTurn(spawnResult, formatter) {
   if (!String(text || "").trim()) {
     return false;
   }
+  if (spawnResult && spawnResult.roundOpen) {
+    return false;
+  }
   return tokenTotal(spawnResult && spawnResult.usage) > 0;
 }
 
@@ -489,6 +492,7 @@ async function spawnOpenCodeTurn(args, env, cwd, formatter, helpers) {
     usage: snapshot.usage,
     cost: snapshot.cost,
     lastEvent: snapshot.lastEvent,
+    roundOpen: Boolean(snapshot.roundOpen),
   };
 }
 
@@ -513,6 +517,23 @@ function tokenTotal(usage) {
     Number(usage.cache_creation_input_tokens || 0) +
     Number(usage.reasoning_tokens || 0)
   );
+}
+
+function mergeUsage(left, right) {
+  const merged = {
+    input_tokens: Number((left && left.input_tokens) || 0) + Number((right && right.input_tokens) || 0),
+    output_tokens: Number((left && left.output_tokens) || 0) + Number((right && right.output_tokens) || 0),
+    cache_read_input_tokens:
+      Number((left && left.cache_read_input_tokens) || 0) + Number((right && right.cache_read_input_tokens) || 0),
+    cache_creation_input_tokens:
+      Number((left && left.cache_creation_input_tokens) || 0) + Number((right && right.cache_creation_input_tokens) || 0),
+    reasoning_tokens: Number((left && left.reasoning_tokens) || 0) + Number((right && right.reasoning_tokens) || 0),
+  };
+  const cost = Number((left && left.total_cost_usd) || 0) + Number((right && right.total_cost_usd) || 0);
+  if (cost) {
+    merged.total_cost_usd = cost;
+  }
+  return merged;
 }
 
 function usageFromStepFinish(part) {
@@ -638,6 +659,7 @@ function createOpenCodeFormatter(telemetry, onSession) {
       lastText = "";
       usage = emptyUsage();
       cost = 0;
+      roundOpen = false;
     },
     handleLine(raw) {
       const line = String(raw || "").trim();
@@ -696,12 +718,13 @@ function createOpenCodeFormatter(telemetry, onSession) {
           formatToolUse(part, tools);
           break;
         case "step_finish": {
-          usage = usageFromStepFinish(part);
+          const stepUsage = usageFromStepFinish(part);
+          usage = mergeUsage(usage, stepUsage);
           if (part.cost != null && Number.isFinite(Number(part.cost))) {
-            cost = Number(part.cost);
+            cost = Number(cost || 0) + Number(part.cost);
           }
           if (!roundOpen) {
-            beginRound(usage, { message: lastText });
+            beginRound(stepUsage, { message: lastText });
           } else {
             tracker.updateCurrentUsage(usage);
           }
@@ -731,6 +754,7 @@ function createOpenCodeFormatter(telemetry, onSession) {
         usage,
         cost,
         lastEvent,
+        roundOpen,
       };
     },
     lastText() {

--- a/pkg/components/runner/openrouter/run.js
+++ b/pkg/components/runner/openrouter/run.js
@@ -10,7 +10,7 @@
 const fs = require("fs");
 const path = require("path");
 const readline = require("readline");
-const { spawn } = require("child_process");
+const { spawn, spawnSync } = require("child_process");
 
 const TOOL_RESULT_MAX_CHARS = 800;
 const TOOL_RESULT_MAX_LINES = 24;
@@ -21,6 +21,8 @@ const SESSION_FILE = "opencode_session";
 
 const PLANNING_SYSTEM_PROMPT =
   "This is a SuperPlane planning session. Call the propose_draft tool only when the user asked for a task in this turn. " +
+  "Call propose_draft with a title and a description. The description must include the user's request and constraints. " +
+  "After you show a draft, tell the user it is on the right and ask them to review it. " +
   "Call the survey tool to ask questions. SuperPlane waits after you stop. Do not create work orders yourself. " +
   "When the user creates or skips a draft, acknowledge that in one short sentence and ask what they want to do next. " +
   "Do not call propose_draft unless they ask for a task. When the user starts a refine, read the current task, tell " +
@@ -203,6 +205,9 @@ function openCodeProcessEnv(taskDir, baseEnv = process.env) {
     ...baseEnv,
     OPENCODE_CONFIG: path.join(taskDir, "opencode.json"),
     OPENCODE_DISABLE_AUTOUPDATE: "1",
+    OPENCODE_DISABLE_MODELS_FETCH: "1",
+    OPENCODE_DISABLE_LSP_DOWNLOAD: "1",
+    OPENCODE_DISABLE_CLAUDE_CODE: "1",
     OPENCODE_PURE: "1",
     XDG_DATA_HOME: path.join(xdg, "data"),
     XDG_CONFIG_HOME: path.join(xdg, "config"),
@@ -269,6 +274,12 @@ async function runPrompt(promptFile, model, helpers = {}) {
   if (promptCount > 0 && sessionID) {
     println("Continuing OpenCode session");
   }
+  const startModel = openRouterModelId(currentModel) || model;
+  if (startModel) {
+    println(`Starting OpenCode · ${startModel}`);
+  } else {
+    println("Starting OpenCode");
+  }
 
   const telemetry = loadTurnTelemetry();
   const formatter = createOpenCodeFormatter(telemetry, (id) => {
@@ -300,10 +311,10 @@ async function runPrompt(promptFile, model, helpers = {}) {
       lastCost = spawnResult.cost;
     }
     lastErrorText = spawnResult.errorText || "";
-    const spawnFailed = spawnResult.exitCode !== 0 || spawnResult.resultFailed;
+    const spawnFailed = spawnTurnFailed(spawnResult, formatter);
     if (!spawnFailed) {
       failed = false;
-      exitCode = spawnResult.exitCode;
+      exitCode = 0;
       break;
     }
     const classKind = classifyOpenRouterError(lastErrorText);
@@ -379,12 +390,45 @@ function defaultSleep(ms) {
   });
 }
 
+function commandExists(name) {
+  const result = spawnSync("sh", ["-c", `command -v ${name}`], { encoding: "utf8" });
+  return result.status === 0;
+}
+
 function defaultSpawnOpenCode(args, options) {
-  return spawn("opencode", args, {
-    stdio: ["ignore", "pipe", "pipe"],
+  let command = "opencode";
+  let spawnArgs = args;
+  if (commandExists("stdbuf")) {
+    command = "stdbuf";
+    spawnArgs = ["-oL", "-eL", "opencode", ...args];
+  }
+  return spawn(command, spawnArgs, {
+    stdio: ["pipe", "pipe", "pipe"],
     env: options.env,
     cwd: options.cwd,
   });
+}
+
+function spawnHasAssistantReply(spawnResult, formatter) {
+  if (tokenTotal(spawnResult && spawnResult.usage) > 0) {
+    return true;
+  }
+  const text = formatter && typeof formatter.lastText === "function" ? formatter.lastText() : "";
+  return Boolean(String(text || "").trim());
+}
+
+function spawnTurnFailed(spawnResult, formatter) {
+  if (spawnResult.resultFailed) {
+    return true;
+  }
+  if (spawnResult.exitCode === 0) {
+    return false;
+  }
+  const kind = classifyOpenRouterError(spawnResult.errorText || "");
+  if (kind === "rate_limit" || kind === "hard") {
+    return true;
+  }
+  return !spawnHasAssistantReply(spawnResult, formatter);
 }
 
 async function spawnOpenCodeTurn(args, env, cwd, formatter, helpers) {
@@ -393,10 +437,14 @@ async function spawnOpenCodeTurn(args, env, cwd, formatter, helpers) {
   }
   const spawnOpenCode = helpers.spawnOpenCode || defaultSpawnOpenCode;
   const child = spawnOpenCode(args, { env, cwd });
+  if (child.stdin && typeof child.stdin.end === "function") {
+    child.stdin.end();
+  }
   let stderrText = "";
   if (child.stderr) {
     child.stderr.on("data", (chunk) => {
       stderrText += String(chunk);
+      process.stderr.write(chunk);
     });
   }
 
@@ -561,6 +609,7 @@ function createOpenCodeFormatter(telemetry, onSession) {
   let usage = emptyUsage();
   let cost = 0;
   let roundOpen = false;
+  let announcedStart = false;
 
   function rememberSession(event) {
     const id = String((event && event.sessionID) || (event && event.part && event.part.sessionID) || "").trim();
@@ -582,6 +631,8 @@ function createOpenCodeFormatter(telemetry, onSession) {
     beginSpawn() {
       resultFailed = false;
       errorText = "";
+      announcedStart = false;
+      lastText = "";
     },
     handleLine(raw) {
       const line = String(raw || "").trim();
@@ -607,6 +658,10 @@ function createOpenCodeFormatter(telemetry, onSession) {
       const part = event.part && typeof event.part === "object" ? event.part : {};
       switch (type) {
         case "step_start":
+          if (!announcedStart) {
+            announcedStart = true;
+            println("OpenCode started");
+          }
           beginRound(undefined, {});
           break;
         case "text": {

--- a/pkg/components/runner/openrouter/run.js
+++ b/pkg/components/runner/openrouter/run.js
@@ -409,10 +409,7 @@ function defaultSpawnOpenCode(args, options) {
   });
 }
 
-function spawnHasAssistantReply(spawnResult, formatter) {
-  if (tokenTotal(spawnResult && spawnResult.usage) > 0) {
-    return true;
-  }
+function spawnHasAssistantReply(formatter) {
   const text = formatter && typeof formatter.lastText === "function" ? formatter.lastText() : "";
   return Boolean(String(text || "").trim());
 }
@@ -431,7 +428,7 @@ function spawnTurnFailed(spawnResult, formatter, allowSoftExitWithReply) {
   if (!allowSoftExitWithReply) {
     return true;
   }
-  return !spawnHasAssistantReply(spawnResult, formatter);
+  return !spawnHasAssistantReply(formatter);
 }
 
 async function spawnOpenCodeTurn(args, env, cwd, formatter, helpers) {

--- a/pkg/components/runner/openrouter/run.js
+++ b/pkg/components/runner/openrouter/run.js
@@ -311,7 +311,7 @@ async function runPrompt(promptFile, model, helpers = {}) {
       lastCost = spawnResult.cost;
     }
     lastErrorText = spawnResult.errorText || "";
-    const spawnFailed = spawnTurnFailed(spawnResult, formatter);
+    const spawnFailed = spawnTurnFailed(spawnResult, formatter, planning);
     if (!spawnFailed) {
       failed = false;
       exitCode = 0;
@@ -417,7 +417,7 @@ function spawnHasAssistantReply(spawnResult, formatter) {
   return Boolean(String(text || "").trim());
 }
 
-function spawnTurnFailed(spawnResult, formatter) {
+function spawnTurnFailed(spawnResult, formatter, allowSoftExitWithReply) {
   if (spawnResult.resultFailed) {
     return true;
   }
@@ -426,6 +426,9 @@ function spawnTurnFailed(spawnResult, formatter) {
   }
   const kind = classifyOpenRouterError(spawnResult.errorText || "");
   if (kind === "rate_limit" || kind === "hard") {
+    return true;
+  }
+  if (!allowSoftExitWithReply) {
     return true;
   }
   return !spawnHasAssistantReply(spawnResult, formatter);

--- a/pkg/components/runner/openrouter/run_test.go
+++ b/pkg/components/runner/openrouter/run_test.go
@@ -41,6 +41,7 @@ func TestOpencodeRunArgsIncludesJSONAutoPureAndPrefix(t *testing.T) {
 		"--dir", "/tmp/repo",
 		"do the work",
 	}, args)
+	assert.NotContains(t, args, "--print-logs")
 	assert.NotContains(t, args, "--agent")
 }
 
@@ -87,6 +88,13 @@ func TestBuildOpenCodeConfigAllowsEditsOutsidePlanning(t *testing.T) {
 	assert.Equal(t, "allow", permission["*"])
 	assert.Nil(t, permission["edit"])
 	assert.Nil(t, config["mcp"])
+}
+
+func TestFormatOpenCodeJsonLinesEmitsWorkingLineOnStepStart(t *testing.T) {
+	output := runOpenCodeFormatter(t, []string{
+		`{"type":"step_start","sessionID":"ses_1","part":{"type":"step-start"}}`,
+	})
+	assert.Contains(t, output, "OpenCode started")
 }
 
 func TestFormatOpenCodeJsonLinesEmitsToolRecords(t *testing.T) {
@@ -179,8 +187,8 @@ func TestRunPromptSwitchesModelAfterNewAccountRPM(t *testing.T) {
 	assert.Contains(t, result.spawns[1], "--session")
 	assert.Contains(t, result.spawns[1], "ses_1")
 	assert.Contains(t, result.spawns[1], "openrouter/anthropic/claude-sonnet-4-6")
+	assert.Contains(t, result.output, "Starting OpenCode · openrouter/x-ai/grok-4.6")
 	assert.Contains(t, result.output, "Rate limit on x-ai/grok-4.6 — switching to anthropic/claude-sonnet-4-6")
-	assert.NotContains(t, result.output, "new accounts are limited to 20 requests")
 	assert.Regexp(t, `✓ done · \d+ turns`, result.output)
 	payload := resultPayload(t, result.resultFile)
 	assert.Equal(t, "working", payload["result"])
@@ -212,6 +220,40 @@ func TestRunPromptWaitsWhenOnlyOneModelIsRateLimited(t *testing.T) {
 	assert.Equal(t, []float64{60000}, result.sleeps)
 	assert.Contains(t, result.output, "Rate limit notice — waiting to continue…")
 	assert.NotContains(t, result.output, "switching to")
+}
+
+func TestRunPromptSucceedsWhenOpenCodeExitsNonZeroAfterReply(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model:    "google/gemma-4-31b-it",
+		fallback: []string{"google/gemma-4-31b-it"},
+		spawns: []spawnScript{{
+			ExitCode: 1,
+			Stdout: []string{
+				`{"type":"step_start","sessionID":"ses_hello","part":{"type":"step-start"}}`,
+				`{"type":"text","sessionID":"ses_hello","part":{"type":"text","text":"Hello! How can I help you today?"}}`,
+				`{"type":"step_finish","sessionID":"ses_hello","part":{"type":"step-finish","tokens":{"input":10,"output":8}}}`,
+			},
+		}},
+	})
+	assert.Equal(t, 0, result.exitCode)
+	require.Len(t, result.spawns, 1)
+	payload := resultPayload(t, result.resultFile)
+	assert.Equal(t, "Hello! How can I help you today?", payload["result"])
+	assert.Regexp(t, `✓ done`, result.output)
+}
+
+func TestRunPromptFailsWhenOpenCodeExitsNonZeroWithoutReply(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model:    "google/gemma-4-31b-it",
+		fallback: []string{"google/gemma-4-31b-it"},
+		spawns: []spawnScript{{
+			ExitCode: 1,
+			Stderr:   "opencode crashed",
+		}},
+	})
+	assert.Equal(t, 1, result.exitCode)
+	require.Len(t, result.spawns, 1)
+	assert.Regexp(t, `✗ failed`, result.output)
 }
 
 func TestRunPromptFailsImmediatelyOnInvalidAPIKey(t *testing.T) {
@@ -292,6 +334,7 @@ func TestRunPromptWritesOpenRouterBaseURLIntoConfig(t *testing.T) {
 	assert.Contains(t, result.spawns[0], "--auto")
 	assert.Equal(t, "--pure", result.spawns[0][0])
 	assert.Equal(t, "run", result.spawns[0][1])
+	assert.Contains(t, result.output, "Starting OpenCode · openrouter/anthropic/claude-sonnet-4-6")
 }
 
 func TestRunPromptDoesNotSwitchWhenSuccessfulSpawnLogs429(t *testing.T) {
@@ -346,6 +389,9 @@ func TestOpenCodeProcessEnvSetsPureAndIsolatesHomes(t *testing.T) {
 	env := jsOpenCodeProcessEnv(t, "/task")
 	assert.Equal(t, "1", env["OPENCODE_PURE"])
 	assert.Equal(t, "1", env["OPENCODE_DISABLE_AUTOUPDATE"])
+	assert.Equal(t, "1", env["OPENCODE_DISABLE_MODELS_FETCH"])
+	assert.Equal(t, "1", env["OPENCODE_DISABLE_LSP_DOWNLOAD"])
+	assert.Equal(t, "1", env["OPENCODE_DISABLE_CLAUDE_CODE"])
 	assert.Equal(t, "/task/opencode.json", env["OPENCODE_CONFIG"])
 	assert.Equal(t, "/task/xdg/data", env["XDG_DATA_HOME"])
 }

--- a/pkg/components/runner/openrouter/run_test.go
+++ b/pkg/components/runner/openrouter/run_test.go
@@ -243,6 +243,34 @@ func TestRunPromptSucceedsWhenOpenCodeExitsNonZeroAfterReply(t *testing.T) {
 	assert.Regexp(t, `✓ done`, result.output)
 }
 
+func TestRunPromptSucceedsWhenOpenCodeExitsNonZeroAfterTwoFinishedSteps(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model:    "google/gemma-4-31b-it",
+		fallback: []string{"google/gemma-4-31b-it"},
+		env:      map[string]string{"SUPERPLANE_PLANNING_SESSION_ID": "plan-1"},
+		spawns: []spawnScript{{
+			ExitCode: 1,
+			Stdout: []string{
+				`{"type":"step_start","sessionID":"ses_hello","part":{"type":"step-start"}}`,
+				`{"type":"text","sessionID":"ses_hello","part":{"type":"text","text":"Hello! How can I help you today?"}}`,
+				`{"type":"step_finish","sessionID":"ses_hello","part":{"type":"step-finish","tokens":{"input":10,"output":8}}}`,
+				`{"type":"step_start","sessionID":"ses_hello","part":{"type":"step-start"}}`,
+				`{"type":"text","sessionID":"ses_hello","part":{"type":"text","text":"I opened the repository."}}`,
+				`{"type":"step_finish","sessionID":"ses_hello","part":{"type":"step-finish","tokens":{"input":5,"output":3}}}`,
+			},
+		}},
+	})
+	assert.Equal(t, 0, result.exitCode)
+	require.Len(t, result.spawns, 1)
+	payload := resultPayload(t, result.resultFile)
+	assert.Equal(t, "I opened the repository.", payload["result"])
+	usage, ok := payload["usage"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(15), usage["input_tokens"])
+	assert.Equal(t, float64(11), usage["output_tokens"])
+	assert.Regexp(t, `✓ done`, result.output)
+}
+
 func TestRunPromptFailsWhenOpenCodeExitsNonZeroAfterReplyOnLineAutomation(t *testing.T) {
 	result := runOpenRouterPrompt(t, promptHarness{
 		model:    "google/gemma-4-31b-it",
@@ -259,6 +287,32 @@ func TestRunPromptFailsWhenOpenCodeExitsNonZeroAfterReplyOnLineAutomation(t *tes
 	assert.Equal(t, 1, result.exitCode)
 	require.Len(t, result.spawns, 1)
 	assert.Regexp(t, `✗ failed`, result.output)
+}
+
+func TestRunPromptFailsWhenOpenCodeExitsNonZeroAfterLaterPartialStep(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model:    "google/gemma-4-31b-it",
+		fallback: []string{"google/gemma-4-31b-it"},
+		env:      map[string]string{"SUPERPLANE_PLANNING_SESSION_ID": "plan-1"},
+		spawns: []spawnScript{{
+			ExitCode: 1,
+			Stdout: []string{
+				`{"type":"step_start","sessionID":"ses_hello","part":{"type":"step-start"}}`,
+				`{"type":"text","sessionID":"ses_hello","part":{"type":"text","text":"Hello! How can I help you today?"}}`,
+				`{"type":"step_finish","sessionID":"ses_hello","part":{"type":"step-finish","tokens":{"input":10,"output":8}}}`,
+				`{"type":"step_start","sessionID":"ses_hello","part":{"type":"step-start"}}`,
+				`{"type":"text","sessionID":"ses_hello","part":{"type":"text","text":"I found a few files to inspect"}}`,
+			},
+		}},
+	})
+	assert.Equal(t, 1, result.exitCode)
+	require.Len(t, result.spawns, 1)
+	assert.Regexp(t, `✗ failed`, result.output)
+	payload := resultPayload(t, result.resultFile)
+	usage, ok := payload["usage"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(10), usage["input_tokens"])
+	assert.Equal(t, float64(8), usage["output_tokens"])
 }
 
 func TestRunPromptFailsWhenOpenCodeExitsNonZeroWithPartialText(t *testing.T) {

--- a/pkg/components/runner/openrouter/run_test.go
+++ b/pkg/components/runner/openrouter/run_test.go
@@ -261,6 +261,24 @@ func TestRunPromptFailsWhenOpenCodeExitsNonZeroAfterReplyOnLineAutomation(t *tes
 	assert.Regexp(t, `✗ failed`, result.output)
 }
 
+func TestRunPromptFailsWhenOpenCodeExitsNonZeroWithUsageOnly(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model:    "google/gemma-4-31b-it",
+		fallback: []string{"google/gemma-4-31b-it"},
+		env:      map[string]string{"SUPERPLANE_PLANNING_SESSION_ID": "plan-1"},
+		spawns: []spawnScript{{
+			ExitCode: 1,
+			Stdout: []string{
+				`{"type":"step_start","sessionID":"ses_hello","part":{"type":"step-start"}}`,
+				`{"type":"step_finish","sessionID":"ses_hello","part":{"type":"step-finish","tokens":{"input":10,"output":8}}}`,
+			},
+		}},
+	})
+	assert.Equal(t, 1, result.exitCode)
+	require.Len(t, result.spawns, 1)
+	assert.Regexp(t, `✗ failed`, result.output)
+}
+
 func TestRunPromptFailsWhenOpenCodeExitsNonZeroWithoutReply(t *testing.T) {
 	result := runOpenRouterPrompt(t, promptHarness{
 		model:    "google/gemma-4-31b-it",

--- a/pkg/components/runner/openrouter/run_test.go
+++ b/pkg/components/runner/openrouter/run_test.go
@@ -261,6 +261,24 @@ func TestRunPromptFailsWhenOpenCodeExitsNonZeroAfterReplyOnLineAutomation(t *tes
 	assert.Regexp(t, `✗ failed`, result.output)
 }
 
+func TestRunPromptFailsWhenOpenCodeExitsNonZeroWithPartialText(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model:    "google/gemma-4-31b-it",
+		fallback: []string{"google/gemma-4-31b-it"},
+		env:      map[string]string{"SUPERPLANE_PLANNING_SESSION_ID": "plan-1"},
+		spawns: []spawnScript{{
+			ExitCode: 1,
+			Stdout: []string{
+				`{"type":"step_start","sessionID":"ses_hello","part":{"type":"step-start"}}`,
+				`{"type":"text","sessionID":"ses_hello","part":{"type":"text","text":"Hello! How can I help"}}`,
+			},
+		}},
+	})
+	assert.Equal(t, 1, result.exitCode)
+	require.Len(t, result.spawns, 1)
+	assert.Regexp(t, `✗ failed`, result.output)
+}
+
 func TestRunPromptFailsWhenOpenCodeExitsNonZeroWithUsageOnly(t *testing.T) {
 	result := runOpenRouterPrompt(t, promptHarness{
 		model:    "google/gemma-4-31b-it",

--- a/pkg/components/runner/openrouter/run_test.go
+++ b/pkg/components/runner/openrouter/run_test.go
@@ -226,6 +226,7 @@ func TestRunPromptSucceedsWhenOpenCodeExitsNonZeroAfterReply(t *testing.T) {
 	result := runOpenRouterPrompt(t, promptHarness{
 		model:    "google/gemma-4-31b-it",
 		fallback: []string{"google/gemma-4-31b-it"},
+		env:      map[string]string{"SUPERPLANE_PLANNING_SESSION_ID": "plan-1"},
 		spawns: []spawnScript{{
 			ExitCode: 1,
 			Stdout: []string{
@@ -240,6 +241,24 @@ func TestRunPromptSucceedsWhenOpenCodeExitsNonZeroAfterReply(t *testing.T) {
 	payload := resultPayload(t, result.resultFile)
 	assert.Equal(t, "Hello! How can I help you today?", payload["result"])
 	assert.Regexp(t, `✓ done`, result.output)
+}
+
+func TestRunPromptFailsWhenOpenCodeExitsNonZeroAfterReplyOnLineAutomation(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model:    "google/gemma-4-31b-it",
+		fallback: []string{"google/gemma-4-31b-it"},
+		spawns: []spawnScript{{
+			ExitCode: 1,
+			Stdout: []string{
+				`{"type":"step_start","sessionID":"ses_hello","part":{"type":"step-start"}}`,
+				`{"type":"text","sessionID":"ses_hello","part":{"type":"text","text":"Hello! How can I help you today?"}}`,
+				`{"type":"step_finish","sessionID":"ses_hello","part":{"type":"step-finish","tokens":{"input":10,"output":8}}}`,
+			},
+		}},
+	})
+	assert.Equal(t, 1, result.exitCode)
+	require.Len(t, result.spawns, 1)
+	assert.Regexp(t, `✗ failed`, result.output)
 }
 
 func TestRunPromptFailsWhenOpenCodeExitsNonZeroWithoutReply(t *testing.T) {

--- a/pkg/components/runner/openrouter/spec_test.go
+++ b/pkg/components/runner/openrouter/spec_test.go
@@ -212,6 +212,7 @@ func TestRunScriptSpawnsOpenCodeNotChatCompletions(t *testing.T) {
 	assert.Contains(t, runScript, "--pure")
 	assert.Contains(t, runScript, "openrouter/")
 	assert.Contains(t, runScript, "OPENCODE_CONFIG")
+	assert.Contains(t, runScript, "OPENCODE_DISABLE_MODELS_FETCH")
 	assert.Contains(t, runScript, "OPENROUTER_BASE_URL")
 	assert.NotContains(t, runScript, "/chat/completions")
 	assert.NotContains(t, runScript, "--agent")

--- a/pkg/components/runner/planning_session_mcp.js
+++ b/pkg/components/runner/planning_session_mcp.js
@@ -46,9 +46,17 @@ async function requestJSON(method, path, body) {
 }
 
 async function proposeDraft(input) {
+  const title = String((input && input.title) || "").trim();
+  const description = String((input && input.description) || "").trim();
+  if (!title) {
+    throw new Error("title is required");
+  }
+  if (!description) {
+    throw new Error("description is required");
+  }
   return requestJSON("POST", "/api/v1/runner/planning-sessions/drafts", {
-    title: String((input && input.title) || "").trim(),
-    description: String((input && input.description) || "").trim(),
+    title,
+    description,
   });
 }
 
@@ -71,14 +79,14 @@ async function proposeSurvey(input) {
 const TOOLS = [
   {
     name: "propose_draft",
-    description: "Show a draft task on the right only when the user asked for a task in this turn. The user confirms or skips. Do not create the task. Do not propose another draft unless the user asks.",
+    description: "Show a draft task on the right only when the user asked for a task in this turn. Title and description are required. Description must include the user's request and constraints. The user confirms or skips. Do not create the task. Do not propose another draft unless the user asks.",
     inputSchema: {
       type: "object",
       properties: {
         title: { type: "string" },
         description: { type: "string" },
       },
-      required: ["title"],
+      required: ["title", "description"],
     },
   },
   {

--- a/pkg/components/runner/planning_session_mcp_test.js
+++ b/pkg/components/runner/planning_session_mcp_test.js
@@ -21,6 +21,7 @@ test("lists planning tools over newline-delimited JSON-RPC", async () => {
     replies[1].result.tools.map((tool) => tool.name),
     ["propose_draft", "survey"],
   );
+  assert.deepEqual(replies[1].result.tools[0].inputSchema.required, ["title", "description"]);
 });
 
 test("lists planning tools over Content-Length JSON-RPC", async () => {

--- a/pkg/models/factory_planning_session.go
+++ b/pkg/models/factory_planning_session.go
@@ -324,10 +324,11 @@ func FindPlanningSessionByRun(tx *gorm.DB, canvasRunID uuid.UUID) (*FactoryPlann
 	return &session, nil
 }
 
-func EndPlanningSessionForFinishedRun(tx *gorm.DB, canvasRunID uuid.UUID, result string) error {
-	if result != CanvasRunResultFailed && result != CanvasRunResultCancelled {
-		return nil
-	}
+// EndPlanningSessionForFinishedRun closes the planning session when the canvas
+// run is finished. Follow-up keeps a healthy session's run in progress. A
+// finished run means the agent process is gone, including a passed greet that
+// never entered wait.
+func EndPlanningSessionForFinishedRun(tx *gorm.DB, canvasRunID uuid.UUID, _ string) error {
 	session, err := FindPlanningSessionByRun(tx, canvasRunID)
 	if errors.Is(err, ErrFactoryPlanningSessionNotFound) {
 		return nil

--- a/pkg/models/factory_planning_session_draft.go
+++ b/pkg/models/factory_planning_session_draft.go
@@ -31,9 +31,13 @@ func (s *FactoryPlanningSession) ProposeDraft(tx *gorm.DB, draft PlanningSession
 		if title == "" {
 			return fmt.Errorf("%w: draft title is required", ErrFactoryPlanningSessionInvalid)
 		}
+		description := strings.TrimSpace(draft.Description)
+		if description == "" {
+			return fmt.Errorf("%w: draft description is required", ErrFactoryPlanningSessionInvalid)
+		}
 		s.setDraft(PlanningSessionDraft{
 			Title:       title,
-			Description: strings.TrimSpace(draft.Description),
+			Description: description,
 			WorkOrderID: s.Draft().WorkOrderID,
 		})
 		return s.saveDraft(inner)

--- a/pkg/models/factory_planning_session_test.go
+++ b/pkg/models/factory_planning_session_test.go
@@ -344,6 +344,17 @@ func TestFactoryPlanningSession_ProposeAndSkipDraft(t *testing.T) {
 	assert.Equal(t, PlanningWaitKindSkipped, session.Wait().Kind)
 }
 
+func TestFactoryPlanningSession_ProposeDraftRequiresDescription(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+	session := startTestPlanningSession(t, "plan-draft-desc")
+	db := database.DB(t.Context())
+
+	err := session.ProposeDraft(db, PlanningSessionDraft{Title: "Add flight transportation mode"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFactoryPlanningSessionInvalid)
+	assert.Equal(t, "", session.Draft().Title)
+}
+
 func TestFactoryPlanningSession_CreateDraftWorkOrder(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 	session := startTestPlanningSession(t, "plan-create")
@@ -562,17 +573,12 @@ func TestFactoryPlanningSession_RefineNoteIgnoresOpenWorkOrder(t *testing.T) {
 
 func TestEndPlanningSessionForFinishedRun(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
-	session := startTestPlanningSession(t, "plan-run-fail")
+	session := startTestPlanningSession(t, "plan-run-pass")
 	db := database.DB(t.Context())
 	require.NotNil(t, session.CanvasRunID)
 
 	require.NoError(t, EndPlanningSessionForFinishedRun(db, *session.CanvasRunID, CanvasRunResultPassed))
 	reloaded, err := FindPlanningSession(db, session.OrganizationID, session.FactoryID, session.ID)
-	require.NoError(t, err)
-	assert.Equal(t, PlanningSessionStateRunning, reloaded.State)
-
-	require.NoError(t, EndPlanningSessionForFinishedRun(db, *session.CanvasRunID, CanvasRunResultFailed))
-	reloaded, err = FindPlanningSession(db, session.OrganizationID, session.FactoryID, session.ID)
 	require.NoError(t, err)
 	assert.Equal(t, PlanningSessionStateEnded, reloaded.State)
 	require.NotNil(t, reloaded.EndedAt)

--- a/pkg/workers/run_finalizer_test.go
+++ b/pkg/workers/run_finalizer_test.go
@@ -141,7 +141,7 @@ func Test__RunFinalizer_EndsPlanningSessionWhenRunFails(t *testing.T) {
 	require.NotNil(t, reloaded.EndedAt)
 }
 
-func Test__RunFinalizer_KeepsPlanningSessionWhenRunPasses(t *testing.T) {
+func Test__RunFinalizer_EndsPlanningSessionWhenRunPasses(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
 
@@ -165,7 +165,8 @@ func Test__RunFinalizer_KeepsPlanningSessionWhenRunPasses(t *testing.T) {
 
 	reloaded, err := models.FindPlanningSession(database.Conn(), session.OrganizationID, session.FactoryID, session.ID)
 	require.NoError(t, err)
-	assert.Equal(t, models.PlanningSessionStateRunning, reloaded.State)
+	assert.Equal(t, models.PlanningSessionStateEnded, reloaded.State)
+	require.NotNil(t, reloaded.EndedAt)
 }
 
 func Test__RunFinalizer_LeavesEndedPlanningSessionEnded(t *testing.T) {

--- a/web_src/src/pages/factories/pages/CreateWithAgentDialog.spec.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgentDialog.spec.tsx
@@ -267,6 +267,16 @@ describe("CreateWithAgentDialog", () => {
     expect(within(draft).queryByRole("button", { name: /show more/i })).not.toBeInTheDocument();
   });
 
+  it("does not create a draft that has no description", () => {
+    renderDialog(
+      runningCreateWithAgentView({
+        right: { kind: "draft", draft: { title: "Add flight transportation mode", description: "" } },
+      }),
+    );
+
+    expect(screen.getByRole("button", { name: CREATE_WITH_AGENT_COPY.create })).toBeDisabled();
+  });
+
   it("wraps a long draft title", () => {
     const title = "Add a color field with a visual color picker to the Puppy entity";
     renderDialog(

--- a/web_src/src/pages/factories/pages/CreateWithAgentDialog.tsx
+++ b/web_src/src/pages/factories/pages/CreateWithAgentDialog.tsx
@@ -393,7 +393,7 @@ function DraftWorkPane({
         <Button
           type="button"
           data-testid="create-with-agent-create"
-          disabled={failed || !title.trim()}
+          disabled={failed || !title.trim() || !description.trim()}
           onClick={onCreate}
         >
           {refining ? CREATE_WITH_AGENT_COPY.update : CREATE_WITH_AGENT_COPY.create}

--- a/web_src/src/pages/factories/pages/planningSessionView.spec.ts
+++ b/web_src/src/pages/factories/pages/planningSessionView.spec.ts
@@ -88,6 +88,23 @@ describe("createWithAgentViewFromSession", () => {
     expect(view.machineStatus).toBe("failed");
   });
 
+  it("marks the machine failed when the live run passed and SuperPlane is not waiting", () => {
+    const view = applyPlanningSessionLiveRun(
+      createWithAgentViewFromSession(
+        {
+          repository: "acme/payments",
+          canvasId: "canvas-1",
+          canvasRunId: "run-1",
+          executionId: "exec-1",
+        },
+        { composer: "", right: { kind: "empty" }, endConfirmOpen: false },
+      ),
+      { result: "RESULT_PASSED" },
+    );
+
+    expect(view.machineStatus).toBe("failed");
+  });
+
   it("keeps waiting when the live run is still open", () => {
     const view = applyPlanningSessionLiveRun(
       createWithAgentViewFromSession(

--- a/web_src/src/pages/factories/pages/planningSessionView.ts
+++ b/web_src/src/pages/factories/pages/planningSessionView.ts
@@ -110,10 +110,16 @@ export function applyPlanningSessionLiveRun(
   view: CreateWithAgentView,
   run: { result?: string } | null | undefined,
 ): CreateWithAgentView {
-  if (view.machineStatus === "failed" || !isFailedPlanningCanvasRun(run)) {
+  if (view.machineStatus === "failed") {
     return view;
   }
-  return { ...view, machineStatus: "failed" };
+  if (isFailedPlanningCanvasRun(run)) {
+    return { ...view, machineStatus: "failed" };
+  }
+  if (run?.result === "RESULT_PASSED" && view.machineStatus !== "waiting") {
+    return { ...view, machineStatus: "failed" };
+  }
+  return view;
 }
 
 function createWithAgentMachineStatus(session: PlanningSessionPayload): CreateWithAgentView["machineStatus"] {

--- a/web_src/src/pages/factories/pages/usePlanningSessionLiveRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/usePlanningSessionLiveRun.spec.tsx
@@ -27,6 +27,15 @@ describe("usePlanningSessionLiveRun", () => {
     expect(result.current.machineStatus).toBe("failed");
   });
 
+  it("marks the machine failed when the live run passed", () => {
+    useDescribeRun.mockReturnValue({ data: { run: { result: "RESULT_PASSED" } } });
+    const view = runningCreateWithAgentView();
+
+    const { result } = renderHook(() => usePlanningSessionLiveRun("org-1", view));
+
+    expect(result.current.machineStatus).toBe("failed");
+  });
+
   it("stays off until the session has a canvas run", () => {
     useDescribeRun.mockReturnValue({ data: undefined });
     const view = runningCreateWithAgentView({ canvasId: "", canvasRunId: "" });

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.spec.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.spec.ts
@@ -5,6 +5,7 @@ import {
   completeCommandSection,
   endToolOnLatestSection,
   sectionTitle,
+  shouldSkipUnindexedLiveLogReplay,
   startCommandSection,
   startToolOnLatestSection,
 } from "./liveLogSections";
@@ -129,6 +130,29 @@ describe("liveLogSections", () => {
     }
     expect(first.tools).toHaveLength(1);
     expect(first.tools[0]).toMatchObject({ status: "passed", duration_ms: 5 });
+    expect(state.sections[1].events).toEqual([]);
+  });
+
+  it("does not attach a replayed tool id to a later running command", () => {
+    let state = startCommandSection(emptyState(), {
+      index: 2,
+      text: "Plan with the user",
+      startedAtMs: 1,
+      kind: "prompt",
+      preview: "Greet the user",
+    });
+    state = startToolOnLatestSection(state, "bash", "ls", "call_1");
+    state = endToolOnLatestSection(state, "passed", 5, "call_1");
+    state = completeCommandSection(state, 2, "passed", 20);
+    state = startCommandSection(state, {
+      index: 1000,
+      text: "Wait for the next message",
+      startedAtMs: 2,
+      kind: "prompt",
+      preview: "Wait for the next user message",
+    });
+    state = startToolOnLatestSection(state, "bash", "ls", "call_1");
+
     expect(state.sections[1].events).toEqual([]);
   });
 
@@ -266,6 +290,28 @@ describe("liveLogSections", () => {
     ]);
   });
 
+  it("keeps the same status line on a later prompt during the first stream", () => {
+    let state = startCommandSection(emptyState(), {
+      index: 2,
+      text: "Greet",
+      startedAtMs: 1,
+      kind: "prompt",
+      preview: "Greet the user",
+    });
+    state = appendLineToLatestSection(state, "OpenCode started");
+    state = completeCommandSection(state, 2, "passed", 20);
+    state = startCommandSection(state, {
+      index: 1000,
+      text: "Follow up",
+      startedAtMs: 2,
+      kind: "prompt",
+      preview: "Continue",
+    });
+    state = appendLineToLatestSection(state, "OpenCode started");
+
+    expect(state.sections[1].lines).toEqual(["OpenCode started"]);
+  });
+
   it("drops replayed clone and greet lines that already belong to earlier commands", () => {
     let state = startCommandSection(emptyState(), {
       index: 0,
@@ -303,9 +349,6 @@ describe("liveLogSections", () => {
     });
     state = appendLineToLatestSection(state, "I've proposed a draft.");
 
-    state = appendLineToLatestSection(state, "Agent ready");
-    state = appendLineToLatestSection(state, "Cloning into 'repo'...");
-    state = appendLineToLatestSection(state, "Hello! How can I help you today?");
     state = appendLineToLatestSection(state, "Agent ready", undefined, 0);
     state = appendLineToLatestSection(state, "Cloning into 'repo'...", undefined, 1);
     state = appendLineToLatestSection(state, "Hello! How can I help you today?", undefined, 2);
@@ -328,5 +371,15 @@ describe("liveLogSections", () => {
 
     expect(state.sections[0].lines).toEqual(["Turn 1 · 3 tokens"]);
     expect(state.sections[0].events).toEqual([{ kind: "note", text: "Turn 1 · 3 tokens" }]);
+  });
+});
+
+describe("shouldSkipUnindexedLiveLogReplay", () => {
+  it("skips unindexed reconnect lines only after an earlier command has finished", () => {
+    expect(shouldSkipUnindexedLiveLogReplay(false, undefined, true)).toBe(false);
+    expect(shouldSkipUnindexedLiveLogReplay(true, undefined, false)).toBe(false);
+    expect(shouldSkipUnindexedLiveLogReplay(true, undefined, true)).toBe(true);
+    expect(shouldSkipUnindexedLiveLogReplay(true, 0, true)).toBe(false);
+    expect(shouldSkipUnindexedLiveLogReplay(false, 1000, true)).toBe(false);
   });
 });

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.spec.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.spec.ts
@@ -101,6 +101,37 @@ describe("liveLogSections", () => {
     expect(tools.tools[1]).toMatchObject({ sourceId: "toolu_b", status: "failed", duration_ms: 10 });
   });
 
+  it("attaches replayed tools to the active command, not the latest section", () => {
+    let state = startCommandSection(emptyState(), {
+      index: 2,
+      text: "Plan with the user",
+      startedAtMs: 1,
+      kind: "prompt",
+      preview: "Greet the user",
+    });
+    state = startToolOnLatestSection(state, "bash", "ls", "call_1");
+    state = endToolOnLatestSection(state, "passed", 5, "call_1");
+    state = startCommandSection(state, {
+      index: 1000,
+      text: "Wait for the next message",
+      startedAtMs: 2,
+      kind: "prompt",
+      preview: "Wait for the next user message",
+    });
+
+    state = startToolOnLatestSection(state, "bash", "ls", "call_1", 2);
+    state = endToolOnLatestSection(state, "failed", 99, "call_1", 2);
+
+    const first = state.sections[0].events[0];
+    expect(first?.kind).toBe("tools");
+    if (first?.kind !== "tools") {
+      throw new Error("expected tools group");
+    }
+    expect(first.tools).toHaveLength(1);
+    expect(first.tools[0]).toMatchObject({ status: "passed", duration_ms: 5 });
+    expect(state.sections[1].events).toEqual([]);
+  });
+
   it("ignores replayed tool records with the same source id", () => {
     let state = startCommandSection(emptyState(), {
       index: 5,
@@ -182,6 +213,106 @@ describe("liveLogSections", () => {
     state = appendLineToLatestSection(state, "Cloning...");
     expect(state.sections[0].events).toEqual([]);
     expect(state.sections[0].lines).toEqual(["Cloning..."]);
+  });
+
+  it("does not replay earlier command output onto the current prompt", () => {
+    let state = startCommandSection(emptyState(), {
+      index: 0,
+      text: "Prepare OpenRouter agent",
+      startedAtMs: 1,
+      kind: "setup",
+      preview: "Prepare OpenRouter agent",
+    });
+    state = appendLineToLatestSection(state, "Agent ready");
+    state = appendLineToLatestSection(state, "opencode=1.18.3");
+    state = completeCommandSection(state, 0, "passed", 10);
+    state = startCommandSection(state, {
+      index: 1,
+      text: "Clone Repo",
+      startedAtMs: 2,
+      kind: "bash",
+      preview: "git clone",
+    });
+    state = appendLineToLatestSection(state, "Cloning into 'repo'...");
+    state = completeCommandSection(state, 1, "passed", 20);
+    state = startCommandSection(state, {
+      index: 2,
+      text: "Plan with the user",
+      startedAtMs: 3,
+      kind: "prompt",
+      preview: "Greet the user",
+    });
+    state = appendLineToLatestSection(state, "Starting OpenCode");
+    state = appendLineToLatestSection(state, "Hello! How can I help you today?");
+
+    const skip = new Map<number, number>([
+      [0, state.sections[0].lines.length],
+      [1, state.sections[1].lines.length],
+      [2, state.sections[2].lines.length],
+    ]);
+    state = appendLineToLatestSection(state, "Agent ready", skip, 0);
+    state = appendLineToLatestSection(state, "opencode=1.18.3", skip, 0);
+    state = appendLineToLatestSection(state, "Cloning into 'repo'...", skip, 1);
+    state = appendLineToLatestSection(state, "Starting OpenCode", skip, 2);
+    state = appendLineToLatestSection(state, "Hello! How can I help you today?", skip, 2);
+    state = appendLineToLatestSection(state, "What should we work on?", skip, 2);
+
+    const prompt = state.sections[2];
+    expect(prompt.lines).toEqual(["Starting OpenCode", "Hello! How can I help you today?", "What should we work on?"]);
+    expect(prompt.events.map((event) => (event.kind === "note" ? event.text : event.kind))).toEqual([
+      "Starting OpenCode",
+      "Hello! How can I help you today?",
+      "What should we work on?",
+    ]);
+  });
+
+  it("drops replayed clone and greet lines that already belong to earlier commands", () => {
+    let state = startCommandSection(emptyState(), {
+      index: 0,
+      text: "Prepare OpenRouter agent",
+      startedAtMs: 1,
+      kind: "setup",
+      preview: "Prepare OpenRouter agent",
+    });
+    state = appendLineToLatestSection(state, "Agent ready");
+    state = completeCommandSection(state, 0, "passed", 10);
+    state = startCommandSection(state, {
+      index: 1,
+      text: "Clone Repo",
+      startedAtMs: 2,
+      kind: "bash",
+      preview: "git clone",
+    });
+    state = appendLineToLatestSection(state, "Cloning into 'repo'...");
+    state = completeCommandSection(state, 1, "passed", 20);
+    state = startCommandSection(state, {
+      index: 2,
+      text: "Plan with the user",
+      startedAtMs: 3,
+      kind: "prompt",
+      preview: "Greet the user",
+    });
+    state = appendLineToLatestSection(state, "Hello! How can I help you today?");
+    state = completeCommandSection(state, 2, "passed", 30);
+    state = startCommandSection(state, {
+      index: 1000,
+      text: "Wait for the next message",
+      startedAtMs: 4,
+      kind: "prompt",
+      preview: "Wait for the next user message",
+    });
+    state = appendLineToLatestSection(state, "I've proposed a draft.");
+
+    state = appendLineToLatestSection(state, "Agent ready");
+    state = appendLineToLatestSection(state, "Cloning into 'repo'...");
+    state = appendLineToLatestSection(state, "Hello! How can I help you today?");
+    state = appendLineToLatestSection(state, "Agent ready", undefined, 0);
+    state = appendLineToLatestSection(state, "Cloning into 'repo'...", undefined, 1);
+    state = appendLineToLatestSection(state, "Hello! How can I help you today?", undefined, 2);
+
+    const prompt = state.sections[3];
+    expect(prompt.lines).toEqual(["I've proposed a draft."]);
+    expect(prompt.events).toEqual([{ kind: "note", text: "I've proposed a draft." }]);
   });
 
   it("drops raw turn JSON so it does not appear as a log line", () => {

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.ts
@@ -66,19 +66,26 @@ export function appendLineToLatestSection(
   state: LogState,
   text: string,
   replayLineSkip?: Map<number, number>,
+  commandIndex?: number,
 ): LogState {
   if (isRawAgentTurnLiveLogText(text)) {
     return state;
   }
-  if (state.sections.length === 0) {
+  const sectionPos = commandSectionPosition(state, commandIndex);
+  if (sectionPos < 0) {
     return {
       ...state,
       orphanLines: [...state.orphanLines, text],
     };
   }
 
-  const lastSectionIndex = state.sections.length - 1;
-  const section = state.sections[lastSectionIndex];
+  const section = state.sections[sectionPos];
+  if (section.status !== "running") {
+    return state;
+  }
+  if (lineOwnedByOtherSection(state, text, section.index)) {
+    return state;
+  }
   const skipLeft = replayLineSkip?.get(section.index) ?? 0;
   if (skipLeft > 0) {
     replayLineSkip?.set(section.index, skipLeft - 1);
@@ -86,24 +93,33 @@ export function appendLineToLatestSection(
   }
 
   const nextSections = [...state.sections];
-  nextSections[lastSectionIndex] = appendLineToSection(section, text);
+  nextSections[sectionPos] = appendLineToSection(section, text);
   return {
     ...state,
     sections: nextSections,
   };
 }
 
-export function startToolOnLatestSection(state: LogState, kind: string, text: string, sourceId?: string): LogState {
-  if (state.sections.length === 0) {
+export function startToolOnLatestSection(
+  state: LogState,
+  kind: string,
+  text: string,
+  sourceId?: string,
+  commandIndex?: number,
+): LogState {
+  const sectionPos = commandSectionPosition(state, commandIndex);
+  if (sectionPos < 0) {
     return state;
   }
-  const lastSectionIndex = state.sections.length - 1;
-  const section = state.sections[lastSectionIndex];
+  const section = state.sections[sectionPos];
+  if (section.status !== "running") {
+    return state;
+  }
   if (sourceId && findToolInSection(section, sourceId)) {
     return state;
   }
   const nextSections = [...state.sections];
-  nextSections[lastSectionIndex] = startToolOnSection(section, kind, text, sourceId);
+  nextSections[sectionPos] = startToolOnSection(section, kind, text, sourceId);
   return { ...state, sections: nextSections };
 }
 
@@ -112,12 +128,13 @@ export function endToolOnLatestSection(
   status: "passed" | "failed",
   durationMs: number,
   sourceId?: string,
+  commandIndex?: number,
 ): LogState {
-  if (state.sections.length === 0) {
+  const sectionPos = commandSectionPosition(state, commandIndex);
+  if (sectionPos < 0) {
     return state;
   }
-  const lastSectionIndex = state.sections.length - 1;
-  const section = state.sections[lastSectionIndex];
+  const section = state.sections[sectionPos];
   if (sourceId) {
     const existing = findToolInSection(section, sourceId);
     if (existing && existing.status !== "running") {
@@ -125,8 +142,23 @@ export function endToolOnLatestSection(
     }
   }
   const nextSections = [...state.sections];
-  nextSections[lastSectionIndex] = endOpenTool(section, status, durationMs, sourceId);
+  nextSections[sectionPos] = endOpenTool(section, status, durationMs, sourceId);
   return { ...state, sections: nextSections };
+}
+
+function commandSectionPosition(state: LogState, commandIndex?: number): number {
+  if (commandIndex === undefined) {
+    return state.sections.length - 1;
+  }
+  return state.sections.findIndex((section) => section.index === commandIndex);
+}
+
+function lineOwnedByOtherSection(state: LogState, text: string, commandIndex: number): boolean {
+  const needle = text.trim();
+  if (!needle) {
+    return false;
+  }
+  return state.sections.some((section) => section.index !== commandIndex && section.lines.includes(text));
 }
 
 function appendLineToSection(section: CommandSection, text: string): CommandSection {

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.ts
@@ -83,9 +83,6 @@ export function appendLineToLatestSection(
   if (section.status !== "running") {
     return state;
   }
-  if (lineOwnedByOtherSection(state, text, section.index)) {
-    return state;
-  }
   const skipLeft = replayLineSkip?.get(section.index) ?? 0;
   if (skipLeft > 0) {
     replayLineSkip?.set(section.index, skipLeft - 1);
@@ -115,7 +112,7 @@ export function startToolOnLatestSection(
   if (section.status !== "running") {
     return state;
   }
-  if (sourceId && findToolInSection(section, sourceId)) {
+  if (sourceId && state.sections.some((candidate) => findToolInSection(candidate, sourceId))) {
     return state;
   }
   const nextSections = [...state.sections];
@@ -146,19 +143,19 @@ export function endToolOnLatestSection(
   return { ...state, sections: nextSections };
 }
 
+export function shouldSkipUnindexedLiveLogReplay(
+  reconnecting: boolean,
+  commandIndex: number | undefined,
+  hasFinishedSection: boolean,
+): boolean {
+  return reconnecting && commandIndex === undefined && hasFinishedSection;
+}
+
 function commandSectionPosition(state: LogState, commandIndex?: number): number {
   if (commandIndex === undefined) {
     return state.sections.length - 1;
   }
   return state.sections.findIndex((section) => section.index === commandIndex);
-}
-
-function lineOwnedByOtherSection(state: LogState, text: string, commandIndex: number): boolean {
-  const needle = text.trim();
-  if (!needle) {
-    return false;
-  }
-  return state.sections.some((section) => section.index !== commandIndex && section.lines.includes(text));
 }
 
 function appendLineToSection(section: CommandSection, text: string): CommandSection {

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogStream.spec.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogStream.spec.ts
@@ -66,6 +66,13 @@ describe("consumeLiveLogNdjsonLine", () => {
     expect(next.onTurn).not.toHaveBeenCalled();
   });
 
+  it("forwards a command index on a log line", () => {
+    const next = handlers();
+    consumeLiveLogNdjsonLine(JSON.stringify({ type: "line", index: 2, text: "Hello" }), next);
+
+    expect(next.onLogLine).toHaveBeenCalledWith("Hello", 2);
+  });
+
   it("splits each prompt command into its own usage series", () => {
     const series = reducePromptUsageFromLiveLogLines([
       JSON.stringify({ type: "cmd_start", index: 2, text: "Implementation", kind: "prompt" }),

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogStream.ts
@@ -30,7 +30,7 @@ type LiveLogSessionResponse = {
 };
 
 export type LiveLogStreamHandlers = {
-  onLogLine: (text: string) => void;
+  onLogLine: (text: string, commandIndex?: number) => void;
   onStreamError: (message: string) => void;
   onCmdStart?: (index: number, text: string, startedAtMs: number | null, kind?: string, preview?: string) => void;
   onCmdEnd?: (index: number, status: "passed" | "failed", durationMs: number) => void;
@@ -111,7 +111,11 @@ function dispatchLineRecord(rec: LiveLogRecordEnvelope, handlers: LiveLogStreamH
     handlers.onTurn?.(nestedTurn.turn, nestedTurn.usage, nestedTurn.message);
     return true;
   }
-  handlers.onLogLine(rec.text);
+  if (typeof rec.index === "number") {
+    handlers.onLogLine(rec.text, rec.index);
+  } else {
+    handlers.onLogLine(rec.text);
+  }
   return true;
 }
 

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
@@ -7,8 +7,10 @@ import {
   closeOpenTool,
   completeCommandSection,
   endToolOnLatestSection,
+  shouldSkipUnindexedLiveLogReplay,
   startCommandSection,
   startToolOnLatestSection,
+  type CommandStart,
 } from "./liveLogSections";
 import type { CommandSection, LogState } from "./types";
 import { useScrollToBottom } from "./useScrollToBottom";
@@ -33,6 +35,10 @@ const initialLogState: LogState = {
 
 function hasRunningCommand(state: LogState): boolean {
   return state.sections.some((section) => section.status === "running");
+}
+
+function hasFinishedCommandSection(state: LogState): boolean {
+  return state.sections.some((section) => section.status !== "running");
 }
 
 export function terminalCommandStatusForExecution(execution: ExecutionInfo): "passed" | "failed" | null {
@@ -105,32 +111,28 @@ function applyStreamFailure(state: LogState, message: string, executionInFlight:
   return state;
 }
 
-function createStreamHandlers(
-  reconnecting: boolean,
-  replayLineSkip: Map<number, number>,
-  executionInFlight: boolean,
-  setState: Dispatch<SetStateAction<LogState>>,
-  setUsage: Dispatch<SetStateAction<AgentPromptUsageState>>,
-  commandCursor: { index?: number },
-): LiveLogStreamHandlers {
+type StreamHandlerContext = {
+  reconnecting: boolean;
+  replayLineSkip: Map<number, number>;
+  executionInFlight: boolean;
+  setState: Dispatch<SetStateAction<LogState>>;
+  setUsage: Dispatch<SetStateAction<AgentPromptUsageState>>;
+  commandCursor: { index?: number };
+};
+
+function createStreamHandlers(ctx: StreamHandlerContext): LiveLogStreamHandlers {
+  const { reconnecting, replayLineSkip, executionInFlight, setState, setUsage, commandCursor } = ctx;
   return {
     onLogLine: (text, commandIndex) => {
       const index = commandIndex ?? commandCursor.index;
-      setState((prev) => appendLineToLatestSection(prev, text, replayLineSkip, index));
+      setState((prev) => appendReplayedLogLine(prev, text, replayLineSkip, index, reconnecting));
     },
     onStreamError: (message) => setState((prev) => applyStreamFailure(prev, message, executionInFlight)),
     onCmdStart: (index, text, startedAtMs, kind, preview) => {
       commandCursor.index = index;
-      setState((prev) => {
-        const existing = prev.sections.find((section) => section.index === index);
-        if (existing) {
-          if (reconnecting) {
-            replayLineSkip.set(index, existing.lines.length);
-          }
-          return prev;
-        }
-        return startCommandSection(prev, { index, text, startedAtMs, kind, preview });
-      });
+      setState((prev) =>
+        rememberOrStartCommand(prev, { index, text, startedAtMs, kind, preview }, replayLineSkip, reconnecting),
+      );
       if (kind === "prompt") {
         setUsage((prev) => startPromptUsageSeries(prev, text, index));
       }
@@ -138,17 +140,72 @@ function createStreamHandlers(
     onCmdEnd: (index, status, durationMs) =>
       setState((prev) => completeCommandSection(prev, index, status, durationMs)),
     onToolStart: (kind, text, id, turn) => {
-      setState((prev) => startToolOnLatestSection(prev, kind, text, id, commandCursor.index));
+      setState((prev) =>
+        startReplayedTool(prev, { kind, text, sourceId: id, commandIndex: commandCursor.index }, reconnecting),
+      );
       setUsage((prev) => applyPromptUsageRecord(prev, { type: "tool_start", kind, text, id, turn }));
     },
     onToolEnd: (status, durationMs, id, turn) => {
-      setState((prev) => endToolOnLatestSection(prev, status, durationMs, id, commandCursor.index));
+      setState((prev) =>
+        endReplayedTool(prev, { status, durationMs, sourceId: id, commandIndex: commandCursor.index }, reconnecting),
+      );
       setUsage((prev) => applyPromptUsageRecord(prev, { type: "tool_end", status, duration_ms: durationMs, id, turn }));
     },
     onTurn: (turn, usage, message) => {
       setUsage((prev) => applyPromptUsageRecord(prev, { type: "turn", turn, usage, message }));
     },
   };
+}
+
+function appendReplayedLogLine(
+  state: LogState,
+  text: string,
+  replayLineSkip: Map<number, number>,
+  commandIndex: number | undefined,
+  reconnecting: boolean,
+): LogState {
+  if (shouldSkipUnindexedLiveLogReplay(reconnecting, commandIndex, hasFinishedCommandSection(state))) {
+    return state;
+  }
+  return appendLineToLatestSection(state, text, replayLineSkip, commandIndex);
+}
+
+function rememberOrStartCommand(
+  state: LogState,
+  start: CommandStart,
+  replayLineSkip: Map<number, number>,
+  reconnecting: boolean,
+): LogState {
+  const existing = state.sections.find((section) => section.index === start.index);
+  if (!existing) {
+    return startCommandSection(state, start);
+  }
+  if (reconnecting) {
+    replayLineSkip.set(start.index, existing.lines.length);
+  }
+  return state;
+}
+
+function startReplayedTool(
+  state: LogState,
+  tool: { kind: string; text: string; sourceId?: string; commandIndex?: number },
+  reconnecting: boolean,
+): LogState {
+  if (shouldSkipUnindexedLiveLogReplay(reconnecting, tool.commandIndex, hasFinishedCommandSection(state))) {
+    return state;
+  }
+  return startToolOnLatestSection(state, tool.kind, tool.text, tool.sourceId, tool.commandIndex);
+}
+
+function endReplayedTool(
+  state: LogState,
+  tool: { status: "passed" | "failed"; durationMs: number; sourceId?: string; commandIndex?: number },
+  reconnecting: boolean,
+): LogState {
+  if (shouldSkipUnindexedLiveLogReplay(reconnecting, tool.commandIndex, hasFinishedCommandSection(state))) {
+    return state;
+  }
+  return endToolOnLatestSection(state, tool.status, tool.durationMs, tool.sourceId, tool.commandIndex);
 }
 
 function sleep(ms: number, signal: AbortSignal): Promise<void> {
@@ -185,46 +242,53 @@ type LiveLogSessionParams = {
   setActiveStream: (stream: LiveLogStream | null) => void;
 };
 
-async function runLiveLogSession({
-  organizationId,
-  canvasId,
-  executionId,
-  executionInFlight,
-  terminalCommandStatus,
-  terminalAtMs,
-  sessionAbort,
-  setState,
-  setUsage,
-  setActiveStream,
-}: LiveLogSessionParams): Promise<void> {
+async function pumpLiveLogConnection(params: LiveLogSessionParams, reconnecting: boolean): Promise<"aborted" | "open"> {
+  const {
+    organizationId,
+    canvasId,
+    executionId,
+    executionInFlight,
+    sessionAbort,
+    setState,
+    setUsage,
+    setActiveStream,
+  } = params;
+  const stream = new LiveLogStream(organizationId, canvasId, executionId);
+  setActiveStream(stream);
+  try {
+    await stream.pump(
+      createStreamHandlers({
+        reconnecting,
+        replayLineSkip: new Map<number, number>(),
+        executionInFlight,
+        setState,
+        setUsage,
+        commandCursor: {},
+      }),
+    );
+  } catch (error) {
+    if ((error as Error).name === "AbortError") {
+      return "aborted";
+    }
+    if (!sessionAbort.signal.aborted) {
+      setState((prev) => applyStreamFailure(prev, (error as Error).message, executionInFlight));
+    }
+  } finally {
+    stream.stop();
+    setActiveStream(null);
+  }
+  return sessionAbort.signal.aborted ? "aborted" : "open";
+}
+
+async function runLiveLogSession(params: LiveLogSessionParams): Promise<void> {
+  const { executionInFlight, terminalCommandStatus, terminalAtMs, sessionAbort, setState } = params;
   let reconnecting = false;
-  const commandCursor: { index?: number } = {};
 
   while (!sessionAbort.signal.aborted) {
-    const stream = new LiveLogStream(organizationId, canvasId, executionId);
-    setActiveStream(stream);
-    const replayLineSkip = new Map<number, number>();
-
-    try {
-      await stream.pump(
-        createStreamHandlers(reconnecting, replayLineSkip, executionInFlight, setState, setUsage, commandCursor),
-      );
-    } catch (error) {
-      if ((error as Error).name === "AbortError") {
-        return;
-      }
-      if (!sessionAbort.signal.aborted) {
-        setState((prev) => applyStreamFailure(prev, (error as Error).message, executionInFlight));
-      }
-    } finally {
-      stream.stop();
-      setActiveStream(null);
-    }
-
-    if (sessionAbort.signal.aborted) {
+    const result = await pumpLiveLogConnection(params, reconnecting);
+    if (result === "aborted") {
       return;
     }
-
     if (!executionInFlight) {
       if (terminalCommandStatus) {
         setState((prev) => finalizeRunningCommandSections(prev, terminalCommandStatus, terminalAtMs));
@@ -233,17 +297,12 @@ async function runLiveLogSession({
     }
 
     reconnecting = true;
-    setState((prev) => ({
-      ...prev,
-      isStreaming: false,
-    }));
-
+    setState((prev) => ({ ...prev, isStreaming: false }));
     try {
       await sleep(RECONNECT_DELAY_MS, sessionAbort.signal);
     } catch {
       return;
     }
-
     setState((prev) => ({ ...prev, isStreaming: true }));
   }
 }

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
@@ -111,11 +111,16 @@ function createStreamHandlers(
   executionInFlight: boolean,
   setState: Dispatch<SetStateAction<LogState>>,
   setUsage: Dispatch<SetStateAction<AgentPromptUsageState>>,
+  commandCursor: { index?: number },
 ): LiveLogStreamHandlers {
   return {
-    onLogLine: (text) => setState((prev) => appendLineToLatestSection(prev, text, replayLineSkip)),
+    onLogLine: (text, commandIndex) => {
+      const index = commandIndex ?? commandCursor.index;
+      setState((prev) => appendLineToLatestSection(prev, text, replayLineSkip, index));
+    },
     onStreamError: (message) => setState((prev) => applyStreamFailure(prev, message, executionInFlight)),
     onCmdStart: (index, text, startedAtMs, kind, preview) => {
+      commandCursor.index = index;
       setState((prev) => {
         const existing = prev.sections.find((section) => section.index === index);
         if (existing) {
@@ -133,11 +138,11 @@ function createStreamHandlers(
     onCmdEnd: (index, status, durationMs) =>
       setState((prev) => completeCommandSection(prev, index, status, durationMs)),
     onToolStart: (kind, text, id, turn) => {
-      setState((prev) => startToolOnLatestSection(prev, kind, text, id));
+      setState((prev) => startToolOnLatestSection(prev, kind, text, id, commandCursor.index));
       setUsage((prev) => applyPromptUsageRecord(prev, { type: "tool_start", kind, text, id, turn }));
     },
     onToolEnd: (status, durationMs, id, turn) => {
-      setState((prev) => endToolOnLatestSection(prev, status, durationMs, id));
+      setState((prev) => endToolOnLatestSection(prev, status, durationMs, id, commandCursor.index));
       setUsage((prev) => applyPromptUsageRecord(prev, { type: "tool_end", status, duration_ms: durationMs, id, turn }));
     },
     onTurn: (turn, usage, message) => {
@@ -193,6 +198,7 @@ async function runLiveLogSession({
   setActiveStream,
 }: LiveLogSessionParams): Promise<void> {
   let reconnecting = false;
+  const commandCursor: { index?: number } = {};
 
   while (!sessionAbort.signal.aborted) {
     const stream = new LiveLogStream(organizationId, canvasId, executionId);
@@ -200,7 +206,9 @@ async function runLiveLogSession({
     const replayLineSkip = new Map<number, number>();
 
     try {
-      await stream.pump(createStreamHandlers(reconnecting, replayLineSkip, executionInFlight, setState, setUsage));
+      await stream.pump(
+        createStreamHandlers(reconnecting, replayLineSkip, executionInFlight, setState, setUsage, commandCursor),
+      );
     } catch (error) {
       if ((error as Error).name === "AbortError") {
         return;


### PR DESCRIPTION
## Summary

Hosted OpenCode Create with an Agent could stop after the greeting. The UI still looked running. Chat and live logs then showed clone and greet again.

Follow-up wait treated ngrok 404 as fatal. OpenCode exit 1 after a valid reply skipped wait. `propose_draft` stored a title with no description.

This change ends the planning session when the canvas run finishes. Wait retries HTTP errors except 401. A planning OpenCode reply counts as success. Draft description is required.

Live logs do not append finished-command output to the current prompt. Claude and Codex line automations keep their current success and prompt behavior. Wait retries apply to all Create with an Agent providers.

## Test plan

- [ ] Start Create with an Agent with hosted OpenRouter / OpenCode.
- [ ] Confirm greet stays in one prompt section after a live-log reconnect.
- [ ] Send a task request and confirm the draft has a title and a description.
- [ ] Confirm Create stays disabled when the description is empty.
- [ ] Send a follow-up message after the agent waits.
- [ ] Run a Claude or Codex canvas node and confirm repeated log lines still appear.
- [ ] Run an OpenRouter line automation that exits non-zero and confirm it fails.


Made with [Cursor](https://cursor.com)







<!-- greptile_comment -->

<sub>Reviews (4): Last reviewed commit: ["fix: Ignore leftover usage on an open Op..."](https://github.com/superplanehq/superplane/commit/3f4b07f925a44a9bde9d2710b5b842c98dc4d017) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62227856)</sub>

<!-- /greptile_comment -->