### PR TITLE
chore: Auto-deploy SuperPlane image on main

### DIFF
--- a/.semaphore/deploy-to-production.yml
+++ b/.semaphore/deploy-to-production.yml
@@ -1,0 +1,34 @@
+version: v1.0
+name: Deploy to Production
+
+agent:
+  machine:
+    type: f1-standard-2
+    os_image: ubuntu2204
+
+# Secret `launchpad` must define SEMAPHORE_API_TOKEN (org API token).
+blocks:
+  - name: Trigger launchpad deploy
+    task:
+      secrets:
+        - name: launchpad
+      env_vars:
+        - name: LAUNCHPAD_TASK_ID
+          value: 5e7e092b-c533-4dee-9802-a3c877647de4
+      jobs:
+        - name: Trigger Deploy SuperPlane image
+          commands:
+            - |
+              set -euo pipefail
+
+              if [ -z "${SEMAPHORE_API_TOKEN:-}" ]; then
+                echo "SEMAPHORE_API_TOKEN is required" >&2
+                exit 1
+              fi
+
+              curl -fsS -X POST \
+                --location "https://superplanehq.semaphoreci.com/api/v1alpha/tasks/${LAUNCHPAD_TASK_ID}/run_now" \
+                -H "Authorization: Token ${SEMAPHORE_API_TOKEN}" \
+                -H "Content-Type: application/json" \
+                -H "User-Agent: SemaphoreCI v2.0 Client" \
+                -d "{\"reference\":\"main\",\"parameters\":{\"ENVIRONMENT\":\"production\",\"BRANCH\":\"main\",\"COMMIT_SHA\":\"${SEMAPHORE_GIT_SHA}\"}}"

--- a/.semaphore/deploy-to-production.yml
+++ b/.semaphore/deploy-to-production.yml
@@ -6,15 +6,14 @@ agent:
     type: f1-standard-2
     os_image: ubuntu2204
 
-# Secret `launchpad` must define SEMAPHORE_API_TOKEN (org API token).
+# Secret `launchpad` must define:
+#   SEMAPHORE_API_TOKEN — org API token
+#   LAUNCHPAD_TASK_ID   — launchpad task "Deploy SuperPlane image"
 blocks:
   - name: Trigger launchpad deploy
     task:
       secrets:
         - name: launchpad
-      env_vars:
-        - name: LAUNCHPAD_TASK_ID
-          value: 5e7e092b-c533-4dee-9802-a3c877647de4
       jobs:
         - name: Trigger Deploy SuperPlane image
           commands:
@@ -23,6 +22,11 @@ blocks:
 
               if [ -z "${SEMAPHORE_API_TOKEN:-}" ]; then
                 echo "SEMAPHORE_API_TOKEN is required" >&2
+                exit 1
+              fi
+
+              if [ -z "${LAUNCHPAD_TASK_ID:-}" ]; then
+                echo "LAUNCHPAD_TASK_ID is required" >&2
                 exit 1
               fi
 

--- a/.semaphore/deploy-to-production.yml
+++ b/.semaphore/deploy-to-production.yml
@@ -6,14 +6,12 @@ agent:
     type: f1-standard-2
     os_image: ubuntu2204
 
-# Secret `launchpad` must define:
-#   SEMAPHORE_API_TOKEN — org API token
-#   LAUNCHPAD_TASK_ID   — launchpad task "Deploy SuperPlane image"
+# Credentials come from the `production` deployment target:
+#   SEMAPHORE_API_TOKEN — service account token
+#   DEPLOY_TASK_ID      — Semaphore task that deploys the SuperPlane image
 blocks:
-  - name: Trigger launchpad deploy
+  - name: Trigger production deploy
     task:
-      secrets:
-        - name: launchpad
       jobs:
         - name: Trigger Deploy SuperPlane image
           commands:
@@ -25,13 +23,13 @@ blocks:
                 exit 1
               fi
 
-              if [ -z "${LAUNCHPAD_TASK_ID:-}" ]; then
-                echo "LAUNCHPAD_TASK_ID is required" >&2
+              if [ -z "${DEPLOY_TASK_ID:-}" ]; then
+                echo "DEPLOY_TASK_ID is required" >&2
                 exit 1
               fi
 
               curl -fsS -X POST \
-                --location "https://superplanehq.semaphoreci.com/api/v1alpha/tasks/${LAUNCHPAD_TASK_ID}/run_now" \
+                --location "https://superplanehq.semaphoreci.com/api/v1alpha/tasks/${DEPLOY_TASK_ID}/run_now" \
                 -H "Authorization: Token ${SEMAPHORE_API_TOKEN}" \
                 -H "Content-Type: application/json" \
                 -H "User-Agent: SemaphoreCI v2.0 Client" \

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -149,3 +149,10 @@ after_pipeline:
       - name: Submit Reports
         commands:
           - test-results gen-pipeline-report
+
+promotions:
+  - name: Deploy to Production
+    pipeline_file: deploy-to-production.yml
+    deployment_target: production
+    auto_promote:
+      when: "branch = 'main' AND result = 'passed'"


### PR DESCRIPTION
## Summary

Green builds on main did not start a production image deploy.
This promotion starts the Deploy SuperPlane image task after CI passes on main.
The job sends the commit SHA so production builds the same revision that passed CI.

Add these variables on the `production` deployment target before the first deploy:

- `SEMAPHORE_API_TOKEN`
- `DEPLOY_TASK_ID`

## Test plan

- [ ] Confirm the `production` deployment target defines `SEMAPHORE_API_TOKEN` and `DEPLOY_TASK_ID`.
- [ ] Confirm the `production` deployment target is active.
- [ ] Merge this PR to main and wait for CI to pass.
- [ ] Confirm the Deploy to Production promotion starts after the green main pipeline.
- [ ] Confirm the deploy task starts with ENVIRONMENT=production.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62588128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

<sub>Reviews (3) · Last reviewed commit: ["chore: Load deploy credentials from targ..."](https://github.com/superplanehq/superplane/commit/b6ebf52891ed4ef34e8db88f3c1bae90013afb1d)</sub>

<!-- /greptile_comment -->