### PR TITLE
fix: Surface deploy task API errors

### DIFF
--- a/.semaphore/deploy-to-production.yml
+++ b/.semaphore/deploy-to-production.yml
@@ -28,9 +28,29 @@ blocks:
                 exit 1
               fi
 
-              curl -fsS -X POST \
-                --location "https://superplanehq.semaphoreci.com/api/v1alpha/tasks/${DEPLOY_TASK_ID}/run_now" \
+              payload="$(cat <<EOF
+              {
+                "parameters": {
+                  "ENVIRONMENT": "production",
+                  "BRANCH": "main",
+                  "COMMIT_SHA": "${SEMAPHORE_GIT_SHA}"
+                }
+              }
+              EOF
+              )"
+
+              http_code="$(curl -sS -o /tmp/run_now.json -w "%{http_code}" -X POST \
+                "https://superplanehq.semaphoreci.com/api/v1alpha/tasks/${DEPLOY_TASK_ID}/run_now" \
                 -H "Authorization: Token ${SEMAPHORE_API_TOKEN}" \
                 -H "Content-Type: application/json" \
                 -H "User-Agent: SemaphoreCI v2.0 Client" \
-                -d "{\"reference\":\"main\",\"parameters\":{\"ENVIRONMENT\":\"production\",\"BRANCH\":\"main\",\"COMMIT_SHA\":\"${SEMAPHORE_GIT_SHA}\"}}"
+                -d "${payload}")"
+
+              echo "HTTP ${http_code}"
+              cat /tmp/run_now.json
+              echo
+
+              if [ "${http_code}" != "200" ]; then
+                echo "Deploy task trigger failed" >&2
+                exit 1
+              fi


### PR DESCRIPTION
## Summary

The production deploy job failed with HTTP 400 from the task trigger.
`curl -f` hid the response body, so the cause was not visible.
This change prints the API body and omits `reference` so the task uses its configured branch.

## Test plan

- [ ] Merge this PR to main and wait for CI to pass.
- [ ] Confirm the Deploy to Production promotion starts.
- [ ] Confirm the trigger job prints HTTP 200.
- [ ] If the job fails, read the printed API body and share it.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62608502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge with no actionable issues identified.

<sub>Reviews (1) · Last reviewed commit: ["fix: Surface deploy task API errors"](https://github.com/superplanehq/superplane/commit/733786677fcb73d8505d86b37de93a95dc8a7bf2)</sub>

<!-- /greptile_comment -->