### PR TITLE
feat: Use SuperPlane Models in Agent Editor

### DIFF
--- a/web_src/src/pages/factories/lib/columnCanvasAgent.spec.ts
+++ b/web_src/src/pages/factories/lib/columnCanvasAgent.spec.ts
@@ -96,6 +96,7 @@ describe("planningReviewDraftFromCanvas", () => {
 
     expect(draft?.title).toBe("Implement From Task Description");
     expect(draft?.components).toHaveLength(1);
+    expect(draft?.components[0].component).toBe("runnerClaudeCode");
     expect(draft?.components[0].configuration).toEqual(implementerConfiguration);
     expect(draft?.components[0].configuration.credentials).toEqual({
       source: "integration",
@@ -168,6 +169,17 @@ describe("canvasNodeToPlanningReviewComponent", () => {
       component: "runnerCodex",
     });
     expect(component.title).toBe("Agent");
+    expect(component.component).toBe("runnerCodex");
     expect(component.concurrency).toEqual({ max: "1", key: "" });
+  });
+
+  it("keeps the Run SuperPlane Agent runner id", () => {
+    const component = canvasNodeToPlanningReviewComponent(
+      agentNode({
+        id: "superplane-agent",
+        component: "runnerSuperPlane",
+      }),
+    );
+    expect(component.component).toBe("runnerSuperPlane");
   });
 });

--- a/web_src/src/pages/factories/lib/columnCanvasAgent.ts
+++ b/web_src/src/pages/factories/lib/columnCanvasAgent.ts
@@ -32,6 +32,7 @@ export function canvasNodeToPlanningReviewComponent(node: CanvasSpecNode): Plann
     title: node.name?.trim() || "Agent",
     description: "",
     expanded: true,
