### PR TITLE
fix: Archive backlog tasks

### DIFF
--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunDecisionFooterPreview.stories.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunDecisionFooterPreview.stories.tsx
@@ -49,7 +49,7 @@ const KINDS: { kind: DecisionFooterKind; label: string; note: string }[] = [
   {
     kind: "draft",
     label: "Draft",
-    note: "Start and Reject in the note.",
+    note: "Archive and Start in the note.",
   },
   {
     kind: "completed",

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunDecisionFooterPreview.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunDecisionFooterPreview.tsx
@@ -35,7 +35,7 @@ const COPY: Record<Exclude<DecisionFooterKind, "running">, DecisionCopy> = {
     text: "Review the details. Change anything you need. Then click Start to send it to the line.",
     tone: "draft",
     actions: [
-      { id: "reject", label: "Reject", emphasis: "quiet" },
+      { id: "archive", label: "Archive", emphasis: "quiet" },
       { id: "start", label: "Start", emphasis: "primary" },
     ],
   },

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.draftModel.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.draftModel.spec.tsx
@@ -51,7 +51,7 @@ describe("SplitRunReview draft model select", () => {
     const note = screen.getByTestId("split-run-attention-note");
     expect(within(note).getByTestId("split-run-draft-model")).toHaveTextContent("Auto");
     expect(within(note).getByRole("button", { name: "Start" })).toBeInTheDocument();
-    expect(within(note).getByRole("button", { name: "Reject" })).toBeInTheDocument();
+    expect(within(note).getByRole("button", { name: "Archive" })).toBeInTheDocument();
   });
 
   it("keeps the model select off a waiting footer", () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunReview.tsx
@@ -58,6 +58,7 @@ export function SplitRunReview({
   canAct = true,
   canRefine = true,
   onStart,
+  onArchive,
   onReject,
   onRefine,
   onBackToDraft,
@@ -75,6 +76,7 @@ export function SplitRunReview({
   canAct?: boolean;
   canRefine?: boolean;
   onStart?: () => void | Promise<void>;
+  onArchive?: () => void | Promise<void>;
   onReject?: () => void | Promise<void>;
   onRefine?: () => void;
   onBackToDraft?: () => void | Promise<void>;
@@ -89,17 +91,17 @@ export function SplitRunReview({
   }
   const runHref = reviewRunHref(organizationId, factoryKey, footer.run, orderNumber);
   const actions = canAct ? footer.actions.filter((action) => canRefine || action.kind !== "refine") : [];
+  const directActions: Partial<Record<SplitRunFooterAction["kind"], (() => void | Promise<void>) | undefined>> = {
+    start: onStart,
+    archive: onArchive,
+    reject: onReject,
+    refine: onRefine,
+    "back-to-draft": onBackToDraft,
+  };
   const onAction = (action: SplitRunFooterAction) => {
-    if (action.kind === "start") {
-      void onStart?.();
-      return;
-    }
-    if (action.kind === "reject") {
-      void onReject?.();
-      return;
-    }
-    if (action.kind === "refine") {
-      onRefine?.();
+    const directAction = directActions[action.kind];
+    if (directAction) {
+      void directAction();
       return;
     }
     if (action.kind === "approve") {
@@ -113,9 +115,6 @@ export function SplitRunReview({
     if (action.kind === "reopen") {
       void onStop?.("reopen");
       return;
-    }
-    if (action.kind === "back-to-draft") {
-      void onBackToDraft?.();
     }
   };
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -716,7 +716,7 @@ describe("WorkOrderSplitRunPopup", () => {
     const start = within(note).getByRole("button", { name: "Start" });
     expect(start).toBeInTheDocument();
     expect(within(note).getByRole("button", { name: "Refine" })).toBeInTheDocument();
-    expect(within(note).getByRole("button", { name: "Reject" })).toBeInTheDocument();
+    expect(within(note).getByRole("button", { name: "Archive" })).toBeInTheDocument();
     expect(start.parentElement).toHaveClass("shrink-0");
     expect(start.parentElement).not.toHaveClass("mt-3");
     expect(screen.getByText("This task is ready to start")).toBeInTheDocument();
@@ -728,7 +728,7 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(screen.getByTestId("split-run-log-pane").className).not.toContain("minmax(0,3fr)_minmax(0,2fr)");
     expect(within(note).getByRole("button", { name: "Start" })).toBeInTheDocument();
     expect(within(note).getByRole("button", { name: "Refine" })).toBeInTheDocument();
-    expect(within(note).getByRole("button", { name: "Reject" })).toBeInTheDocument();
+    expect(within(note).getByRole("button", { name: "Archive" })).toBeInTheDocument();
     const backlog = screen.getByTestId("split-run-phase-backlog");
     expect(within(backlog).getByRole("button", { name: "Backlog" })).toHaveAttribute("aria-expanded", "false");
     expect(within(backlog).queryByText(/Created manually/)).not.toBeInTheDocument();
@@ -749,7 +749,7 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent("Ask an agent to update this task.");
   });
 
-  it("tells a draft is under analysis and hides Reject while it runs", () => {
+  it("tells a draft is under analysis and hides Archive while it runs", () => {
     renderPopup({
       fixture: splitRunFixtureForWorkOrder(DRAFT_WORK_ORDER, {
         analysisRuns: [
@@ -772,7 +772,7 @@ describe("WorkOrderSplitRunPopup", () => {
     const note = screen.getByTestId("split-run-attention-note");
     expect(within(note).getByRole("button", { name: "Start" })).toBeInTheDocument();
     expect(within(note).getByRole("button", { name: "Refine" })).toBeInTheDocument();
-    expect(within(note).queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(within(note).queryByRole("button", { name: "Archive" })).not.toBeInTheDocument();
   });
 
   it("puts artifacts on the right and check analyses under the description", () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -36,6 +36,7 @@ import { useSplitRunLiveCanvas } from "./useSplitRunLiveCanvas";
 import { runningSplitRunPhaseId } from "./followLogScroll";
 import { useFollowLogScroll } from "./useFollowLogScroll";
 import { useSplitRunStreamArtifacts } from "./useSplitRunStreamArtifacts";
+import { useCurrentPopupDismiss } from "./useCurrentPopupDismiss";
 import { WorkOrderStatusIcon } from "../../workOrders/WorkOrderStatusIcon";
 import { displayStatusForLineStatus } from "./splitRunWorkOrderDisplay";
 import { WorkOrderSplitRunOverview } from "./WorkOrderSplitRunOverview";
@@ -52,11 +53,22 @@ function popupWorkOrderUrl(organizationId?: string, factoryKey?: string, orderNu
   return window.location.origin + workOrderDetailPath(organizationId, factoryKey, orderNumber, lineId);
 }
 
-function footerMutationHandlers(canUpdate: boolean, footerActions: SplitRunFooterActions, fixture: SplitRunFixture) {
+function footerMutationHandlers(
+  canUpdate: boolean,
+  footerActions: SplitRunFooterActions,
+  fixture: SplitRunFixture,
+  onDismiss?: () => void,
+) {
   if (!canUpdate) {
     return {};
   }
   return {
+    onArchive: async () => {
+      const archived = await footerActions.handleArchive();
+      if (archived) {
+        onDismiss?.();
+      }
+    },
     onReject: () => void footerActions.handleReject(),
     onBackToDraft: () => footerActions.handleBackToDraft(),
     onStop: (choice: Parameters<typeof footerActions.handleStop>[0]) =>
@@ -277,7 +289,8 @@ export function WorkOrderSplitRunPopup({
 }) {
   const canPickDraftStartModel = useExperimentalFeature(organizationId).has(FEATURE_FACTORY_DRAFT_START_MODEL);
   const footerActions = useSplitRunFooterActions(organizationId, factoryId, orderId);
-  const mutations = footerMutationHandlers(canUpdate, footerActions, fixture);
+  const dismissCurrentPopup = useCurrentPopupDismiss(orderId, onClose);
+  const mutations = footerMutationHandlers(canUpdate, footerActions, fixture, dismissCurrentPopup);
   const popupData = useSplitRunPopupData({ organizationId, factoryId, orderId, fixture });
   const edits = useSplitRunWorkOrderEdits({
     organizationId,
@@ -345,6 +358,7 @@ export function WorkOrderSplitRunPopup({
         canAct={canUpdate}
         canRefine={canRefine}
         onStart={draftStart}
+        onArchive={mutations.onArchive}
         onReject={mutations.onReject}
         onRefine={onRefine}
         onBackToDraft={backToDraft}

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunStop.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunStop.spec.tsx
@@ -1,21 +1,24 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { MemoryRouter } from "react-router";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { handleStopMock, handleRejectMock, handleBackToDraftMock, enabledExperimentalFeatures } = vi.hoisted(() => ({
-  handleStopMock: vi.fn(),
-  handleRejectMock: vi.fn(),
-  handleBackToDraftMock: vi.fn(),
-  enabledExperimentalFeatures: new Set<string>(),
-}));
+const { handleStopMock, handleRejectMock, handleArchiveMock, handleBackToDraftMock, enabledExperimentalFeatures } =
+  vi.hoisted(() => ({
+    handleStopMock: vi.fn(),
+    handleRejectMock: vi.fn(),
+    handleArchiveMock: vi.fn(),
+    handleBackToDraftMock: vi.fn(),
+    enabledExperimentalFeatures: new Set<string>(),
+  }));
 
 vi.mock("./useSplitRunFooterActions", () => ({
   useSplitRunFooterActions: () => ({
     handleStop: handleStopMock,
     handleReject: handleRejectMock,
+    handleArchive: handleArchiveMock,
     handleBackToDraft: handleBackToDraftMock,
     handleStopAutomation: vi.fn(),
     busy: false,
@@ -72,6 +75,7 @@ describe("WorkOrderSplitRunPopup decision footer", () => {
     enabledExperimentalFeatures.clear();
     handleStopMock.mockReset();
     handleRejectMock.mockReset();
+    handleArchiveMock.mockReset().mockResolvedValue(true);
     handleBackToDraftMock.mockReset().mockResolvedValue(true);
   });
 
@@ -145,7 +149,7 @@ describe("WorkOrderSplitRunPopup decision footer", () => {
     expect(onRefine).toHaveBeenCalledTimes(1);
   });
 
-  it("starts and rejects a draft from the note", async () => {
+  it("starts and archives a draft from the note", async () => {
     enabledExperimentalFeatures.add(FEATURE_FACTORY_DRAFT_START_MODEL);
     const user = userEvent.setup();
     const onDispatch = vi.fn();
@@ -172,8 +176,70 @@ describe("WorkOrderSplitRunPopup decision footer", () => {
     expect(onDispatch).toHaveBeenCalledTimes(1);
     expect(onDispatch).toHaveBeenCalledWith(undefined);
     expect(screen.getByRole("tab", { name: "Automations" })).toHaveAttribute("data-state", "active");
-    await user.click(within(note).getByRole("button", { name: "Reject" }));
-    expect(handleRejectMock).toHaveBeenCalledTimes(1);
+    await user.click(within(note).getByRole("button", { name: "Archive" }));
+    expect(handleArchiveMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the popup only after a draft is archived", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderPopup(splitRunFixtureForWorkOrder(DRAFT_WORK_ORDER), onClose);
+
+    await user.click(within(screen.getByTestId("split-run-attention-note")).getByRole("button", { name: "Archive" }));
+
+    expect(handleArchiveMock).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close a newer popup when a previous archive finishes", async () => {
+    let resolveArchive: ((archived: boolean) => void) | undefined;
+    handleArchiveMock.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveArchive = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+    const firstClose = vi.fn();
+    const secondClose = vi.fn();
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const popup = (orderId: string, onClose: () => void) => (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ThemeProvider>
+            <TooltipProvider>
+              <WorkOrderSplitRunPopup
+                orderId={orderId}
+                fixture={splitRunFixtureForWorkOrder(DRAFT_WORK_ORDER)}
+                onClose={onClose}
+              />
+            </TooltipProvider>
+          </ThemeProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const view = render(popup("order-a", firstClose));
+
+    await user.click(within(screen.getByTestId("split-run-attention-note")).getByRole("button", { name: "Archive" }));
+    view.rerender(popup("order-b", secondClose));
+    await act(async () => {
+      resolveArchive?.(true);
+    });
+
+    expect(firstClose).not.toHaveBeenCalled();
+    expect(secondClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps the popup open when a draft cannot be archived", async () => {
+    handleArchiveMock.mockResolvedValue(false);
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderPopup(splitRunFixtureForWorkOrder(DRAFT_WORK_ORDER), onClose);
+
+    await user.click(within(screen.getByTestId("split-run-attention-note")).getByRole("button", { name: "Archive" }));
+
+    expect(handleArchiveMock).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("starts a draft with the listed model", async () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.spec.ts
@@ -41,6 +41,7 @@ const BACK_TO_DRAFT = {
   icon: "undo-2",
 };
 const REJECT = { id: "reject", kind: "reject", label: "Reject", emphasis: "quiet" };
+const ARCHIVE = { id: "archive", kind: "archive", label: "Archive", emphasis: "quiet" };
 const REFINE = {
   id: "refine",
   kind: "refine",
@@ -55,17 +56,17 @@ const START = { id: "start", kind: "start", label: "Start", emphasis: "primary" 
 const REOPEN = { id: "reopen", kind: "reopen", label: "Reopen", emphasis: "primary" };
 
 describe("buildSplitRunFooter", () => {
-  it("keeps a draft note with Refine, Reject, and Start", () => {
+  it("keeps a draft note with Refine, Archive, and Start", () => {
     expect(buildSplitRunFooter({ kind: "draft", note: DRAFT_NOTE })).toEqual({
       kind: "draft",
       sentence: "This task is a draft.",
       note: { headline: "Review the plan, then start", text: "From GitHub issue PAY-842. Confidence 5/5." },
       attentionCard: true,
-      actions: [REFINE, REJECT, START],
+      actions: [REFINE, ARCHIVE, START],
     });
   });
 
-  it("tells a draft is under analysis and drops Reject", () => {
+  it("tells a draft is under analysis and drops Archive", () => {
     const footer = buildSplitRunFooter({ kind: "draft", note: DRAFT_NOTE, isAnalyzing: true });
 
     expect(footer).toEqual({
@@ -78,7 +79,7 @@ describe("buildSplitRunFooter", () => {
       attentionCard: true,
       actions: [REFINE, START],
     });
-    expect(footer.actions).not.toContainEqual(expect.objectContaining({ kind: "reject" }));
+    expect(footer.actions).not.toContainEqual(expect.objectContaining({ kind: "archive" }));
   });
 
   it("keeps no close actions on a running order", () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.ts
@@ -9,7 +9,15 @@ export type SplitRunFooterKind = "draft" | "running" | "waiting" | "failed" | "s
 /** @deprecated Use SplitRunFooterKind. Kept for fixture field name. */
 export type SplitRunFooterTone = SplitRunFooterKind;
 
-export type SplitRunFooterActionKind = "start" | "reject" | "refine" | "approve" | "rerun" | "reopen" | "back-to-draft";
+export type SplitRunFooterActionKind =
+  | "start"
+  | "archive"
+  | "reject"
+  | "refine"
+  | "approve"
+  | "rerun"
+  | "reopen"
+  | "back-to-draft";
 
 export type SplitRunStopChoice = "canceled" | "completed" | "rerun-step" | "rerun-start" | "reopen";
 
@@ -147,6 +155,7 @@ export interface SplitRunFooter {
 }
 
 const REJECT: SplitRunFooterAction = { id: "reject", kind: "reject", label: "Reject", emphasis: "quiet" };
+const ARCHIVE: SplitRunFooterAction = { id: "archive", kind: "archive", label: "Archive", emphasis: "quiet" };
 const REFINE: SplitRunFooterAction = {
   id: "refine",
   kind: "refine",
@@ -275,8 +284,8 @@ export function toFooterNote(note: WorkOrderStatusNotePresentation): SplitRunFoo
 /**
  * Decision strip for the work-order popup. Running has no strip. Open
  * waiting and failed keep To Backlog with Reject, Approve, or Rerun.
- * Draft keeps Refine, Reject, and Start. A draft still under Backlog
- * analysis drops Reject; rejecting a task before its analysis finishes
+ * Draft keeps Refine, Archive, and Start. A draft still under Backlog
+ * analysis drops Archive; archiving a task before its analysis finishes
  * makes no sense. Closed failed keeps Reopen. Completed and rejected
  * explain the result only.
  */
@@ -323,7 +332,7 @@ function draftDecisionFooter(input: FooterInput, note?: SplitRunFooterNote): Spl
     sentence: "This task is a draft.",
     note,
     attentionCard: true,
-    actions: [REFINE, REJECT, START],
+    actions: [REFINE, ARCHIVE, START],
   });
 }
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
@@ -170,7 +170,7 @@ describe("splitRunFixtureForWorkOrder", () => {
     expect(note?.text).toContain("**plan.md**");
     expect(note?.text).toContain("Confidence 5/5 (High):");
     expect(note?.text).toContain("- The GitHub issue names retryable status codes and a hard attempt limit.");
-    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Refine", "Reject", "Start"]);
+    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Refine", "Archive", "Start"]);
   });
 
   it("pins a pull request review on a waiting implement card", () => {
@@ -745,7 +745,7 @@ describe("splitRunFixtureForWorkOrder", () => {
     expect(fixture.waitingNotes).toEqual([]);
     expect(fixture.footer.note?.headline).toBe("This task is ready to start");
     expect(fixture.footer.note?.text).toContain("Then click Start to send it to the line.");
-    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Refine", "Reject", "Start"]);
+    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Refine", "Archive", "Start"]);
   });
 
   it("omits invented files and ledger pull requests for a live order", () => {
@@ -1133,7 +1133,7 @@ describe("line board work-order examples", () => {
     expect(analysis[1].checks?.map((check) => check.name)).toEqual(["Confidence score"]);
     expect(fixture.openPhaseId).toBeUndefined();
     expect(fixture.footer.note?.headline).toBe("This task is ready to start");
-    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Refine", "Reject", "Start"]);
+    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Refine", "Archive", "Start"]);
   });
 
   it("appends matching PR feedback runs after line steps, oldest first", () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/useCurrentPopupDismiss.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/useCurrentPopupDismiss.ts
@@ -1,0 +1,21 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export function useCurrentPopupDismiss(orderId: string | undefined, onClose: (() => void) | undefined) {
+  const activeOrderId = useRef(orderId);
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    activeOrderId.current = orderId;
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, [orderId]);
+
+  return useCallback(() => {
+    if (!mounted.current || activeOrderId.current !== orderId) {
+      return;
+    }
+    onClose?.();
+  }, [onClose, orderId]);
+}

--- a/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunFooterActions.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunFooterActions.spec.tsx
@@ -193,14 +193,25 @@ describe("useSplitRunFooterActions", () => {
     expect(showSuccessToast).toHaveBeenCalledWith("Task returned to the Backlog.");
   });
 
-  it("closes a draft from Reject", async () => {
+  it("archives a draft as rejected", async () => {
     const { result } = renderHook(() => useSplitRunFooterActions("org-1", "factory-1", "wo-1"), { wrapper });
 
-    const deleted = await result.current.handleReject();
+    const archived = await result.current.handleArchive();
 
-    expect(deleted).toBe(true);
+    expect(archived).toBe(true);
     expect(closeMutateAsync).toHaveBeenCalledWith({ orderId: "wo-1", result: "RESULT_REJECTED" });
-    expect(showSuccessToast).toHaveBeenCalledWith("Task closed as rejected.");
+    expect(showSuccessToast).toHaveBeenCalledWith("Task archived.");
+  });
+
+  it("keeps a draft open when archive fails", async () => {
+    closeMutateAsync.mockRejectedValue(new Error("Failed to fetch"));
+    const { result } = renderHook(() => useSplitRunFooterActions("org-1", "factory-1", "wo-1"), { wrapper });
+
+    const archived = await result.current.handleArchive();
+
+    expect(archived).toBe(false);
+    expect(showSuccessToast).not.toHaveBeenCalled();
+    expect(showErrorToast).toHaveBeenCalledWith("Failed to archive task");
   });
 
   it("does not mutate when the popup has no live order", async () => {
@@ -208,6 +219,7 @@ describe("useSplitRunFooterActions", () => {
 
     await result.current.handleStop("canceled", { kind: "running" });
     await result.current.handleReject();
+    await result.current.handleArchive();
     await result.current.handleBackToDraft();
 
     expect(closeMutateAsync).not.toHaveBeenCalled();

--- a/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunFooterActions.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunFooterActions.ts
@@ -16,6 +16,21 @@ type StopFooter = Pick<SplitRunFooter, "kind" | "run" | "status"> & {
   stepIndex?: number;
 };
 
+type RejectedCloseCopy = {
+  success: string;
+  error: string;
+};
+
+const REJECT_COPY: RejectedCloseCopy = {
+  success: "Task closed as rejected.",
+  error: "Failed to close task",
+};
+
+const ARCHIVE_COPY: RejectedCloseCopy = {
+  success: "Task archived.",
+  error: "Failed to archive task",
+};
+
 function closeToast(choice: SplitRunStopChoice): string {
   if (choice === "completed") {
     return "Task closed as completed.";
@@ -33,10 +48,6 @@ function closeToast(choice: SplitRunStopChoice): string {
     return "Task step started again.";
   }
   return "Task closed as failed.";
-}
-
-function rejectToast(): string {
-  return closeToast("canceled");
 }
 
 function stopErrorFallback(choice: SplitRunStopChoice, footer: StopFooter): string {
@@ -96,19 +107,25 @@ export function useSplitRunFooterActions(organizationId?: string, factoryId?: st
     }
   }, [busy, live, orderId, updateStatus]);
 
-  const handleReject = useCallback(async () => {
-    if (!live || !orderId || busy) {
-      return false;
-    }
-    try {
-      await closeWorkOrder.mutateAsync({ orderId, result: "RESULT_REJECTED" });
-      showSuccessToast(rejectToast());
-      return true;
-    } catch (error) {
-      showErrorToast(getApiErrorMessage(error, "Failed to close task"));
-      return false;
-    }
-  }, [busy, closeWorkOrder, live, orderId]);
+  const closeAsRejected = useCallback(
+    async (copy: RejectedCloseCopy) => {
+      if (!live || !orderId || busy) {
+        return false;
+      }
+      try {
+        await closeWorkOrder.mutateAsync({ orderId, result: "RESULT_REJECTED" });
+        showSuccessToast(copy.success);
+        return true;
+      } catch (error) {
+        showErrorToast(getApiErrorMessage(error, copy.error));
+        return false;
+      }
+    },
+    [busy, closeWorkOrder, live, orderId],
+  );
+
+  const handleReject = useCallback(() => closeAsRejected(REJECT_COPY), [closeAsRejected]);
+  const handleArchive = useCallback(() => closeAsRejected(ARCHIVE_COPY), [closeAsRejected]);
 
   const handleStop = useCallback(
     async (choice: SplitRunStopChoice, footer: StopFooter) => {
@@ -169,6 +186,7 @@ export function useSplitRunFooterActions(organizationId?: string, factoryId?: st
     handleStop,
     handleStopAutomation,
     handleReject,
+    handleArchive,
     handleBackToDraft,
     busy,
   };


### PR DESCRIPTION
## Summary

- Rename the draft Backlog action from Reject to Archive.
- Close the task popup only after the archive request succeeds.
- Keep Reject for non-draft decisions and keep failed archives open.

## Test plan

- [x] Run the focused archive footer tests.
- [x] Run `make check.test.ui`.
- [x] Run `make check.format.js`.
- [x] Run `make check.lint.ui`.
- [x] Run `make check.build.ui`.
- [x] Run `make check.generated.artifacts`.



<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["fix: Archive backlog tasks"](https://github.com/superplanehq/superplane/commit/13b343f52c0b4f82bc6ca4146f5b3af1991e164f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62243807)</sub>

<!-- /greptile_comment -->