+    component: node.component,
     configuration: { ...(node.configuration ?? {}) },
     concurrency: {
       max: String(node.concurrency?.max ?? 1),

--- a/web_src/src/pages/factories/pages/PlanningReviewForm.spec.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewForm.spec.tsx
@@ -1,0 +1,144 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConfigurationField } from "@/api-client";
+import { useComponent } from "@/hooks/useComponentData";
+import { useOrganizationWorkspaceUsage } from "@/hooks/useOrganizationWorkspaceUsage";
+import { useSelectableLLMModels } from "@/hooks/useSelectableLLMModels";
+import { HOSTED_MODEL_ALL_PROVIDERS } from "@/lib/hostedLLMModels";
+
+import { PlanningReviewForm } from "./PlanningReviewForm";
+import { PLANNING_REVIEW_DRAFT, type PlanningReviewDraft } from "./planningReviewMockup";
+
+const useCanvasMock = vi.hoisted(() =>
+  vi.fn((): { data: { metadata?: { factoryId?: string } } | undefined; isPending: boolean } => ({
+    data: undefined,
+    isPending: false,
+  })),
+);
+
+vi.mock("@/hooks/useComponentData", () => ({
+  useComponent: vi.fn(),
+}));
+
+vi.mock("@/hooks/useSelectableLLMModels", () => ({
+  useSelectableLLMModels: vi.fn(),
+}));
+
+vi.mock("@/hooks/useOrganizationWorkspaceUsage", () => ({
+  useOrganizationWorkspaceUsage: vi.fn(),
+}));
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useCanvas: useCanvasMock,
+}));
+
+const superPlaneModelField: ConfigurationField = {
+  name: "model",
+  label: "Model",
+  type: "hosted-model",
+  placeholder: "Instance SuperPlane agent model",
+  typeOptions: { hostedModel: { provider: HOSTED_MODEL_ALL_PROVIDERS } },
+};
+
+function selectableModel(provider: string, id: string) {
+  return {
+    source: { id: "hosted", name: "SuperPlane" },
+    provider: { id: provider, name: provider },
+    model: { id, name: id },
+    key: `hosted::${provider}::${id}`,
+    label: provider === "openrouter" ? id : `${provider}/${id}`,
+  };
+}
+
+function superPlaneDraft(): PlanningReviewDraft {
+  return {
+    ...PLANNING_REVIEW_DRAFT,
+    components: [
+      {
+        ...PLANNING_REVIEW_DRAFT.components[0],
+        component: "runnerSuperPlane",
+        configuration: {
+          ...PLANNING_REVIEW_DRAFT.components[0].configuration,
+          model: "",
+        },
+      },
+    ],
+  };
+}
+
+function renderForm(draft: PlanningReviewDraft) {
+  return render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter>
+        <PlanningReviewForm draft={draft} onChange={vi.fn()} organizationId="org-1" />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("PlanningReviewForm model options", () => {
+  beforeAll(() => {
+    Element.prototype.hasPointerCapture ??= () => false;
+    Element.prototype.setPointerCapture ??= () => {};
+    Element.prototype.releasePointerCapture ??= () => {};
+    Element.prototype.scrollIntoView ??= () => {};
+  });
+
+  beforeEach(() => {
+    useCanvasMock.mockReset();
+    useCanvasMock.mockReturnValue({ data: undefined, isPending: false });
+    vi.mocked(useComponent).mockReturnValue({ data: undefined } as ReturnType<typeof useComponent>);
+    vi.mocked(useSelectableLLMModels).mockReturnValue({
+      data: [
+        selectableModel("openrouter", "qwen/qwen3.7-max"),
+        selectableModel("anthropic", "claude-opus-5"),
+        selectableModel("openrouter", "moonshotai/kimi-k2.6"),
+      ],
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useSelectableLLMModels>);
+    vi.mocked(useOrganizationWorkspaceUsage).mockReturnValue({
+      data: { defaultHostedProvider: "openrouter", defaultHostedModel: "qwen/qwen3.7-max" },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useOrganizationWorkspaceUsage>);
+  });
+
+  it("lists hosted SuperPlane models when the automation agent is Run SuperPlane Agent", async () => {
+    const user = userEvent.setup();
+    vi.mocked(useComponent).mockReturnValue({
+      data: { name: "runnerSuperPlane", configuration: [superPlaneModelField] },
+    } as ReturnType<typeof useComponent>);
+
+    renderForm(superPlaneDraft());
+
+    expect(screen.getByText("Model used")).toBeInTheDocument();
+    await user.click(screen.getByTestId("field-model-hosted-model"));
+    expect(screen.getByRole("option", { name: "qwen/qwen3.7-max" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "anthropic/claude-opus-5" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "moonshotai/kimi-k2.6" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Claude Sonnet" })).not.toBeInTheDocument();
+  });
+
+  it("lists hosted SuperPlane models from the runner fallback when the catalog is empty", async () => {
+    const user = userEvent.setup();
+
+    renderForm(superPlaneDraft());
+
+    await user.click(screen.getByTestId("field-model-hosted-model"));
+    expect(screen.getByRole("option", { name: "qwen/qwen3.7-max" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Claude Sonnet" })).not.toBeInTheDocument();
+  });
+
+  it("keeps Claude aliases when the agent is not Run SuperPlane Agent", async () => {
+    const user = userEvent.setup();
+    renderForm(PLANNING_REVIEW_DRAFT);
+
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("option", { name: "Claude Sonnet" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Claude Opus" })).toBeInTheDocument();
+    expect(screen.queryByTestId("field-model-hosted-model")).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/PlanningReviewForm.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewForm.tsx
@@ -1,19 +1,11 @@
-import type { ConfigurationField } from "@/api-client";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useComponent } from "@/hooks/useComponentData";
 import { ConfigurationFieldRenderer } from "@/ui/configurationFieldRenderer";
 
 import type { PlanningReviewComponent, PlanningReviewDraft, PlanningReviewStep } from "./planningReviewMockup";
-import { PLANNING_REVIEW_RUNNER_FIELDS } from "./planningReviewRunnerFields";
+import { planningReviewModelUsedField } from "./planningReviewRunnerFields";
 import { PlanningReviewStepList } from "./PlanningReviewStepList";
-
-const MODEL_FIELD: ConfigurationField | undefined = PLANNING_REVIEW_RUNNER_FIELDS.find(
-  (field) => field.name === "model",
-);
-
-const MODEL_USED_FIELD: ConfigurationField | undefined = MODEL_FIELD
-  ? { ...MODEL_FIELD, label: "Model used", description: "" }
-  : undefined;
 
 const EXPRESSION_CONTEXT = {
   data: { branch: "feature/planning-review" },
@@ -66,6 +58,8 @@ function AgentPanel({
       configuration: { ...component.configuration, [name]: value },
     });
   };
+  const { data: action } = useComponent(organizationId ?? "", component.component ?? "");
+  const modelUsedField = planningReviewModelUsedField(component.component, action?.configuration);
 
   return (
     <div className="flex flex-col gap-4" data-testid={`planning-review-component-${component.id}`}>
@@ -90,9 +84,9 @@ function AgentPanel({
             className="shadow-none"
           />
         </div>
-        {MODEL_USED_FIELD ? (
+        {modelUsedField ? (
           <ConfigurationFieldRenderer
-            field={MODEL_USED_FIELD}
+            field={modelUsedField}
             value={component.configuration.model}
             onChange={(value) => setConfigurationField("model", value)}
             allValues={component.configuration}

--- a/web_src/src/pages/factories/pages/PlanningReviewPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewPopup.spec.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
@@ -19,13 +20,15 @@ function renderPopup(
   props: Omit<ComponentProps<typeof PlanningReviewPopup>, "onClose"> & { onClose?: () => void } = {},
 ) {
   return render(
-    <MemoryRouter>
-      <ThemeProvider>
-        <TooltipProvider>
-          <PlanningReviewPopup onClose={props.onClose ?? vi.fn()} {...props} />
-        </TooltipProvider>
-      </ThemeProvider>
-    </MemoryRouter>,
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter>
+        <ThemeProvider>
+          <TooltipProvider>
+            <PlanningReviewPopup onClose={props.onClose ?? vi.fn()} {...props} />
+          </TooltipProvider>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 

--- a/web_src/src/pages/factories/pages/planningReviewMockup.ts
+++ b/web_src/src/pages/factories/pages/planningReviewMockup.ts
@@ -18,6 +18,8 @@ export interface PlanningReviewComponent {
   title: string;
   description: string;
   expanded: boolean;
+  /** Canvas runner id, e.g. runnerSuperPlane. Selects the model picker. */
+  component?: string;
   configuration: Record<string, unknown>;
   concurrency: PlanningReviewConcurrency;
 }

--- a/web_src/src/pages/factories/pages/planningReviewRunnerFields.spec.ts
+++ b/web_src/src/pages/factories/pages/planningReviewRunnerFields.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigurationField } from "@/api-client";
+import { HOSTED_MODEL_ALL_PROVIDERS } from "@/lib/hostedLLMModels";
+
+import { planningReviewModelUsedField } from "./planningReviewRunnerFields";
+
+const superPlaneCatalogField: ConfigurationField = {
+  name: "model",
+  label: "Model",
+  type: "hosted-model",
+  placeholder: "Instance SuperPlane agent model",
+  typeOptions: { hostedModel: { provider: HOSTED_MODEL_ALL_PROVIDERS } },
+};
+
+describe("planningReviewModelUsedField", () => {
+  it("uses the catalog model field when the automation supplies one", () => {
+    const field = planningReviewModelUsedField("runnerSuperPlane", [superPlaneCatalogField]);
+
+    expect(field).toMatchObject({
+      name: "model",
+      label: "Model used",
+      type: "hosted-model",
+      typeOptions: { hostedModel: { provider: HOSTED_MODEL_ALL_PROVIDERS } },
+    });
+  });
+
+  it("uses the Run SuperPlane Agent hosted-model field when the catalog is empty", () => {
+    const field = planningReviewModelUsedField("runnerSuperPlane");
+
+    expect(field?.type).toBe("hosted-model");
+    expect(field?.typeOptions?.hostedModel?.provider).toBe(HOSTED_MODEL_ALL_PROVIDERS);
+    expect(field?.label).toBe("Model used");
+    expect(field?.typeOptions?.select?.options).toBeUndefined();
+  });
+
+  it("keeps the Claude aliases when the agent is not Run SuperPlane Agent", () => {
+    const field = planningReviewModelUsedField("runnerClaudeCode");
+
+    expect(field?.type).toBe("select");
+    expect(field?.typeOptions?.select?.options?.map((option) => option.label)).toEqual([
+      "Claude Sonnet",
+      "Claude Opus",
+      "Claude Haiku",
+    ]);
+  });
+});

--- a/web_src/src/pages/factories/pages/planningReviewRunnerFields.ts
+++ b/web_src/src/pages/factories/pages/planningReviewRunnerFields.ts
@@ -1,4 +1,7 @@
 import type { ConfigurationField } from "@/api-client";
+import { HOSTED_MODEL_ALL_PROVIDERS } from "@/lib/hostedLLMModels";
+
+const SUPERPLANE_AGENT_COMPONENT = "runnerSuperPlane";
 
 const select = (options: Array<{ label: string; value: string }>) => ({
   select: { options },
@@ -155,3 +158,36 @@ export const PLANNING_REVIEW_RUNNER_FIELDS: ConfigurationField[] = [
     typeOptions: { number: { min: 0, max: 86_400 } },
   },
 ];
+
+const CLAUDE_MODEL_FIELD = PLANNING_REVIEW_RUNNER_FIELDS.find((field) => field.name === "model");
+
+/** Same field Run SuperPlane Agent uses on the automation canvas. */
+const SUPERPLANE_AGENT_MODEL_FIELD: ConfigurationField = {
+  name: "model",
+  label: "Model",
+  type: "hosted-model",
+  required: false,
+  description:
+    "Select a SuperPlane-hosted model. The instance SuperPlane agent model is used when you do not select one.",
+  placeholder: "Instance SuperPlane agent model",
+  typeOptions: { hostedModel: { provider: HOSTED_MODEL_ALL_PROVIDERS } },
+};
+
+function withModelUsedLabel(field: ConfigurationField): ConfigurationField {
+  return { ...field, label: "Model used", description: "" };
+}
+
+/** Model picker for the agent editor. SuperPlane agents use the hosted allowlist. */
+export function planningReviewModelUsedField(
+  componentName: string | undefined,
+  catalogFields?: ConfigurationField[],
+): ConfigurationField | undefined {
+  const catalogModel = catalogFields?.find((field) => field.name === "model");
+  if (catalogModel) {
+    return withModelUsedLabel(catalogModel);
+  }
+  if (componentName === SUPERPLANE_AGENT_COMPONENT) {
+    return withModelUsedLabel(SUPERPLANE_AGENT_MODEL_FIELD);
+  }
+  return CLAUDE_MODEL_FIELD ? withModelUsedLabel(CLAUDE_MODEL_FIELD) : undefined;
+}


### PR DESCRIPTION
## Summary

The simple agent editor always showed Claude Sonnet, Opus, and Haiku.
A Run SuperPlane Agent canvas must use the hosted model allowlist from that component.

This change keeps the canvas runner id on the draft.
The editor loads the catalog model field when the organization has it.

## Test plan

- [ ] Open the agent editor on a Run SuperPlane Agent canvas.
- [ ] Confirm Model used lists SuperPlane-hosted models, not Claude aliases.
- [ ] Select a hosted model and save the agent.
- [ ] Open the agent editor on a Run Claude Code canvas.
- [ ] Confirm Model used still lists Claude Sonnet, Opus, and Haiku.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62568866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR should not merge until catalog fields are restricted to Run SuperPlane Agent so Run Claude Code retains its Claude alias picker.

<sub>Reviews (1) · Last reviewed commit: ["feat: Use SuperPlane models in agent edi..."](https://github.com/superplanehq/superplane/commit/22106a6254dbd8a927e3dd2efcdaa63cdbdd502b)</sub>

<!-- /greptile_comment -->