### PR TITLE
feat: include status checks handling in post-onboarding steps

### DIFF
--- a/web_src/src/App.css
+++ b/web_src/src/App.css
@@ -987,3 +987,85 @@
     opacity: 0.25;
   }
 }
+
+.workspace-next-steps-progress {
+  view-transition-name: workspace-next-steps-progress;
+}
+
+.workspace-next-steps-title {
+  view-transition-name: workspace-next-steps-title;
+}
+
+.workspace-next-steps-banner {
+  view-transition-name: workspace-next-steps-banner;
+}
+
+.workspace-next-steps-reveal {
+  animation: workspace-next-steps-banner-in 320ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+::view-transition-group(workspace-next-steps-progress) {
+  z-index: 20;
+  animation-duration: 420ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+::view-transition-old(workspace-next-steps-progress),
+::view-transition-new(workspace-next-steps-progress) {
+  height: 100%;
+  animation-duration: 420ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+::view-transition-group(workspace-next-steps-title) {
+  z-index: 19;
+  animation-duration: 420ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+::view-transition-old(workspace-next-steps-title),
+::view-transition-new(workspace-next-steps-title) {
+  height: auto;
+  animation-duration: 420ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+::view-transition-old(workspace-next-steps-banner) {
+  animation: workspace-next-steps-banner-out 280ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+::view-transition-new(workspace-next-steps-banner) {
+  animation: workspace-next-steps-banner-in 320ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 220ms;
+  animation-timing-function: ease;
+}
+
+@keyframes workspace-next-steps-banner-out {
+  to {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.98);
+  }
+}
+
+@keyframes workspace-next-steps-banner-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.98);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-next-steps-progress,
+  .workspace-next-steps-title,
+  .workspace-next-steps-banner {
+    view-transition-name: none;
+  }
+
+  .workspace-next-steps-reveal {
+    animation: none;
+  }
+}

--- a/web_src/src/pages/factories/layout/WorkspacePageHeader.tsx
+++ b/web_src/src/pages/factories/layout/WorkspacePageHeader.tsx
@@ -96,7 +96,9 @@ export function WorkspacePageHeader(props: WorkspacePageHeaderProps) {
               <h1 className="workspace-page-title min-w-0 overflow-visible" data-testid="workspace-page-header-title">
                 {props.title}
               </h1>
-              {!isEntity && props.leading ? <div className="flex items-center gap-2">{props.leading}</div> : null}
+              {!isEntity && props.leading ? (
+                <div className="flex min-w-0 items-center gap-2">{props.leading}</div>
+              ) : null}
             </div>
           </div>
           {hasSubtitle ? (

--- a/web_src/src/pages/factories/pages/ChecksPRFeedbackSetupDialog.spec.tsx
+++ b/web_src/src/pages/factories/pages/ChecksPRFeedbackSetupDialog.spec.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ChecksPRFeedbackSetupDialog } from "./ChecksPRFeedbackSetupDialog";
 import { PR_FEEDBACK_SOURCES } from "./prFeedbackSettingsModel";
+import { readDeferredWorkspaceNextStep, WORKSPACE_NEXT_STEP_DEFERRAL_STORAGE_KEY } from "./workspaceNextStepDeferral";
 
 const mocks = vi.hoisted(() => ({
   createHandler: vi.fn(),
@@ -81,6 +82,7 @@ describe("ChecksPRFeedbackSetupDialog", () => {
     mocks.fetching = false;
     mocks.catalog.splice(0, mocks.catalog.length, ...defaultCatalog);
     mocks.connected.splice(0);
+    window.localStorage.removeItem(WORKSPACE_NEXT_STEP_DEFERRAL_STORAGE_KEY);
   });
 
   it("waits for the catalog before it offers continue", () => {
@@ -133,10 +135,17 @@ describe("ChecksPRFeedbackSetupDialog", () => {
     await user.click(screen.getByTestId("checks-setup-continue"));
 
     expect(screen.getByRole("heading", { name: "Which tools report these checks?" })).toBeInTheDocument();
-    expect(screen.getByText("Suggested from the selected checks")).toBeInTheDocument();
+    expect(screen.queryByText("Suggested")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Based on the status checks you selected, SuperPlane needs access to these tools."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Grant that access so the agent can read CI logs and fix failing checks."),
+    ).toBeInTheDocument();
     expect(screen.getByText("CircleCI")).toBeInTheDocument();
-    expect(screen.getByText("Semaphore")).toBeInTheDocument();
+    expect(screen.queryByText("Semaphore")).not.toBeInTheDocument();
     expect(screen.queryByText("Slack")).not.toBeInTheDocument();
+    expect(screen.queryByText("Other CI tools")).not.toBeInTheDocument();
     await user.click(screen.getByTestId("checks-setup-connect-circleci"));
     expect(screen.getByTestId("integration-create-dialog")).toBeInTheDocument();
   });
@@ -208,7 +217,12 @@ describe("ChecksPRFeedbackSetupDialog", () => {
     await waitFor(() => expect(screen.getByTestId("pr-feedback-check-names-list")).toHaveTextContent("lint"));
     await user.click(screen.getByTestId("checks-setup-continue"));
     expect(screen.getByTestId("checks-setup-finish")).toHaveTextContent("Finish");
-    expect(screen.getByText(/Connect the external tools reporting the status checks/)).toBeInTheDocument();
+    expect(
+      screen.getByText("Based on the status checks you selected, SuperPlane needs access to these tools."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Grant that access so the agent can read CI logs and fix failing checks."),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("checks-setup-tools-unselected")).toHaveTextContent(
       "Some of the checks you selected require additional access that you are not granting.",
     );
@@ -230,9 +244,104 @@ describe("ChecksPRFeedbackSetupDialog", () => {
     expect(onCreated).toHaveBeenCalledWith("handler-1");
   });
 
-  it("warns when no CI tool is suggested and still lets the user finish", async () => {
+  it("says no additional access is required when no CI tool is suggested", async () => {
     const user = userEvent.setup();
+    const onCreated = vi.fn();
     mocks.catalog.splice(0, mocks.catalog.length, { type: "status_check", id: "lint", name: "lint" });
+    render(
+      <ChecksPRFeedbackSetupDialog
+        organizationId="org-1"
+        factoryId="factory-1"
+        githubIntegrationId="gh-1"
+        repository="acme/api"
+        source={checksSource}
+        onClose={vi.fn()}
+        onCreated={onCreated}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("pr-feedback-check-names-list")).toHaveTextContent("lint"));
+    await user.click(screen.getByTestId("checks-setup-continue"));
+
+    expect(screen.getByTestId("checks-setup-tools-no-access")).toHaveTextContent(
+      "The selected status checks do not need additional access.",
+    );
+    expect(screen.queryByText("Suggested")).not.toBeInTheDocument();
+    expect(screen.queryByText("CircleCI")).not.toBeInTheDocument();
+    expect(screen.queryByText("Semaphore")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("checks-setup-tools-unknown")).not.toBeInTheDocument();
+    expect(screen.getByTestId("checks-setup-finish")).toBeEnabled();
+
+    await user.click(screen.getByTestId("checks-setup-finish"));
+    await waitFor(() => {
+      expect(mocks.createHandler).toHaveBeenCalledWith({
+        source: "SOURCE_PULL_REQUEST_CHECKS",
+        name: "Fix pull request checks",
+        settings: {
+          subject: { repository: "acme/api" },
+          checks: { names: ["lint"], maximumAttempts: 3, runnerIntegrationIds: [] },
+        },
+      });
+    });
+    expect(onCreated).toHaveBeenCalledWith("handler-1");
+  });
+
+  it("says GitHub Actions does not need additional access", async () => {
+    const user = userEvent.setup();
+    const onCreated = vi.fn();
+    mocks.catalog.splice(0, mocks.catalog.length, {
+      type: "status_check",
+      id: "build",
+      name: "build",
+      url: "https://github.com/acme/api/actions/runs/99",
+    });
+    render(
+      <ChecksPRFeedbackSetupDialog
+        organizationId="org-1"
+        factoryId="factory-1"
+        githubIntegrationId="gh-1"
+        repository="acme/api"
+        source={checksSource}
+        onClose={vi.fn()}
+        onCreated={onCreated}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("pr-feedback-check-names-list")).toHaveTextContent("build"));
+    await user.click(screen.getByTestId("checks-setup-continue"));
+
+    expect(screen.getByTestId("checks-setup-tools-github-actions")).toHaveTextContent("GitHub Actions");
+    expect(screen.getByTestId("checks-setup-tools-github-actions")).toHaveTextContent(
+      "SuperPlane does not need additional access.",
+    );
+    expect(screen.queryByText("CircleCI")).not.toBeInTheDocument();
+    expect(screen.queryByText("Semaphore")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("checks-setup-tools-no-access")).not.toBeInTheDocument();
+    expect(screen.getByTestId("checks-setup-finish")).toBeEnabled();
+
+    await user.click(screen.getByTestId("checks-setup-finish"));
+    await waitFor(() => expect(mocks.createHandler).toHaveBeenCalled());
+    expect(onCreated).toHaveBeenCalledWith("handler-1");
+  });
+
+  it("keeps suggested tools when GitHub Actions is mixed with another CI tool", async () => {
+    const user = userEvent.setup();
+    mocks.catalog.splice(
+      0,
+      mocks.catalog.length,
+      {
+        type: "status_check",
+        id: "build",
+        name: "build",
+        url: "https://github.com/acme/api/actions/runs/99",
+      },
+      {
+        type: "status_check",
+        id: "e2e",
+        name: "e2e",
+        url: "https://app.circleci.com/pipelines/github/acme/api/1",
+      },
+    );
     render(
       <ChecksPRFeedbackSetupDialog
         organizationId="org-1"
@@ -245,14 +354,49 @@ describe("ChecksPRFeedbackSetupDialog", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getByTestId("pr-feedback-check-names-list")).toHaveTextContent("lint"));
+    await waitFor(() => expect(screen.getByTestId("pr-feedback-check-names-list")).toHaveTextContent("e2e"));
     await user.click(screen.getByTestId("checks-setup-continue"));
 
-    expect(screen.getByTestId("checks-setup-tools-unknown")).toHaveTextContent(
-      "The agent may not have enough context to fix them",
+    expect(screen.getByText("CircleCI")).toBeInTheDocument();
+    expect(screen.queryByText("Semaphore")).not.toBeInTheDocument();
+    expect(screen.getByTestId("checks-setup-tools-github-actions")).toHaveTextContent(
+      "GitHub Actions does not need additional access.",
     );
-    expect(screen.getByTestId("checks-setup-finish")).toBeEnabled();
-    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  it("finishes without a handler and minimizes next steps when no checks exist", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onCreated = vi.fn();
+    mocks.catalog.splice(0);
+    render(
+      <ChecksPRFeedbackSetupDialog
+        organizationId="org-1"
+        factoryId="factory-1"
+        githubIntegrationId="gh-1"
+        repository="acme/api"
+        source={checksSource}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("checks-setup-empty")).toBeInTheDocument());
+    expect(screen.getByTestId("checks-setup-empty")).toHaveTextContent(
+      "This repository does not have status checks yet. That is OK.",
+    );
+    expect(screen.getByTestId("checks-setup-empty")).toHaveTextContent(
+      "After you add them, you can configure SuperPlane to fix them automatically.",
+    );
+    expect(screen.queryByTestId("pr-feedback-check-names-picker")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("checks-setup-continue")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("checks-setup-finish"));
+
+    expect(mocks.createHandler).not.toHaveBeenCalled();
+    expect(onCreated).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+    expect(readDeferredWorkspaceNextStep("factory-1")).toBe("pr-checks-handler");
   });
 
   it("preselects a connected integration and hides Connect", async () => {
@@ -280,7 +424,8 @@ describe("ChecksPRFeedbackSetupDialog", () => {
     await waitFor(() => expect(row).toHaveAttribute("aria-selected", "true"));
     expect(row).toHaveTextContent("circleci-prod");
     expect(screen.queryByTestId("checks-setup-connect-circleci")).not.toBeInTheDocument();
-    expect(screen.getByTestId("checks-setup-connect-semaphore")).toHaveTextContent("Connect");
+    expect(screen.queryByTestId("checks-setup-connect-semaphore")).not.toBeInTheDocument();
+    expect(screen.queryByText("Semaphore")).not.toBeInTheDocument();
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
     expect(screen.queryByTestId("checks-setup-tools-unselected")).not.toBeInTheDocument();
 

--- a/web_src/src/pages/factories/pages/ChecksPRFeedbackSetupDialog.spec.tsx
+++ b/web_src/src/pages/factories/pages/ChecksPRFeedbackSetupDialog.spec.tsx
@@ -107,6 +107,7 @@ describe("ChecksPRFeedbackSetupDialog", () => {
     );
     expect(loading.querySelector("svg.animate-spin")).not.toBeNull();
     expect(screen.getByTestId("checks-setup-continue")).toBeDisabled();
+    expect(screen.queryByTestId("checks-setup-maximum-attempts")).not.toBeInTheDocument();
   });
 
   it("preselects catalog checks and creates the handler after the tools step", async () => {
@@ -131,8 +132,17 @@ describe("ChecksPRFeedbackSetupDialog", () => {
 
     expect(screen.getByTestId("checks-setup-back")).toHaveTextContent("Back to board");
     expect(screen.getByRole("heading", { name: "Which status checks should be fixed?" })).toBeInTheDocument();
+    expect(screen.getByTestId("checks-setup-maximum-attempts")).toHaveValue(3);
+    expect(screen.getByText("How many times should SuperPlane try before giving up?")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "SuperPlane pauses automatic fixes after this many consecutive attempts. Passing checks reset the count.",
+      ),
+    ).toBeInTheDocument();
 
     await user.click(screen.getByTestId("checks-setup-continue"));
+
+    expect(screen.queryByTestId("checks-setup-maximum-attempts")).not.toBeInTheDocument();
 
     expect(screen.getByRole("heading", { name: "Which tools report these checks?" })).toBeInTheDocument();
     expect(screen.queryByText("Suggested")).not.toBeInTheDocument();
@@ -197,6 +207,37 @@ describe("ChecksPRFeedbackSetupDialog", () => {
 
     expect(screen.getByTestId("pr-feedback-check-option-lint")).toHaveAttribute("aria-selected", "false");
     expect(screen.getByTestId("pr-feedback-check-option-e2e")).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("sends the maximum attempts from the first step", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChecksPRFeedbackSetupDialog
+        organizationId="org-1"
+        factoryId="factory-1"
+        githubIntegrationId="gh-1"
+        repository="acme/api"
+        source={checksSource}
+        onClose={vi.fn()}
+        onCreated={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("checks-setup-maximum-attempts")).toHaveValue(3));
+    await user.clear(screen.getByTestId("checks-setup-maximum-attempts"));
+    await user.type(screen.getByTestId("checks-setup-maximum-attempts"), "5");
+    await user.click(screen.getByTestId("checks-setup-continue"));
+    await user.click(screen.getByTestId("checks-setup-finish"));
+
+    await waitFor(() => {
+      expect(mocks.createHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          settings: expect.objectContaining({
+            checks: expect.objectContaining({ maximumAttempts: 5 }),
+          }),
+        }),
+      );
+    });
   });
 
   it("creates the handler with selected check names", async () => {
@@ -389,6 +430,7 @@ describe("ChecksPRFeedbackSetupDialog", () => {
       "After you add them, you can configure SuperPlane to fix them automatically.",
     );
     expect(screen.queryByTestId("pr-feedback-check-names-picker")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("checks-setup-maximum-attempts")).not.toBeInTheDocument();
     expect(screen.queryByTestId("checks-setup-continue")).not.toBeInTheDocument();
 
     await user.click(screen.getByTestId("checks-setup-finish"));

--- a/web_src/src/pages/factories/pages/ChecksPRFeedbackSetupDialog.spec.tsx
+++ b/web_src/src/pages/factories/pages/ChecksPRFeedbackSetupDialog.spec.tsx
@@ -209,6 +209,27 @@ describe("ChecksPRFeedbackSetupDialog", () => {
     expect(screen.getByTestId("pr-feedback-check-option-e2e")).toHaveAttribute("aria-selected", "true");
   });
 
+  it("does not continue when the attempt limit is not a whole number", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChecksPRFeedbackSetupDialog
+        organizationId="org-1"
+        factoryId="factory-1"
+        githubIntegrationId="gh-1"
+        repository="acme/api"
+        source={checksSource}
+        onClose={vi.fn()}
+        onCreated={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("checks-setup-maximum-attempts")).toHaveValue(3));
+    await user.clear(screen.getByTestId("checks-setup-maximum-attempts"));
+    await user.type(screen.getByTestId("checks-setup-maximum-attempts"), "5.5");
+
+    expect(screen.getByTestId("checks-setup-continue")).toBeDisabled();
+  });
+
   it("sends the maximum attempts from the first step", async () => {
     const user = userEvent.setup();
     render(

--- a/web_src/src/pages/factories/pages/ChecksPRFeedbackSetupDialog.tsx
+++ b/web_src/src/pages/factories/pages/ChecksPRFeedbackSetupDialog.tsx
@@ -190,6 +190,7 @@ function MaximumAttemptsField({ value, onChange }: { value: number; onChange: (v
         type="number"
         min={1}
         max={10}
+        step={1}
         value={String(value)}
         onChange={(event) => onChange(Number(event.target.value))}
         data-testid="checks-setup-maximum-attempts"

--- a/web_src/src/pages/factories/pages/ChecksPRFeedbackSetupDialog.tsx
+++ b/web_src/src/pages/factories/pages/ChecksPRFeedbackSetupDialog.tsx
@@ -20,6 +20,7 @@ import {
   type ChecksPRFeedbackSetupModel,
 } from "./useChecksPRFeedbackSetup";
 import { PR_FEEDBACK_SETTINGS_COPY, toggleUniqueString, type PRFeedbackSource } from "./prFeedbackSettingsModel";
+import { writeDeferredWorkspaceNextStep } from "./workspaceNextStepDeferral";
 
 interface ChecksPRFeedbackSetupDialogProps {
   organizationId: string;
@@ -45,6 +46,8 @@ export function ChecksPRFeedbackSetupDialog(props: ChecksPRFeedbackSetupDialogPr
         <div className="space-y-6" data-testid="checks-pr-feedback-setup">
           <SetupHeader
             step={setup.step}
+            catalogEmpty={setup.catalogEmpty}
+            toolsAccess={setup.toolsAccess}
             onBack={() => {
               if (setup.step === "tools") {
                 setup.setStep("checks");
@@ -54,18 +57,7 @@ export function ChecksPRFeedbackSetupDialog(props: ChecksPRFeedbackSetupDialogPr
             }}
           />
           <div>
-            {setup.step === "checks" ? (
-              <StatusCheckPicker
-                names={setup.checkNames}
-                catalog={setup.catalog}
-                loading={setup.catalogLoading}
-                loadError={setup.catalogQuery.isError}
-                onToggle={setup.toggleCheckName}
-                hideHeading
-              />
-            ) : (
-              <ToolsStep setup={setup} />
-            )}
+            <SetupStepBody setup={setup} />
             {setup.error ? (
               <p className="workspace-body-text mt-4 text-destructive" role="alert">
                 {setup.error}
@@ -74,7 +66,13 @@ export function ChecksPRFeedbackSetupDialog(props: ChecksPRFeedbackSetupDialogPr
           </div>
           <div className="space-y-3">
             {setup.step === "tools" ? <ToolsAccessWarning warning={toolsAccessWarning(setup)} /> : null}
-            <SetupFooter setup={setup} source={props.source} onClose={props.onClose} onCreated={props.onCreated} />
+            <SetupFooter
+              setup={setup}
+              factoryId={props.factoryId}
+              source={props.source}
+              onClose={props.onClose}
+              onCreated={props.onCreated}
+            />
           </div>
         </div>
       )}
@@ -106,13 +104,21 @@ export function ChecksPRFeedbackSetupDialog(props: ChecksPRFeedbackSetupDialogPr
   );
 }
 
-function SetupHeader({ step, onBack }: { step: "checks" | "tools"; onBack: () => void }) {
+function SetupHeader({
+  step,
+  catalogEmpty,
+  toolsAccess,
+  onBack,
+}: {
+  step: "checks" | "tools";
+  catalogEmpty: boolean;
+  toolsAccess: ChecksPRFeedbackSetupModel["toolsAccess"];
+  onBack: () => void;
+}) {
   const stepTitle =
     step === "checks"
       ? PR_FEEDBACK_SETTINGS_COPY.wizardStepWhichChecks
       : PR_FEEDBACK_SETTINGS_COPY.wizardStepWhichTools;
-  const stepHelper =
-    step === "checks" ? PR_FEEDBACK_SETTINGS_COPY.checkNamesHelper : PR_FEEDBACK_SETTINGS_COPY.wizardToolsDescription;
 
   return (
     <header className="text-left">
@@ -128,9 +134,74 @@ function SetupHeader({ step, onBack }: { step: "checks" | "tools"; onBack: () =>
         </span>
       </button>
       <h1 className={factoryPageTitleClassName}>{stepTitle}</h1>
-      <p className="workspace-body-text mt-2 text-muted-foreground">{stepHelper}</p>
+      <SetupHeaderHelper step={step} catalogEmpty={catalogEmpty} toolsAccess={toolsAccess} />
     </header>
   );
+}
+
+function SetupHeaderHelper({
+  step,
+  catalogEmpty,
+  toolsAccess,
+}: {
+  step: "checks" | "tools";
+  catalogEmpty: boolean;
+  toolsAccess: ChecksPRFeedbackSetupModel["toolsAccess"];
+}) {
+  if (step === "checks") {
+    if (catalogEmpty) {
+      return null;
+    }
+    return (
+      <p className="workspace-body-text mt-2 text-muted-foreground">{PR_FEEDBACK_SETTINGS_COPY.checkNamesHelper}</p>
+    );
+  }
+  if (toolsAccess === "github-actions") {
+    return (
+      <p className="workspace-body-text mt-2 text-muted-foreground" data-testid="checks-setup-tools-github-actions">
+        {PR_FEEDBACK_SETTINGS_COPY.wizardToolsGitHubActions}
+      </p>
+    );
+  }
+  if (toolsAccess === "none") {
+    return (
+      <p className="workspace-body-text mt-2 text-muted-foreground" data-testid="checks-setup-tools-no-access">
+        {PR_FEEDBACK_SETTINGS_COPY.wizardToolsNoAccess}
+      </p>
+    );
+  }
+  return null;
+}
+
+function EmptyChecksMessage() {
+  return (
+    <div className="workspace-body-text space-y-2 text-muted-foreground" data-testid="checks-setup-empty">
+      <p>{PR_FEEDBACK_SETTINGS_COPY.wizardChecksEmpty}</p>
+      <p>{PR_FEEDBACK_SETTINGS_COPY.wizardChecksEmptyDetail}</p>
+    </div>
+  );
+}
+
+function SetupStepBody({ setup }: { setup: ChecksPRFeedbackSetupModel }) {
+  if (setup.step === "checks") {
+    if (setup.catalogEmpty) {
+      return <EmptyChecksMessage />;
+    }
+    return (
+      <StatusCheckPicker
+        names={setup.checkNames}
+        catalog={setup.catalog}
+        loading={setup.catalogLoading}
+        loadError={setup.catalogQuery.isError}
+        onToggle={setup.toggleCheckName}
+        hideHeading
+      />
+    );
+  }
+  if (setup.toolsAccess === "suggested") {
+    return <ToolsStep setup={setup} />;
+  }
+  return null;
 }
 
 function ToolsStep({ setup }: { setup: ChecksPRFeedbackSetupModel }) {
@@ -143,13 +214,15 @@ function ToolsStep({ setup }: { setup: ChecksPRFeedbackSetupModel }) {
     ),
   );
   const suggested = setup.available.filter((integration) => setup.suggestedNames.includes(integration.name ?? ""));
-  const others = setup.available.filter((integration) => !setup.suggestedNames.includes(integration.name ?? ""));
 
   return (
     <div className="space-y-5">
       {suggested.length > 0 ? (
         <IntegrationChoiceList
-          title={PR_FEEDBACK_SETTINGS_COPY.wizardSuggested}
+          description={[
+            PR_FEEDBACK_SETTINGS_COPY.wizardSuggestedHelper,
+            PR_FEEDBACK_SETTINGS_COPY.wizardSuggestedHelperDetail,
+          ]}
           definitions={suggested}
           ready={ready}
           selectedIds={setup.runnerIntegrationIds}
@@ -157,19 +230,10 @@ function ToolsStep({ setup }: { setup: ChecksPRFeedbackSetupModel }) {
           onConnect={setup.setConnectName}
         />
       ) : null}
-      {others.length > 0 ? (
-        <IntegrationChoiceList
-          title={
-            setup.suggestedNames.length > 0
-              ? PR_FEEDBACK_SETTINGS_COPY.wizardOtherTools
-              : PR_FEEDBACK_SETTINGS_COPY.integrationsLabel
-          }
-          definitions={others}
-          ready={ready}
-          selectedIds={setup.runnerIntegrationIds}
-          onToggle={setup.setRunnerIntegrationIds}
-          onConnect={setup.setConnectName}
-        />
+      {setup.usesGitHubActions ? (
+        <p className="workspace-body-text text-muted-foreground" data-testid="checks-setup-tools-github-actions">
+          {PR_FEEDBACK_SETTINGS_COPY.wizardToolsGitHubActionsNote}
+        </p>
       ) : null}
     </div>
   );
@@ -179,7 +243,7 @@ type ToolsAccessWarningContent = { testId: string; lines: string[] };
 
 function toolsAccessWarning(setup: ChecksPRFeedbackSetupModel): ToolsAccessWarningContent | null {
   if (setup.suggestedNames.length === 0) {
-    return { testId: "checks-setup-tools-unknown", lines: [PR_FEEDBACK_SETTINGS_COPY.wizardToolsUnknown] };
+    return null;
   }
   const ready = (setup.connected ?? []).filter(
     (integration) =>
@@ -217,14 +281,14 @@ function ToolsAccessWarning({ warning }: { warning: ToolsAccessWarningContent | 
 }
 
 function IntegrationChoiceList({
-  title,
+  description,
   definitions,
   ready,
   selectedIds,
   onToggle,
   onConnect,
 }: {
-  title: string;
+  description?: string[];
   definitions: Array<{ name?: string; label?: string }>;
   ready: Array<{ metadata?: { id?: string; name?: string; integrationName?: string } }>;
   selectedIds: string[];
@@ -236,11 +300,18 @@ function IntegrationChoiceList({
     label: getIntegrationTypeDisplayName(definition.label, definition.name ?? ""),
   }));
   const rows = checksHandlerIntegrationRows(labeled, ready);
+  const lines = description?.filter((line) => line.trim()) ?? [];
 
   return (
     <section>
-      <h3 className="text-sm font-medium text-gray-800 dark:text-gray-100">{title}</h3>
-      <div className="mt-2 rounded-lg border border-border">
+      {lines.length > 0 ? (
+        <div className="workspace-body-text space-y-1 text-muted-foreground">
+          {lines.map((line) => (
+            <p key={line}>{line}</p>
+          ))}
+        </div>
+      ) : null}
+      <div className={cn("rounded-lg border border-border", lines.length > 0 && "mt-5")}>
         <ul className="divide-y divide-border">
           {rows.map((row) => (
             <IntegrationChoiceRow
@@ -311,18 +382,37 @@ function IntegrationChoiceRow({
 
 function SetupFooter({
   setup,
+  factoryId,
   source,
   onClose,
   onCreated,
 }: {
   setup: ChecksPRFeedbackSetupModel;
+  factoryId: string;
   source: PRFeedbackSource;
   onClose: () => void;
   onCreated: (handlerId: string) => void;
 }) {
-  return (
-    <footer className="flex items-center justify-end gap-3 pt-2">
-      {setup.step === "checks" ? (
+  if (setup.step === "checks" && setup.catalogEmpty) {
+    return (
+      <footer className="flex items-center justify-end gap-3 pt-2">
+        <Button
+          type="button"
+          onClick={() => {
+            writeDeferredWorkspaceNextStep(factoryId, "pr-checks-handler");
+            onClose();
+          }}
+          data-testid="checks-setup-finish"
+        >
+          {PR_FEEDBACK_SETTINGS_COPY.wizardFinish}
+        </Button>
+      </footer>
+    );
+  }
+
+  if (setup.step === "checks") {
+    return (
+      <footer className="flex items-center justify-end gap-3 pt-2">
         <Button
           type="button"
           disabled={!setup.canContinue}
@@ -331,25 +421,29 @@ function SetupFooter({
         >
           {PR_FEEDBACK_SETTINGS_COPY.wizardContinue}
         </Button>
-      ) : (
-        <Button
-          type="button"
-          disabled={setup.createHandler.isPending}
-          onClick={() => {
-            void setup.finish(source).then((handler) => {
-              if (handler?.id) {
-                onCreated(handler.id);
-                onClose();
-              }
-            });
-          }}
-          data-testid="checks-setup-finish"
-        >
-          {setup.createHandler.isPending
-            ? PR_FEEDBACK_SETTINGS_COPY.wizardFinishing
-            : PR_FEEDBACK_SETTINGS_COPY.wizardFinish}
-        </Button>
-      )}
+      </footer>
+    );
+  }
+
+  return (
+    <footer className="flex items-center justify-end gap-3 pt-2">
+      <Button
+        type="button"
+        disabled={setup.createHandler.isPending}
+        onClick={() => {
+          void setup.finish(source).then((handler) => {
+            if (handler?.id) {
+              onCreated(handler.id);
+              onClose();
+            }
+          });
+        }}
+        data-testid="checks-setup-finish"
+      >
+        {setup.createHandler.isPending
+          ? PR_FEEDBACK_SETTINGS_COPY.wizardFinishing
+          : PR_FEEDBACK_SETTINGS_COPY.wizardFinish}
+      </Button>
     </footer>
   );
 }

--- a/web_src/src/pages/factories/pages/ChecksPRFeedbackSetupDialog.tsx
+++ b/web_src/src/pages/factories/pages/ChecksPRFeedbackSetupDialog.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { getIntegrationTypeDisplayName } from "@/lib/integrationDisplayName";
 import { cn } from "@/lib/utils";
 import { sortConnectedIntegrationsByType } from "@/lib/sortConnectedIntegrations";
@@ -173,6 +174,30 @@ function SetupHeaderHelper({
   return null;
 }
 
+function MaximumAttemptsField({ value, onChange }: { value: number; onChange: (value: number) => void }) {
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className={factoryPageTitleClassName}>
+          <label htmlFor="checks-setup-maximum-attempts">{PR_FEEDBACK_SETTINGS_COPY.wizardMaximumAttempts}</label>
+        </h2>
+        <p className="workspace-body-text mt-2 text-muted-foreground">
+          {PR_FEEDBACK_SETTINGS_COPY.maximumAttemptsHelper}
+        </p>
+      </div>
+      <Input
+        id="checks-setup-maximum-attempts"
+        type="number"
+        min={1}
+        max={10}
+        value={String(value)}
+        onChange={(event) => onChange(Number(event.target.value))}
+        data-testid="checks-setup-maximum-attempts"
+      />
+    </section>
+  );
+}
+
 function EmptyChecksMessage() {
   return (
     <div className="workspace-body-text space-y-2 text-muted-foreground" data-testid="checks-setup-empty">
@@ -188,14 +213,19 @@ function SetupStepBody({ setup }: { setup: ChecksPRFeedbackSetupModel }) {
       return <EmptyChecksMessage />;
     }
     return (
-      <StatusCheckPicker
-        names={setup.checkNames}
-        catalog={setup.catalog}
-        loading={setup.catalogLoading}
-        loadError={setup.catalogQuery.isError}
-        onToggle={setup.toggleCheckName}
-        hideHeading
-      />
+      <div className="space-y-6">
+        <StatusCheckPicker
+          names={setup.checkNames}
+          catalog={setup.catalog}
+          loading={setup.catalogLoading}
+          loadError={setup.catalogQuery.isError}
+          onToggle={setup.toggleCheckName}
+          hideHeading
+        />
+        {setup.catalog.length > 0 ? (
+          <MaximumAttemptsField value={setup.maximumAttempts} onChange={setup.setMaximumAttempts} />
+        ) : null}
+      </div>
     );
   }
   if (setup.toolsAccess === "suggested") {

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -671,7 +671,7 @@ describe("LinesPage board", () => {
     expect(screen.queryByTestId("workspace-next-steps")).not.toBeInTheDocument();
     const restore = screen.getByTestId("workspace-next-steps-restore");
     expect(restore).toHaveTextContent("3/4");
-    expect(restore).toHaveTextContent("How should failing status checks be handled?");
+    expect(restore).toHaveTextContent("Configure status checks");
     expect(screen.getByTestId("lines-detail-header")).toContainElement(restore);
     const trial = screen.queryByTestId("hosted-credit-header-kicker");
     if (trial) {
@@ -694,18 +694,14 @@ describe("LinesPage board", () => {
     const { unmount } = renderLinesBoard(undefined, vi.fn(), REFUND_FACTORY, LANE_BANNERS);
     await user.click(screen.getByTestId("workspace-next-step-later"));
     expect(screen.getByTestId("workspace-next-steps-restore")).toHaveTextContent("3/4");
-    expect(screen.getByTestId("workspace-next-steps-restore")).toHaveTextContent(
-      "How should failing status checks be handled?",
-    );
+    expect(screen.getByTestId("workspace-next-steps-restore")).toHaveTextContent("Configure status checks");
     unmount();
 
     renderLinesBoard(undefined, vi.fn(), REFUND_FACTORY, LANE_BANNERS);
 
     expect(screen.queryByTestId("workspace-next-steps")).not.toBeInTheDocument();
     expect(screen.getByTestId("workspace-next-steps-restore")).toHaveTextContent("3/4");
-    expect(screen.getByTestId("workspace-next-steps-restore")).toHaveTextContent(
-      "How should failing status checks be handled?",
-    );
+    expect(screen.getByTestId("workspace-next-steps-restore")).toHaveTextContent("Configure status checks");
   });
 
   it("keeps next steps hidden while PR feedback handlers load", () => {

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -637,16 +637,91 @@ describe("LinesPage board", () => {
     expect(screen.getByTestId("workspace-next-steps")).toHaveTextContent(
       "How should pull request comments be handled?",
     );
-    expect(screen.getByTestId("workspace-next-steps-progress")).toHaveTextContent("2/3");
+    expect(screen.getByTestId("workspace-next-steps-progress")).toHaveTextContent("2/4");
     expect(screen.getByTestId("workspace-next-steps")).toHaveTextContent(
       "SuperPlane can implement tasks and open pull requests, but pull request reviews are not handled yet.",
     );
     expect(screen.getByTestId("workspace-next-step-cta-pr-comments-handler")).toHaveTextContent("Configure");
+    expect(screen.queryByTestId("workspace-next-step-later")).not.toBeInTheDocument();
   });
 
-  it("hides next steps when the comments handler is configured", () => {
+  it("shows status checks after the comments handler is configured", () => {
     useFactoryPRFeedbackHandlers.mockReturnValue({
       data: [{ id: "handler-discussion", source: "SOURCE_PULL_REQUEST_DISCUSSION", healthy: true }],
+    });
+    renderLinesBoard(undefined, vi.fn(), REFUND_FACTORY, LANE_BANNERS);
+
+    expect(screen.getByTestId("workspace-next-steps")).toHaveTextContent(
+      "How should failing status checks be handled?",
+    );
+    expect(screen.getByTestId("workspace-next-steps-progress")).toHaveTextContent("3/4");
+    expect(screen.getByTestId("workspace-next-step-cta-pr-checks-handler")).toHaveTextContent("Configure");
+    expect(screen.getByTestId("workspace-next-step-later")).toHaveTextContent("Later");
+  });
+
+  it("moves the status-checks banner into a header badge when the user chooses Later", async () => {
+    useFactoryPRFeedbackHandlers.mockReturnValue({
+      data: [{ id: "handler-discussion", source: "SOURCE_PULL_REQUEST_DISCUSSION", healthy: true }],
+    });
+    const user = userEvent.setup();
+    renderLinesBoard(undefined, vi.fn(), REFUND_FACTORY, LANE_BANNERS);
+
+    await user.click(screen.getByTestId("workspace-next-step-later"));
+
+    expect(screen.queryByTestId("workspace-next-steps")).not.toBeInTheDocument();
+    const restore = screen.getByTestId("workspace-next-steps-restore");
+    expect(restore).toHaveTextContent("3/4");
+    expect(restore).toHaveTextContent("How should failing status checks be handled?");
+    expect(screen.getByTestId("lines-detail-header")).toContainElement(restore);
+    const trial = screen.queryByTestId("hosted-credit-header-kicker");
+    if (trial) {
+      expect(trial.compareDocumentPosition(restore) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    }
+
+    await user.click(restore);
+
+    expect(screen.getByTestId("workspace-next-steps")).toHaveTextContent(
+      "How should failing status checks be handled?",
+    );
+    expect(screen.queryByTestId("workspace-next-steps-restore")).not.toBeInTheDocument();
+  });
+
+  it("keeps the deferred status-checks badge after a reload", async () => {
+    useFactoryPRFeedbackHandlers.mockReturnValue({
+      data: [{ id: "handler-discussion", source: "SOURCE_PULL_REQUEST_DISCUSSION", healthy: true }],
+    });
+    const user = userEvent.setup();
+    const { unmount } = renderLinesBoard(undefined, vi.fn(), REFUND_FACTORY, LANE_BANNERS);
+    await user.click(screen.getByTestId("workspace-next-step-later"));
+    expect(screen.getByTestId("workspace-next-steps-restore")).toHaveTextContent("3/4");
+    expect(screen.getByTestId("workspace-next-steps-restore")).toHaveTextContent(
+      "How should failing status checks be handled?",
+    );
+    unmount();
+
+    renderLinesBoard(undefined, vi.fn(), REFUND_FACTORY, LANE_BANNERS);
+
+    expect(screen.queryByTestId("workspace-next-steps")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workspace-next-steps-restore")).toHaveTextContent("3/4");
+    expect(screen.getByTestId("workspace-next-steps-restore")).toHaveTextContent(
+      "How should failing status checks be handled?",
+    );
+  });
+
+  it("keeps next steps hidden while PR feedback handlers load", () => {
+    useFactoryPRFeedbackHandlers.mockReturnValue({ data: [], isPending: true });
+    renderLinesBoard(undefined, vi.fn(), REFUND_FACTORY, LANE_BANNERS);
+
+    expect(screen.queryByTestId("workspace-next-steps")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-next-steps-restore")).not.toBeInTheDocument();
+  });
+
+  it("hides next steps when both handlers are configured", () => {
+    useFactoryPRFeedbackHandlers.mockReturnValue({
+      data: [
+        { id: "handler-discussion", source: "SOURCE_PULL_REQUEST_DISCUSSION", healthy: true },
+        { id: "handler-checks", source: "SOURCE_PULL_REQUEST_CHECKS", healthy: true },
+      ],
     });
     renderLinesBoard(undefined, vi.fn(), REFUND_FACTORY, LANE_BANNERS);
 
@@ -662,6 +737,22 @@ describe("LinesPage board", () => {
     expect(screen.getByTestId("discussion-pr-feedback-setup")).toBeInTheDocument();
     expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
       factoryPRFeedbackSetupPath("org-1", PRIMARY_FACTORY_KEY, REFUND_LINE_PLAN_ID, "comments"),
+    );
+    expect(createFactoryPRFeedbackHandler).not.toHaveBeenCalled();
+  });
+
+  it("opens the status-checks setup page from the next-step CTA", async () => {
+    useFactoryPRFeedbackHandlers.mockReturnValue({
+      data: [{ id: "handler-discussion", source: "SOURCE_PULL_REQUEST_DISCUSSION", healthy: true }],
+    });
+    const user = userEvent.setup();
+    renderLinesBoard(undefined, vi.fn(), REFUND_FACTORY, LANE_BANNERS);
+
+    await user.click(screen.getByTestId("workspace-next-step-cta-pr-checks-handler"));
+
+    expect(screen.getByTestId("checks-pr-feedback-setup")).toBeInTheDocument();
+    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
+      factoryPRFeedbackSetupPath("org-1", PRIMARY_FACTORY_KEY, REFUND_LINE_PLAN_ID, "checks"),
     );
     expect(createFactoryPRFeedbackHandler).not.toHaveBeenCalled();
   });

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -68,9 +68,17 @@ const useFactoryPullRequests = vi.fn(() => ({ data: [] as FactoriesFactoryPullRe
 const useFactoryApps = vi.fn(() => ({ data: [] as FactoryApp[] }));
 const useFactoryIntakes = vi.fn(() => ({ data: [] as FactoriesFactoryIntake[] }));
 const createFactoryIntakeMutateAsync = vi.fn();
-const useFactoryPRFeedbackHandlers = vi.fn(() => ({
-  data: [] as { id?: string; source?: string; healthy?: boolean }[],
-}));
+const useFactoryPRFeedbackHandlers = vi.fn(
+  (): {
+    data?: { id?: string; source?: string; healthy?: boolean }[];
+    isPending?: boolean;
+    isError?: boolean;
+  } => ({
+    data: [],
+    isPending: false,
+    isError: false,
+  }),
+);
 const createFactoryPRFeedbackHandler = vi.fn();
 const searchFactoryIntakeItems = vi.fn(() => ({
   data: [] as { id: string; key: string; title: string; body: string; url: string }[],
@@ -630,6 +638,12 @@ describe("LinesPage board", () => {
     );
     expect(createFactoryPRFeedbackHandler).not.toHaveBeenCalled();
   });
+});
+
+describe("LinesPage next steps", () => {
+  beforeEach(async () => {
+    await resetLinesBoardMocks();
+  });
 
   it("shows comments as open after onboarding", () => {
     renderLinesBoard(undefined, vi.fn(), REFUND_FACTORY, LANE_BANNERS);
@@ -712,6 +726,14 @@ describe("LinesPage board", () => {
     expect(screen.queryByTestId("workspace-next-steps-restore")).not.toBeInTheDocument();
   });
 
+  it("keeps next steps hidden when PR feedback handlers fail to load", () => {
+    useFactoryPRFeedbackHandlers.mockReturnValue({ isPending: false, isError: true });
+    renderLinesBoard(undefined, vi.fn(), REFUND_FACTORY, LANE_BANNERS);
+
+    expect(screen.queryByTestId("workspace-next-steps")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-next-steps-restore")).not.toBeInTheDocument();
+  });
+
   it("hides next steps when both handlers are configured", () => {
     useFactoryPRFeedbackHandlers.mockReturnValue({
       data: [
@@ -751,6 +773,12 @@ describe("LinesPage board", () => {
       factoryPRFeedbackSetupPath("org-1", PRIMARY_FACTORY_KEY, REFUND_LINE_PLAN_ID, "checks"),
     );
     expect(createFactoryPRFeedbackHandler).not.toHaveBeenCalled();
+  });
+});
+
+describe("LinesPage board extras", () => {
+  beforeEach(async () => {
+    await resetLinesBoardMocks();
   });
 
   it("hides Add automation on the Backlog, Verify, and Done column menus", async () => {

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -49,6 +49,7 @@ import {
   isWorkspaceNextStepDeferred,
   runWorkspaceNextStepAction,
   shouldForgetDeferredWorkspaceNextStep,
+  isWorkspaceNextStepsQueryReady,
   workspaceNextStepBanner,
   workspaceNextSteps,
   workspaceNextStepsProgressCopy,
@@ -242,10 +243,8 @@ export function LinesPage() {
   const { data: pullRequests = [] } = useFactoryPullRequests(organizationId, factoryId);
   const { data: factoryApps = [] } = useFactoryApps(organizationId, factoryId);
   const { data: me } = useMe(false);
-  const { data: prFeedbackHandlers = [], isPending: prFeedbackHandlersPending } = useFactoryPRFeedbackHandlers(
-    organizationId,
-    factoryId,
-  );
+  const prFeedbackHandlersQuery = useFactoryPRFeedbackHandlers(organizationId, factoryId);
+  const prFeedbackHandlers = prFeedbackHandlersQuery.data ?? [];
   const listState = useWorkOrderListState(factoryId);
   const { data: factoryIntakes = [] } = useFactoryIntakes(organizationId, factoryId);
   const createIntake = useCreateFactoryIntake(organizationId, factoryId);
@@ -359,7 +358,7 @@ export function LinesPage() {
     onboardingComplete: isFactoryOnboardingComplete(factory),
     canConfigure: canUpdate,
     takenPRFeedbackSources,
-    ready: !prFeedbackHandlersPending,
+    ready: isWorkspaceNextStepsQueryReady(prFeedbackHandlersQuery),
   });
   const nextStepBanner = workspaceNextStepBanner(nextSteps);
   const nextStepDeferral = useWorkspaceNextStepDeferral(factoryId);

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -521,7 +521,7 @@ export function LinesPage() {
               nextStepsCollapsed && nextStepBanner ? (
                 <WorkspaceNextStepsHeaderBadge
                   progress={workspaceNextStepsProgressCopy(nextStepBanner.doneCount, nextStepBanner.totalCount)}
-                  title={nextStepBanner.title}
+                  title={nextStepBanner.badgeLabel}
                   onOpen={nextStepDeferral.restore}
                 />
               ) : undefined

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -43,8 +43,16 @@ import { useColumnAutomationViewPreference, type ColumnAutomationView } from "..
 import { useHostedCreditChrome } from "../lib/useHostedCreditEmptyBanner";
 import { AddIntakePicker } from "./AddIntakePicker";
 import { AddPRFeedbackPicker } from "./AddPRFeedbackPicker";
-import { NextStepsPanel } from "./NextStepsPanel";
-import { runWorkspaceNextStepAction, workspaceNextSteps } from "./workspaceNextStepCatalog";
+import { NextStepsPanel, WorkspaceNextStepsHeaderBadge } from "./NextStepsPanel";
+import { useWorkspaceNextStepDeferral } from "./workspaceNextStepDeferral";
+import {
+  isWorkspaceNextStepDeferred,
+  runWorkspaceNextStepAction,
+  shouldForgetDeferredWorkspaceNextStep,
+  workspaceNextStepBanner,
+  workspaceNextSteps,
+  workspaceNextStepsProgressCopy,
+} from "./workspaceNextStepCatalog";
 import { BacklogColumn, type BacklogIntakePanel } from "./BacklogColumn";
 import { LineBoardViewMenu } from "./LineBoardViewMenu";
 import { columnAutomationRowsSubheader } from "./columnAutomationRowsSubheader";
@@ -234,7 +242,10 @@ export function LinesPage() {
   const { data: pullRequests = [] } = useFactoryPullRequests(organizationId, factoryId);
   const { data: factoryApps = [] } = useFactoryApps(organizationId, factoryId);
   const { data: me } = useMe(false);
-  const { data: prFeedbackHandlers = [] } = useFactoryPRFeedbackHandlers(organizationId, factoryId);
+  const { data: prFeedbackHandlers = [], isPending: prFeedbackHandlersPending } = useFactoryPRFeedbackHandlers(
+    organizationId,
+    factoryId,
+  );
   const listState = useWorkOrderListState(factoryId);
   const { data: factoryIntakes = [] } = useFactoryIntakes(organizationId, factoryId);
   const createIntake = useCreateFactoryIntake(organizationId, factoryId);
@@ -348,7 +359,17 @@ export function LinesPage() {
     onboardingComplete: isFactoryOnboardingComplete(factory),
     canConfigure: canUpdate,
     takenPRFeedbackSources,
+    ready: !prFeedbackHandlersPending,
   });
+  const nextStepBanner = workspaceNextStepBanner(nextSteps);
+  const nextStepDeferral = useWorkspaceNextStepDeferral(factoryId);
+  const nextStepsCollapsed = isWorkspaceNextStepDeferred(nextStepBanner, nextStepDeferral.deferredStepId);
+
+  useEffect(() => {
+    if (shouldForgetDeferredWorkspaceNextStep(nextStepDeferral.deferredStepId, takenPRFeedbackSources)) {
+      nextStepDeferral.forget();
+    }
+  }, [nextStepDeferral.deferredStepId, nextStepDeferral.forget, takenPRFeedbackSources]);
 
   const verifyListeners: LaneListener[] = prFeedbackHandlers.flatMap((handler) => {
     if (!handler.id) {
@@ -496,12 +517,22 @@ export function LinesPage() {
             state={listState}
             canUpdate={canUpdate}
             hostedCreditHeaderKicker={hostedCreditHeaderKicker}
+            nextStepsRestore={
+              nextStepsCollapsed && nextStepBanner ? (
+                <WorkspaceNextStepsHeaderBadge
+                  progress={workspaceNextStepsProgressCopy(nextStepBanner.doneCount, nextStepBanner.totalCount)}
+                  title={nextStepBanner.title}
+                  onOpen={nextStepDeferral.restore}
+                />
+              ) : undefined
+            }
             hostedCreditEmptyBanner={hostedCreditEmptyBanner}
             automationView={canChooseAutomationView ? columnAutomationView : undefined}
             onAutomationViewChange={canChooseAutomationView ? setColumnAutomationView : undefined}
           />
           <NextStepsPanel
             steps={nextSteps}
+            collapsed={nextStepsCollapsed}
             onContinue={(step) =>
               runWorkspaceNextStepAction(step.action, {
                 openPRFeedbackSetup: (sourceId) => {
@@ -512,6 +543,11 @@ export function LinesPage() {
                 },
               })
             }
+            onDefer={() => {
+              if (nextStepBanner) {
+                nextStepDeferral.defer(nextStepBanner.activeStep.id);
+              }
+            }}
           />
         </div>
         <div className={factoryWorkOrdersBodyClassName}>
@@ -573,6 +609,7 @@ function LineDetailHeader({
   state,
   canUpdate,
   hostedCreditHeaderKicker,
+  nextStepsRestore,
   hostedCreditEmptyBanner,
   automationView,
   onAutomationViewChange,
@@ -585,6 +622,7 @@ function LineDetailHeader({
   state: WorkOrderListState;
   canUpdate: boolean;
   hostedCreditHeaderKicker?: ReactNode;
+  nextStepsRestore?: ReactNode;
   hostedCreditEmptyBanner?: ReactNode;
   automationView?: ColumnAutomationView;
   onAutomationViewChange?: (view: ColumnAutomationView) => void;
@@ -621,7 +659,14 @@ function LineDetailHeader({
           inputClassName="font-medium text-[length:var(--workspace-page-title-size)] leading-[var(--workspace-page-title-line-height)] tracking-[var(--workspace-page-title-tracking)]"
         />
       }
-      leading={hostedCreditHeaderKicker}
+      leading={
+        nextStepsRestore || hostedCreditHeaderKicker ? (
+          <>
+            {hostedCreditHeaderKicker}
+            {nextStepsRestore}
+          </>
+        ) : undefined
+      }
       actions={
         <>
           <ScopePills

--- a/web_src/src/pages/factories/pages/NextStepsPanel.spec.tsx
+++ b/web_src/src/pages/factories/pages/NextStepsPanel.spec.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { NextStepsPanel, WorkspaceNextStepsHeaderBadge } from "./NextStepsPanel";
+import { workspaceNextSteps } from "./workspaceNextStepCatalog";
+
+const commentsSteps = workspaceNextSteps({
+  onboardingComplete: true,
+  canConfigure: true,
+  takenPRFeedbackSources: [],
+});
+
+const checksSteps = workspaceNextSteps({
+  onboardingComplete: true,
+  canConfigure: true,
+  takenPRFeedbackSources: ["discussion"],
+});
+
+describe("NextStepsPanel", () => {
+  it("does not offer Later for the required comments step", () => {
+    render(<NextStepsPanel steps={commentsSteps} onContinue={vi.fn()} onDefer={vi.fn()} />);
+
+    expect(screen.getByTestId("workspace-next-step-cta-pr-comments-handler")).toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-next-step-later")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workspace-next-steps")).toHaveClass("workspace-next-steps-reveal");
+  });
+
+  it("offers Later for the optional status-checks step", async () => {
+    const user = userEvent.setup();
+    const onDefer = vi.fn();
+    render(<NextStepsPanel steps={checksSteps} onContinue={vi.fn()} onDefer={onDefer} />);
+
+    const later = screen.getByTestId("workspace-next-step-later");
+    const configure = screen.getByTestId("workspace-next-step-cta-pr-checks-handler");
+    expect(configure).toHaveTextContent("Configure");
+    expect(later.compareDocumentPosition(configure) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    await user.click(later);
+    expect(onDefer).toHaveBeenCalledOnce();
+  });
+
+  it("hides the banner when the optional step is deferred", () => {
+    render(<NextStepsPanel steps={checksSteps} collapsed onContinue={vi.fn()} onDefer={vi.fn()} />);
+
+    expect(screen.queryByTestId("workspace-next-steps")).not.toBeInTheDocument();
+  });
+});
+
+describe("WorkspaceNextStepsHeaderBadge", () => {
+  it("keeps the banner question next to the progress count", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    render(
+      <WorkspaceNextStepsHeaderBadge
+        progress="3/4"
+        title="How should failing status checks be handled?"
+        onOpen={onOpen}
+      />,
+    );
+
+    const restore = screen.getByTestId("workspace-next-steps-restore");
+    expect(restore).toHaveTextContent("3/4");
+    expect(restore).toHaveTextContent("How should failing status checks be handled?");
+    expect(restore).toHaveAccessibleName("Show next steps. How should failing status checks be handled?");
+    await user.click(restore);
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+});

--- a/web_src/src/pages/factories/pages/NextStepsPanel.spec.tsx
+++ b/web_src/src/pages/factories/pages/NextStepsPanel.spec.tsx
@@ -47,21 +47,15 @@ describe("NextStepsPanel", () => {
 });
 
 describe("WorkspaceNextStepsHeaderBadge", () => {
-  it("keeps the banner question next to the progress count", async () => {
+  it("keeps the call to action next to the progress count", async () => {
     const user = userEvent.setup();
     const onOpen = vi.fn();
-    render(
-      <WorkspaceNextStepsHeaderBadge
-        progress="3/4"
-        title="How should failing status checks be handled?"
-        onOpen={onOpen}
-      />,
-    );
+    render(<WorkspaceNextStepsHeaderBadge progress="3/4" title="Configure status checks" onOpen={onOpen} />);
 
     const restore = screen.getByTestId("workspace-next-steps-restore");
     expect(restore).toHaveTextContent("3/4");
-    expect(restore).toHaveTextContent("How should failing status checks be handled?");
-    expect(restore).toHaveAccessibleName("Show next steps. How should failing status checks be handled?");
+    expect(restore).toHaveTextContent("Configure status checks");
+    expect(restore).toHaveAccessibleName("Show next steps. Configure status checks");
     await user.click(restore);
     expect(onOpen).toHaveBeenCalledOnce();
   });

--- a/web_src/src/pages/factories/pages/NextStepsPanel.tsx
+++ b/web_src/src/pages/factories/pages/NextStepsPanel.tsx
@@ -1,8 +1,10 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { ArrowRight } from "lucide-react";
 
 import {
+  WORKSPACE_NEXT_STEPS_COPY,
   workspaceNextStepBanner,
   workspaceNextStepsProgressCopy,
   type WorkspaceNextStep,
@@ -10,50 +12,96 @@ import {
 
 export function NextStepsPanel({
   steps,
+  collapsed = false,
   onContinue,
+  onDefer,
 }: {
   steps: WorkspaceNextStep[];
+  collapsed?: boolean;
   onContinue: (step: WorkspaceNextStep) => void;
+  onDefer: () => void;
 }) {
   const banner = workspaceNextStepBanner(steps);
-  if (!banner) {
+  if (!banner || collapsed) {
     return null;
   }
 
   const progress = workspaceNextStepsProgressCopy(banner.doneCount, banner.totalCount);
 
   return (
-    <section className="px-3 pb-3" data-testid="workspace-next-steps">
+    <section className="workspace-next-steps-reveal px-3 pb-3" data-testid="workspace-next-steps">
       <div
         role="status"
-        className="flex items-center gap-3 rounded-lg border border-border bg-background px-3.5 py-3 sm:gap-4"
+        className="workspace-next-steps-banner flex items-center gap-3 rounded-lg border border-border bg-background px-3.5 py-3 sm:gap-4"
       >
-        <Badge
-          variant="secondary"
-          className="shrink-0 rounded-full px-3 py-1.5 text-[15px] font-semibold tabular-nums tracking-tight"
-          data-testid="workspace-next-steps-progress"
-        >
-          {progress}
-        </Badge>
+        <WorkspaceNextStepsProgressBadge progress={progress} />
         <div className="min-w-0">
-          <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-foreground">{banner.title}</h2>
+          <h2 className="workspace-next-steps-title text-[18px] font-semibold tracking-[-0.02em] text-foreground">
+            {banner.title}
+          </h2>
           {banner.description.split("\n").map((line) => (
             <p key={line} className="mt-1.5 text-[13px] text-muted-foreground">
               {line}
             </p>
           ))}
-          <Button
-            type="button"
-            size="sm"
-            className="mt-3"
-            onClick={() => onContinue(banner.activeStep)}
-            data-testid={`workspace-next-step-cta-${banner.activeStep.id}`}
-          >
-            {banner.ctaLabel}
-            <ArrowRight className="size-3.5" aria-hidden />
-          </Button>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            {banner.canDefer ? (
+              <Button type="button" size="sm" variant="ghost" onClick={onDefer} data-testid="workspace-next-step-later">
+                {WORKSPACE_NEXT_STEPS_COPY.later}
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => onContinue(banner.activeStep)}
+              data-testid={`workspace-next-step-cta-${banner.activeStep.id}`}
+            >
+              {banner.ctaLabel}
+              <ArrowRight className="size-3.5" aria-hidden />
+            </Button>
+          </div>
         </div>
       </div>
     </section>
+  );
+}
+
+export function WorkspaceNextStepsHeaderBadge({
+  progress,
+  title,
+  onOpen,
+}: {
+  progress: string;
+  title: string;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      aria-label={WORKSPACE_NEXT_STEPS_COPY.restoreLabel(title)}
+      data-testid="workspace-next-steps-restore"
+      className="inline-flex h-8 min-w-0 max-w-[min(32rem,46vw)] cursor-pointer items-center gap-2 rounded-full bg-secondary py-1 pl-1 pr-3 text-secondary-foreground hover:bg-secondary/80"
+    >
+      <WorkspaceNextStepsProgressBadge progress={progress} compact />
+      <span className="workspace-next-steps-title min-w-0 truncate text-[13px] font-medium tracking-[-0.01em]">
+        {title}
+      </span>
+    </button>
+  );
+}
+
+function WorkspaceNextStepsProgressBadge({ progress, compact = false }: { progress: string; compact?: boolean }) {
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        "workspace-next-steps-progress shrink-0 rounded-full font-semibold tabular-nums tracking-tight",
+        compact ? "h-6 bg-background px-2 text-[12px]" : "px-3 py-1.5 text-[15px]",
+      )}
+      data-testid={compact ? undefined : "workspace-next-steps-progress"}
+    >
+      {progress}
+    </Badge>
   );
 }

--- a/web_src/src/pages/factories/pages/PRFeedbackSettingsFields.tsx
+++ b/web_src/src/pages/factories/pages/PRFeedbackSettingsFields.tsx
@@ -53,6 +53,7 @@ export function PRFeedbackTextField({
   type = "text",
   min,
   max,
+  step,
 }: {
   id: string;
   label: string;
@@ -62,6 +63,7 @@ export function PRFeedbackTextField({
   type?: "text" | "number";
   min?: number;
   max?: number;
+  step?: number;
 }) {
   return (
     <section>
@@ -73,6 +75,7 @@ export function PRFeedbackTextField({
         type={type}
         min={min}
         max={max}
+        step={step}
         value={value}
         onChange={(event) => onChange(event.target.value)}
         data-testid={id}
@@ -118,6 +121,7 @@ export function PRFeedbackChecksFields({
         type="number"
         min={1}
         max={10}
+        step={1}
         onChange={(value) => onUpdate("maximumAttempts", Number(value))}
       />
       <PRFeedbackIntegrationsField

--- a/web_src/src/pages/factories/pages/checksPRFeedbackSetup.spec.ts
+++ b/web_src/src/pages/factories/pages/checksPRFeedbackSetup.spec.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   catalogStatusCheckNames,
+  checksToolsAccess,
+  isGitHubActionsCheckURL,
+  selectedChecksUseGitHubActions,
   suggestedIntegrationsForChecks,
   suggestIntegrationFromCheckURL,
 } from "./checksPRFeedbackSetup";
@@ -18,6 +21,15 @@ describe("checksPRFeedbackSetup helpers", () => {
     expect(suggestIntegrationFromCheckURL("")).toBe("");
   });
 
+  it("detects GitHub Actions check urls", () => {
+    expect(isGitHubActionsCheckURL("https://github.com/acme/api/actions/runs/99")).toBe(true);
+    expect(isGitHubActionsCheckURL("https://github.com/acme/api/actions/runs/99/job/12")).toBe(true);
+    expect(isGitHubActionsCheckURL("https://api.github.com/repos/acme/api/actions/runs/99")).toBe(true);
+    expect(isGitHubActionsCheckURL("https://github.com/acme/api/pull/12")).toBe(false);
+    expect(isGitHubActionsCheckURL("https://app.circleci.com/pipelines/1")).toBe(false);
+    expect(isGitHubActionsCheckURL("")).toBe(false);
+  });
+
   it("keeps only common status-check integrations", () => {
     expect(
       suggestedIntegrationsForChecks(
@@ -32,5 +44,21 @@ describe("checksPRFeedbackSetup helpers", () => {
     expect(
       suggestedIntegrationsForChecks([{ name: "lint", url: "https://ci.example.com/job/lint" }], ["lint"]),
     ).toEqual([]);
+  });
+
+  it("detects when selected checks use GitHub Actions", () => {
+    const catalog = [
+      { name: "build", url: "https://github.com/acme/api/actions/runs/1" },
+      { name: "e2e", url: "https://app.circleci.com/pipelines/1" },
+    ];
+    expect(selectedChecksUseGitHubActions(catalog, ["build"])).toBe(true);
+    expect(selectedChecksUseGitHubActions(catalog, ["e2e"])).toBe(false);
+    expect(selectedChecksUseGitHubActions(catalog, ["build", "e2e"])).toBe(true);
+  });
+
+  it("classifies tools-step access from suggestions and GitHub Actions", () => {
+    expect(checksToolsAccess(["circleci"], true)).toBe("suggested");
+    expect(checksToolsAccess([], true)).toBe("github-actions");
+    expect(checksToolsAccess([], false)).toBe("none");
   });
 });

--- a/web_src/src/pages/factories/pages/checksPRFeedbackSetup.ts
+++ b/web_src/src/pages/factories/pages/checksPRFeedbackSetup.ts
@@ -13,19 +13,11 @@ export function catalogStatusCheckNames(catalog: OrganizationsIntegrationResourc
 }
 
 export function suggestIntegrationFromCheckURL(rawURL: string | undefined): string {
-  const value = rawURL?.trim();
-  if (!value) {
+  const parsed = parseCheckURL(rawURL);
+  if (!parsed) {
     return "";
   }
-  let host: string;
-  try {
-    host = new URL(value).hostname.toLowerCase();
-  } catch {
-    return "";
-  }
-  if (!host) {
-    return "";
-  }
+  const host = parsed.hostname.toLowerCase();
   if (hostHasSuffix(host, "semaphoreci.com") || hostHasSuffix(host, "semaphore.com")) {
     return "semaphore";
   }
@@ -36,6 +28,54 @@ export function suggestIntegrationFromCheckURL(rawURL: string | undefined): stri
     return "harness";
   }
   return "";
+}
+
+export function isGitHubActionsCheckURL(rawURL: string | undefined): boolean {
+  const parsed = parseCheckURL(rawURL);
+  if (!parsed) {
+    return false;
+  }
+  if (!hostHasSuffix(parsed.hostname, "github.com")) {
+    return false;
+  }
+  return parsed.pathname.toLowerCase().includes("/actions/");
+}
+
+export function selectedChecksUseGitHubActions(
+  catalog: OrganizationsIntegrationResourceRef[],
+  selectedNames: string[],
+): boolean {
+  const selected = new Set(selectedNames.map((name) => name.toLowerCase()));
+  return catalog.some((check) => {
+    if (!check.name || !selected.has(check.name.toLowerCase())) {
+      return false;
+    }
+    return isGitHubActionsCheckURL(check.url);
+  });
+}
+
+export type ChecksToolsAccess = "suggested" | "github-actions" | "none";
+
+export function checksToolsAccess(suggestedNames: string[], usesGitHubActions: boolean): ChecksToolsAccess {
+  if (suggestedNames.length > 0) {
+    return "suggested";
+  }
+  if (usesGitHubActions) {
+    return "github-actions";
+  }
+  return "none";
+}
+
+function parseCheckURL(rawURL: string | undefined): URL | undefined {
+  const value = rawURL?.trim();
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return new URL(value);
+  } catch {
+    return undefined;
+  }
 }
 
 function hostHasSuffix(host: string, suffix: string): boolean {

--- a/web_src/src/pages/factories/pages/prFeedbackSettingsCopy.ts
+++ b/web_src/src/pages/factories/pages/prFeedbackSettingsCopy.ts
@@ -18,6 +18,8 @@ export const PR_FEEDBACK_SETTINGS_COPY = {
   checkNamesHelper: "Select the status checks SuperPlane must wait for and automatically attempt to fix.",
   checkNamesNone: "Select at least one status check.",
   checkNamesCatalogEmpty: "No status checks found.",
+  wizardChecksEmpty: "This repository does not have status checks yet. That is OK.",
+  wizardChecksEmptyDetail: "After you add them, you can configure SuperPlane to fix them automatically.",
   checkNamesLoading: "Loading status checks",
   checkNamesLoadingDetail: "Reading recent pull requests and the required status checks for this repository...",
   checkNamesLoadingMore: "Loading other status checks...",
@@ -54,6 +56,9 @@ export const PR_FEEDBACK_SETTINGS_COPY = {
   wizardBotsAdd: "Add",
   wizardToolsDescription:
     "Connect the external tools reporting the status checks so the agent fixing the issues has enough access to troubleshoot the issues.",
+  wizardToolsNoAccess: "The selected status checks do not need additional access.",
+  wizardToolsGitHubActions: "These checks use GitHub Actions. SuperPlane does not need additional access.",
+  wizardToolsGitHubActionsNote: "GitHub Actions does not need additional access.",
   wizardToolsUnknown:
     "SuperPlane could not match these checks to a CI tool. The agent may not have enough context to fix them.",
   wizardToolsUnselected: "Some of the checks you selected require additional access that you are not granting.",
@@ -62,7 +67,8 @@ export const PR_FEEDBACK_SETTINGS_COPY = {
   wizardFinish: "Finish",
   wizardFinishing: "Finishing...",
   wizardConnect: "Connect",
-  wizardSuggested: "Suggested from the selected checks",
+  wizardSuggestedHelper: "Based on the status checks you selected, SuperPlane needs access to these tools.",
+  wizardSuggestedHelperDetail: "Grant that access so the agent can read CI logs and fix failing checks.",
   wizardOtherTools: "Other CI tools",
   maximumAttemptsLabel: "Maximum automatic fix attempts",
   maximumAttemptsHelper:

--- a/web_src/src/pages/factories/pages/prFeedbackSettingsCopy.ts
+++ b/web_src/src/pages/factories/pages/prFeedbackSettingsCopy.ts
@@ -71,6 +71,7 @@ export const PR_FEEDBACK_SETTINGS_COPY = {
   wizardSuggestedHelperDetail: "Grant that access so the agent can read CI logs and fix failing checks.",
   wizardOtherTools: "Other CI tools",
   maximumAttemptsLabel: "Maximum automatic fix attempts",
+  wizardMaximumAttempts: "How many times should SuperPlane try before giving up?",
   maximumAttemptsHelper:
     "SuperPlane pauses automatic fixes after this many consecutive attempts. Passing checks reset the count.",
   integrationsLabel: "Additional integration access",

--- a/web_src/src/pages/factories/pages/prFeedbackSettingsModel.spec.ts
+++ b/web_src/src/pages/factories/pages/prFeedbackSettingsModel.spec.ts
@@ -394,6 +394,17 @@ describe("prFeedbackDraftIsValid", () => {
         }),
       ),
     ).toBe(false);
+    expect(
+      prFeedbackDraftIsValid(
+        discussionDraft({
+          source: "checks",
+          name: "Fix pull request checks",
+          mention: "",
+          checkNames: ["lint"],
+          maximumAttempts: 5.5,
+        }),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/web_src/src/pages/factories/pages/prFeedbackSettingsModel.ts
+++ b/web_src/src/pages/factories/pages/prFeedbackSettingsModel.ts
@@ -209,13 +209,22 @@ function normalizeUniqueStrings(values: string[]): string[] {
   return normalized;
 }
 
+export const PR_FEEDBACK_MAXIMUM_ATTEMPTS_MIN = 1;
+export const PR_FEEDBACK_MAXIMUM_ATTEMPTS_MAX = 10;
+
+export function isPRFeedbackMaximumAttemptsValid(value: number): boolean {
+  return (
+    Number.isInteger(value) && value >= PR_FEEDBACK_MAXIMUM_ATTEMPTS_MIN && value <= PR_FEEDBACK_MAXIMUM_ATTEMPTS_MAX
+  );
+}
+
 export function prFeedbackDraftIsValid(draft: PRFeedbackDraftSettings): boolean {
   const next = normalizePRFeedbackDraft(draft);
   if (next.name.length === 0 || next.repository.length === 0) {
     return false;
   }
   if (next.source === "checks") {
-    return next.checkNames.length > 0 && next.maximumAttempts >= 1 && next.maximumAttempts <= 10;
+    return next.checkNames.length > 0 && isPRFeedbackMaximumAttemptsValid(next.maximumAttempts);
   }
   return next.mention.length === 0 || next.mention.startsWith("@");
 }

--- a/web_src/src/pages/factories/pages/prFeedbackSettingsModel.ts
+++ b/web_src/src/pages/factories/pages/prFeedbackSettingsModel.ts
@@ -55,9 +55,6 @@ export const PR_FEEDBACK_SOURCES: PRFeedbackSource[] = [
   },
 ];
 
-/** Hide the status-checks next step until that post-onboarding prompt is ready. */
-export const CHECKS_PR_FEEDBACK_NEXT_STEP_AVAILABLE = false;
-
 export function availablePRFeedbackSources(): PRFeedbackSource[] {
   return PR_FEEDBACK_SOURCES;
 }

--- a/web_src/src/pages/factories/pages/useChecksPRFeedbackSetup.ts
+++ b/web_src/src/pages/factories/pages/useChecksPRFeedbackSetup.ts
@@ -27,6 +27,7 @@ export function useChecksPRFeedbackSetup(
 ) {
   const [step, setStep] = useState<"checks" | "tools">("checks");
   const [checkNames, setCheckNames] = useState<string[]>([]);
+  const [maximumAttempts, setMaximumAttempts] = useState(3);
   const [runnerIntegrationIds, setRunnerIntegrationIds] = useState<string[]>([]);
   const [connectName, setConnectName] = useState<string | null>(null);
   const [error, setError] = useState<string>();
@@ -88,7 +89,7 @@ export function useChecksPRFeedbackSetup(
           subject: repository ? { repository } : undefined,
           checks: {
             names: checkNames,
-            maximumAttempts: 3,
+            maximumAttempts,
             runnerIntegrationIds,
           },
         },
@@ -109,7 +110,9 @@ export function useChecksPRFeedbackSetup(
     catalogQuery,
     catalogLoading,
     catalogEmpty,
-    canContinue: !catalogLoading && checkNames.length > 0,
+    canContinue: !catalogLoading && checkNames.length > 0 && maximumAttempts >= 1 && maximumAttempts <= 10,
+    maximumAttempts,
+    setMaximumAttempts,
     usesGitHubActions,
     toolsAccess,
     runnerIntegrationIds,

--- a/web_src/src/pages/factories/pages/useChecksPRFeedbackSetup.ts
+++ b/web_src/src/pages/factories/pages/useChecksPRFeedbackSetup.ts
@@ -17,7 +17,12 @@ import {
   selectedChecksUseGitHubActions,
   suggestedIntegrationsForChecks,
 } from "./checksPRFeedbackSetup";
-import { PR_FEEDBACK_SETTINGS_COPY, toggleUniqueString, type PRFeedbackSource } from "./prFeedbackSettingsModel";
+import {
+  isPRFeedbackMaximumAttemptsValid,
+  PR_FEEDBACK_SETTINGS_COPY,
+  toggleUniqueString,
+  type PRFeedbackSource,
+} from "./prFeedbackSettingsModel";
 
 export function useChecksPRFeedbackSetup(
   organizationId: string,
@@ -26,13 +31,79 @@ export function useChecksPRFeedbackSetup(
   repository: string,
 ) {
   const [step, setStep] = useState<"checks" | "tools">("checks");
-  const [checkNames, setCheckNames] = useState<string[]>([]);
   const [maximumAttempts, setMaximumAttempts] = useState(3);
-  const [runnerIntegrationIds, setRunnerIntegrationIds] = useState<string[]>([]);
   const [connectName, setConnectName] = useState<string | null>(null);
   const [error, setError] = useState<string>();
-  const [seeded, setSeeded] = useState({ catalog: false, connected: false });
+  const resources = useChecksSetupResources(organizationId, factoryId, githubIntegrationId, repository);
+  const suggestedNames = useMemo(
+    () => suggestedIntegrationsForChecks(resources.catalog, resources.checkNames),
+    [resources.catalog, resources.checkNames],
+  );
+  const usesGitHubActions = useMemo(
+    () => selectedChecksUseGitHubActions(resources.catalog, resources.checkNames),
+    [resources.catalog, resources.checkNames],
+  );
+  const toolsAccess = checksToolsAccess(suggestedNames, usesGitHubActions);
+  const connectDefinition = resources.available.find((integration) => integration.name === connectName) ?? null;
 
+  const finish = (source: PRFeedbackSource) =>
+    finishChecksSetup({
+      repository,
+      source,
+      checkNames: resources.checkNames,
+      maximumAttempts,
+      runnerIntegrationIds: resources.runnerIntegrationIds,
+      createHandler: resources.createHandler,
+      setError,
+    });
+
+  return {
+    step,
+    setStep,
+    checkNames: resources.checkNames,
+    toggleCheckName: resources.toggleCheckName,
+    catalog: resources.catalog,
+    catalogQuery: resources.catalogQuery,
+    catalogLoading: resources.catalogLoading,
+    catalogEmpty: resources.catalogEmpty,
+    canContinue:
+      !resources.catalogLoading && resources.checkNames.length > 0 && isPRFeedbackMaximumAttemptsValid(maximumAttempts),
+    maximumAttempts,
+    setMaximumAttempts,
+    usesGitHubActions,
+    toolsAccess,
+    runnerIntegrationIds: resources.runnerIntegrationIds,
+    setRunnerIntegrationIds: resources.setRunnerIntegrationIds,
+    suggestedNames,
+    available: resources.available,
+    connected: resources.connected,
+    connectedQuery: resources.connectedQuery,
+    connectName,
+    setConnectName,
+    connectDefinition,
+    existingNames: resources.existingNames,
+    createIntegration: resources.createIntegration,
+    error,
+    createHandler: resources.createHandler,
+    finish,
+  };
+}
+
+export type ChecksPRFeedbackSetupModel = ReturnType<typeof useChecksPRFeedbackSetup>;
+
+export function integrationDefinitionLabel(definition: IntegrationsIntegrationDefinition | null): string {
+  return definition?.label || definition?.name || "integration";
+}
+
+function useChecksSetupResources(
+  organizationId: string,
+  factoryId: string,
+  githubIntegrationId: string,
+  repository: string,
+) {
+  const [checkNames, setCheckNames] = useState<string[]>([]);
+  const [runnerIntegrationIds, setRunnerIntegrationIds] = useState<string[]>([]);
+  const [seeded, setSeeded] = useState({ catalog: false, connected: false });
   const catalogParameters = repository.trim() ? { repository: repository.trim() } : undefined;
   const catalogQuery = useIntegrationResources(organizationId, githubIntegrationId, "status_check", catalogParameters);
   const catalog = useMemo(() => catalogQuery.data ?? [], [catalogQuery.data]);
@@ -60,80 +131,68 @@ export function useChecksPRFeedbackSetup(
     setSeeded((current) => ({ ...current, connected: true }));
   }, [connected, connectedLoading, seeded.connected]);
 
-  const suggestedNames = useMemo(() => suggestedIntegrationsForChecks(catalog, checkNames), [catalog, checkNames]);
-  const usesGitHubActions = useMemo(() => selectedChecksUseGitHubActions(catalog, checkNames), [catalog, checkNames]);
-  const toolsAccess = checksToolsAccess(suggestedNames, usesGitHubActions);
   const catalogEmpty = !catalogLoading && !catalogQuery.isError && catalog.length === 0;
   const available = (availableQuery.data ?? []).filter((integration) => isChecksHandlerCIIntegration(integration.name));
   const existingNames = useMemo(
     () => new Set(connected.map((item) => item.metadata?.name?.trim()).filter((name): name is string => Boolean(name))),
     [connected],
   );
-  const connectDefinition = available.find((integration) => integration.name === connectName) ?? null;
-
-  const toggleCheckName = (name: string) => {
-    setCheckNames((current) => toggleUniqueString(current, name));
-  };
-
-  const finish = async (source: PRFeedbackSource) => {
-    if (checkNames.length === 0) {
-      setError(PR_FEEDBACK_SETTINGS_COPY.checkNamesNone);
-      return undefined;
-    }
-    setError(undefined);
-    try {
-      const handler = await createHandler.mutateAsync({
-        source: "SOURCE_PULL_REQUEST_CHECKS",
-        name: source.defaultName,
-        settings: {
-          subject: repository ? { repository } : undefined,
-          checks: {
-            names: checkNames,
-            maximumAttempts,
-            runnerIntegrationIds,
-          },
-        },
-      });
-      return handler;
-    } catch (cause) {
-      setError(getApiErrorMessage(cause, PR_FEEDBACK_SETTINGS_COPY.createError));
-      return undefined;
-    }
-  };
 
   return {
-    step,
-    setStep,
     checkNames,
-    toggleCheckName,
+    toggleCheckName: (name: string) => setCheckNames((current) => toggleUniqueString(current, name)),
     catalog,
     catalogQuery,
     catalogLoading,
     catalogEmpty,
-    canContinue: !catalogLoading && checkNames.length > 0 && maximumAttempts >= 1 && maximumAttempts <= 10,
-    maximumAttempts,
-    setMaximumAttempts,
-    usesGitHubActions,
-    toolsAccess,
     runnerIntegrationIds,
     setRunnerIntegrationIds,
-    suggestedNames,
     available,
     connected,
     connectedQuery,
-    connectName,
-    setConnectName,
-    connectDefinition,
     existingNames,
     createIntegration,
-    error,
     createHandler,
-    finish,
   };
 }
 
-export type ChecksPRFeedbackSetupModel = ReturnType<typeof useChecksPRFeedbackSetup>;
-
-export function integrationDefinitionLabel(definition: IntegrationsIntegrationDefinition | null): string {
-  return definition?.label || definition?.name || "integration";
+async function finishChecksSetup({
+  repository,
+  source,
+  checkNames,
+  maximumAttempts,
+  runnerIntegrationIds,
+  createHandler,
+  setError,
+}: {
+  repository: string;
+  source: PRFeedbackSource;
+  checkNames: string[];
+  maximumAttempts: number;
+  runnerIntegrationIds: string[];
+  createHandler: ReturnType<typeof useCreateFactoryPRFeedbackHandler>;
+  setError: (error: string | undefined) => void;
+}) {
+  if (checkNames.length === 0) {
+    setError(PR_FEEDBACK_SETTINGS_COPY.checkNamesNone);
+    return undefined;
+  }
+  setError(undefined);
+  try {
+    return await createHandler.mutateAsync({
+      source: "SOURCE_PULL_REQUEST_CHECKS",
+      name: source.defaultName,
+      settings: {
+        subject: repository ? { repository } : undefined,
+        checks: {
+          names: checkNames,
+          maximumAttempts,
+          runnerIntegrationIds,
+        },
+      },
+    });
+  } catch (cause) {
+    setError(getApiErrorMessage(cause, PR_FEEDBACK_SETTINGS_COPY.createError));
+    return undefined;
+  }
 }

--- a/web_src/src/pages/factories/pages/useChecksPRFeedbackSetup.ts
+++ b/web_src/src/pages/factories/pages/useChecksPRFeedbackSetup.ts
@@ -11,8 +11,10 @@ import { useEffect, useMemo, useState } from "react";
 
 import {
   catalogStatusCheckNames,
+  checksToolsAccess,
   isChecksHandlerCIIntegration,
   readyChecksHandlerIntegrationIds,
+  selectedChecksUseGitHubActions,
   suggestedIntegrationsForChecks,
 } from "./checksPRFeedbackSetup";
 import { PR_FEEDBACK_SETTINGS_COPY, toggleUniqueString, type PRFeedbackSource } from "./prFeedbackSettingsModel";
@@ -58,6 +60,9 @@ export function useChecksPRFeedbackSetup(
   }, [connected, connectedLoading, seeded.connected]);
 
   const suggestedNames = useMemo(() => suggestedIntegrationsForChecks(catalog, checkNames), [catalog, checkNames]);
+  const usesGitHubActions = useMemo(() => selectedChecksUseGitHubActions(catalog, checkNames), [catalog, checkNames]);
+  const toolsAccess = checksToolsAccess(suggestedNames, usesGitHubActions);
+  const catalogEmpty = !catalogLoading && !catalogQuery.isError && catalog.length === 0;
   const available = (availableQuery.data ?? []).filter((integration) => isChecksHandlerCIIntegration(integration.name));
   const existingNames = useMemo(
     () => new Set(connected.map((item) => item.metadata?.name?.trim()).filter((name): name is string => Boolean(name))),
@@ -103,7 +108,10 @@ export function useChecksPRFeedbackSetup(
     catalog,
     catalogQuery,
     catalogLoading,
+    catalogEmpty,
     canContinue: !catalogLoading && checkNames.length > 0,
+    usesGitHubActions,
+    toolsAccess,
     runnerIntegrationIds,
     setRunnerIntegrationIds,
     suggestedNames,

--- a/web_src/src/pages/factories/pages/workspaceNextStepCatalog.ts
+++ b/web_src/src/pages/factories/pages/workspaceNextStepCatalog.ts
@@ -10,6 +10,8 @@ export interface WorkspaceNextStep {
   title: string;
   /** Banner header when this step is the next action. */
   bannerTitle: string;
+  /** Short call to action for the minimized header badge. */
+  badgeLabel: string;
   /** Banner body when this step is the next action. */
   description: string;
   ctaLabel: string;
@@ -33,6 +35,7 @@ export interface WorkspaceNextStepBanner {
   /** First incomplete step; drives the single CTA. */
   activeStep: WorkspaceNextStep;
   title: string;
+  badgeLabel: string;
   description: string;
   ctaLabel: string;
   canDefer: boolean;
@@ -49,6 +52,7 @@ const COMMENTS_NEXT_STEP: WorkspaceNextStepDefinition = {
   id: "pr-comments-handler",
   title: "Comments handler",
   bannerTitle: PR_FEEDBACK_SETTINGS_COPY.wizardPageTitleComments,
+  badgeLabel: "Configure pull request comments",
   description: "SuperPlane can implement tasks and open pull requests, but pull request reviews are not handled yet.",
   ctaLabel: "Configure",
   canDefer: false,
@@ -60,6 +64,7 @@ const CHECKS_NEXT_STEP: WorkspaceNextStepDefinition = {
   id: "pr-checks-handler",
   title: "Status checks handler",
   bannerTitle: PR_FEEDBACK_SETTINGS_COPY.wizardPageTitleChecks,
+  badgeLabel: "Configure status checks",
   description: [
     "SuperPlane can implement tasks, open pull requests, and address pull request reviews.",
     "Do you also want SuperPlane to automatically fix failing pull request status checks?",
@@ -105,6 +110,7 @@ export function workspaceNextStepBanner(steps: WorkspaceNextStep[]): WorkspaceNe
     totalCount: ONBOARDING_COMPLETED_STEP_COUNT + steps.length,
     activeStep,
     title: activeStep.bannerTitle,
+    badgeLabel: activeStep.badgeLabel,
     description: activeStep.description,
     ctaLabel: activeStep.ctaLabel,
     canDefer: activeStep.canDefer,

--- a/web_src/src/pages/factories/pages/workspaceNextStepCatalog.ts
+++ b/web_src/src/pages/factories/pages/workspaceNextStepCatalog.ts
@@ -25,7 +25,7 @@ export interface WorkspaceNextStepContext {
   onboardingComplete: boolean;
   canConfigure: boolean;
   takenPRFeedbackSources: readonly PRFeedbackSourceId[];
-  /** Stay hidden until PR feedback handlers have loaded. */
+  /** Stay hidden until PR feedback handlers have loaded. Also hide when the query fails without cached data. */
   ready?: boolean;
 }
 
@@ -84,6 +84,17 @@ const WORKSPACE_NEXT_STEPS = [COMMENTS_NEXT_STEP, CHECKS_NEXT_STEP];
 
 export function workspaceNextStepsProgressCopy(done: number, total: number): string {
   return `${done}/${total}`;
+}
+
+export function isWorkspaceNextStepsQueryReady(query: {
+  isPending: boolean;
+  isError?: boolean;
+  data?: unknown;
+}): boolean {
+  if (query.isPending) {
+    return false;
+  }
+  return query.data !== undefined || query.isError !== true;
 }
 
 export function workspaceNextSteps(ctx: WorkspaceNextStepContext): WorkspaceNextStep[] {

--- a/web_src/src/pages/factories/pages/workspaceNextStepCatalog.ts
+++ b/web_src/src/pages/factories/pages/workspaceNextStepCatalog.ts
@@ -1,8 +1,4 @@
-import {
-  CHECKS_PR_FEEDBACK_NEXT_STEP_AVAILABLE,
-  PR_FEEDBACK_SETTINGS_COPY,
-  type PRFeedbackSourceId,
-} from "./prFeedbackSettingsModel";
+import { PR_FEEDBACK_SETTINGS_COPY, type PRFeedbackSourceId } from "./prFeedbackSettingsModel";
 
 export type WorkspaceNextStepId = "pr-comments-handler" | "pr-checks-handler";
 
@@ -17,6 +13,8 @@ export interface WorkspaceNextStep {
   /** Banner body when this step is the next action. */
   description: string;
   ctaLabel: string;
+  /** Optional steps can hide the banner without completing the task. */
+  canDefer: boolean;
   action: WorkspaceNextStepAction;
   done: boolean;
 }
@@ -25,6 +23,8 @@ export interface WorkspaceNextStepContext {
   onboardingComplete: boolean;
   canConfigure: boolean;
   takenPRFeedbackSources: readonly PRFeedbackSourceId[];
+  /** Stay hidden until PR feedback handlers have loaded. */
+  ready?: boolean;
 }
 
 export interface WorkspaceNextStepBanner {
@@ -35,6 +35,7 @@ export interface WorkspaceNextStepBanner {
   title: string;
   description: string;
   ctaLabel: string;
+  canDefer: boolean;
 }
 
 /** GitHub and the repository are already set during onboarding. */
@@ -50,6 +51,7 @@ const COMMENTS_NEXT_STEP: WorkspaceNextStepDefinition = {
   bannerTitle: PR_FEEDBACK_SETTINGS_COPY.wizardPageTitleComments,
   description: "SuperPlane can implement tasks and open pull requests, but pull request reviews are not handled yet.",
   ctaLabel: "Configure",
+  canDefer: false,
   action: { type: "open-pr-feedback-setup", sourceId: "discussion" },
   isDone: (ctx) => ctx.takenPRFeedbackSources.includes("discussion"),
 };
@@ -63,21 +65,24 @@ const CHECKS_NEXT_STEP: WorkspaceNextStepDefinition = {
     "Do you also want SuperPlane to automatically fix failing pull request status checks?",
   ].join("\n"),
   ctaLabel: "Configure",
+  canDefer: true,
   action: { type: "open-pr-feedback-setup", sourceId: "checks" },
   isDone: (ctx) => ctx.takenPRFeedbackSources.includes("checks"),
 };
 
-const WORKSPACE_NEXT_STEPS = [
-  COMMENTS_NEXT_STEP,
-  ...(CHECKS_PR_FEEDBACK_NEXT_STEP_AVAILABLE ? [CHECKS_NEXT_STEP] : []),
-];
+export const WORKSPACE_NEXT_STEPS_COPY = {
+  later: "Later",
+  restoreLabel: (title: string) => `Show next steps. ${title}`,
+} as const;
+
+const WORKSPACE_NEXT_STEPS = [COMMENTS_NEXT_STEP, CHECKS_NEXT_STEP];
 
 export function workspaceNextStepsProgressCopy(done: number, total: number): string {
   return `${done}/${total}`;
 }
 
 export function workspaceNextSteps(ctx: WorkspaceNextStepContext): WorkspaceNextStep[] {
-  if (!ctx.onboardingComplete || !ctx.canConfigure) {
+  if (ctx.ready === false || !ctx.onboardingComplete || !ctx.canConfigure) {
     return [];
   }
   const steps = WORKSPACE_NEXT_STEPS.map(({ isDone, ...step }) => ({
@@ -102,7 +107,22 @@ export function workspaceNextStepBanner(steps: WorkspaceNextStep[]): WorkspaceNe
     title: activeStep.bannerTitle,
     description: activeStep.description,
     ctaLabel: activeStep.ctaLabel,
+    canDefer: activeStep.canDefer,
   };
+}
+
+export function isWorkspaceNextStepDeferred(
+  banner: WorkspaceNextStepBanner | null,
+  deferredStepId: WorkspaceNextStepId | null,
+): boolean {
+  return Boolean(banner?.canDefer && deferredStepId === banner.activeStep.id);
+}
+
+export function shouldForgetDeferredWorkspaceNextStep(
+  deferredStepId: WorkspaceNextStepId | null,
+  takenPRFeedbackSources: readonly PRFeedbackSourceId[],
+): boolean {
+  return deferredStepId === "pr-checks-handler" && takenPRFeedbackSources.includes("checks");
 }
 
 export function runWorkspaceNextStepAction(

--- a/web_src/src/pages/factories/pages/workspaceNextStepDeferral.spec.ts
+++ b/web_src/src/pages/factories/pages/workspaceNextStepDeferral.spec.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  readDeferredWorkspaceNextStep,
+  useWorkspaceNextStepDeferral,
+  WORKSPACE_NEXT_STEP_DEFERRAL_STORAGE_KEY,
+  writeDeferredWorkspaceNextStep,
+} from "./workspaceNextStepDeferral";
+
+vi.mock("./workspaceNextStepTransition", () => ({
+  runWorkspaceNextStepTransition: (update: () => void) => {
+    update();
+  },
+}));
+
+describe("workspaceNextStepDeferral", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("reads and writes a deferred step for one workspace", () => {
+    expect(readDeferredWorkspaceNextStep("factory-1")).toBeNull();
+    writeDeferredWorkspaceNextStep("factory-1", "pr-checks-handler");
+    expect(readDeferredWorkspaceNextStep("factory-1")).toBe("pr-checks-handler");
+    expect(readDeferredWorkspaceNextStep("factory-2")).toBeNull();
+  });
+
+  it("clears a stored step", () => {
+    writeDeferredWorkspaceNextStep("factory-1", "pr-checks-handler");
+    writeDeferredWorkspaceNextStep("factory-1", null);
+    expect(readDeferredWorkspaceNextStep("factory-1")).toBeNull();
+    expect(window.localStorage.getItem(WORKSPACE_NEXT_STEP_DEFERRAL_STORAGE_KEY)).toBeNull();
+  });
+
+  it("defers and restores through the hook", () => {
+    const { result } = renderHook(() => useWorkspaceNextStepDeferral("factory-1"));
+
+    expect(result.current.deferredStepId).toBeNull();
+    act(() => {
+      result.current.defer("pr-checks-handler");
+    });
+    expect(result.current.deferredStepId).toBe("pr-checks-handler");
+    expect(readDeferredWorkspaceNextStep("factory-1")).toBe("pr-checks-handler");
+
+    act(() => {
+      result.current.restore();
+    });
+    expect(result.current.deferredStepId).toBeNull();
+    expect(readDeferredWorkspaceNextStep("factory-1")).toBeNull();
+  });
+
+  it("reads a stored deferral on the first render", () => {
+    writeDeferredWorkspaceNextStep("factory-1", "pr-checks-handler");
+    const { result } = renderHook(() => useWorkspaceNextStepDeferral("factory-1"));
+    expect(result.current.deferredStepId).toBe("pr-checks-handler");
+  });
+
+  it("loads the stored step when the workspace changes", () => {
+    writeDeferredWorkspaceNextStep("factory-2", "pr-checks-handler");
+    const { result, rerender } = renderHook(({ factoryId }) => useWorkspaceNextStepDeferral(factoryId), {
+      initialProps: { factoryId: "factory-1" },
+    });
+
+    expect(result.current.deferredStepId).toBeNull();
+    rerender({ factoryId: "factory-2" });
+    expect(result.current.deferredStepId).toBe("pr-checks-handler");
+  });
+});

--- a/web_src/src/pages/factories/pages/workspaceNextStepDeferral.ts
+++ b/web_src/src/pages/factories/pages/workspaceNextStepDeferral.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { WorkspaceNextStepId } from "./workspaceNextStepCatalog";
+import { runWorkspaceNextStepTransition } from "./workspaceNextStepTransition";
+
+export const WORKSPACE_NEXT_STEP_DEFERRAL_STORAGE_KEY = "sp:workspace-next-steps-deferred:v1";
+
+type DeferredByFactory = Record<string, WorkspaceNextStepId>;
+
+function isWorkspaceNextStepId(value: unknown): value is WorkspaceNextStepId {
+  return value === "pr-comments-handler" || value === "pr-checks-handler";
+}
+
+function readStore(): DeferredByFactory {
+  try {
+    const raw = window.localStorage.getItem(WORKSPACE_NEXT_STEP_DEFERRAL_STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return {};
+    }
+    const store: DeferredByFactory = {};
+    for (const [factoryId, stepId] of Object.entries(parsed)) {
+      if (factoryId && isWorkspaceNextStepId(stepId)) {
+        store[factoryId] = stepId;
+      }
+    }
+    return store;
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: DeferredByFactory): void {
+  try {
+    if (Object.keys(store).length === 0) {
+      window.localStorage.removeItem(WORKSPACE_NEXT_STEP_DEFERRAL_STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(WORKSPACE_NEXT_STEP_DEFERRAL_STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // Ignore storage failures (private mode, quota, etc.).
+  }
+}
+
+export function readDeferredWorkspaceNextStep(factoryId: string): WorkspaceNextStepId | null {
+  if (!factoryId) {
+    return null;
+  }
+  return readStore()[factoryId] ?? null;
+}
+
+export function writeDeferredWorkspaceNextStep(factoryId: string, stepId: WorkspaceNextStepId | null): void {
+  if (!factoryId) {
+    return;
+  }
+  const store = readStore();
+  if (stepId) {
+    store[factoryId] = stepId;
+  } else {
+    delete store[factoryId];
+  }
+  writeStore(store);
+}
+
+export function useWorkspaceNextStepDeferral(factoryId: string): {
+  deferredStepId: WorkspaceNextStepId | null;
+  defer: (stepId: WorkspaceNextStepId) => void;
+  restore: () => void;
+  forget: () => void;
+} {
+  const [deferredStepId, setDeferredStepId] = useState<WorkspaceNextStepId | null>(() =>
+    readDeferredWorkspaceNextStep(factoryId),
+  );
+
+  useEffect(() => {
+    setDeferredStepId(readDeferredWorkspaceNextStep(factoryId));
+  }, [factoryId]);
+
+  const persist = useCallback(
+    (stepId: WorkspaceNextStepId | null) => {
+      setDeferredStepId(stepId);
+      writeDeferredWorkspaceNextStep(factoryId, stepId);
+    },
+    [factoryId],
+  );
+
+  const defer = useCallback(
+    (stepId: WorkspaceNextStepId) => {
+      runWorkspaceNextStepTransition(() => {
+        persist(stepId);
+      });
+    },
+    [persist],
+  );
+
+  const restore = useCallback(() => {
+    runWorkspaceNextStepTransition(() => {
+      persist(null);
+    });
+  }, [persist]);
+
+  const forget = useCallback(() => {
+    persist(null);
+  }, [persist]);
+
+  return { deferredStepId, defer, restore, forget };
+}

--- a/web_src/src/pages/factories/pages/workspaceNextStepTransition.spec.ts
+++ b/web_src/src/pages/factories/pages/workspaceNextStepTransition.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runWorkspaceNextStepTransition } from "./workspaceNextStepTransition";
+
+describe("runWorkspaceNextStepTransition", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("updates immediately when view transitions are not available", () => {
+    const update = vi.fn();
+    vi.stubGlobal("matchMedia", undefined);
+    Object.defineProperty(document, "startViewTransition", { value: undefined, configurable: true });
+
+    runWorkspaceNextStepTransition(update);
+
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it("skips the animation when the user prefers reduced motion", () => {
+    const update = vi.fn();
+    const startViewTransition = vi.fn();
+    vi.stubGlobal("matchMedia", () => ({ matches: true }));
+    Object.defineProperty(document, "startViewTransition", { value: startViewTransition, configurable: true });
+
+    runWorkspaceNextStepTransition(update);
+
+    expect(update).toHaveBeenCalledOnce();
+    expect(startViewTransition).not.toHaveBeenCalled();
+  });
+
+  it("runs the update inside a view transition", () => {
+    const update = vi.fn();
+    const startViewTransition = vi.fn((callback: () => void) => {
+      callback();
+      return { finished: Promise.resolve() };
+    });
+    vi.stubGlobal("matchMedia", () => ({ matches: false }));
+    Object.defineProperty(document, "startViewTransition", { value: startViewTransition, configurable: true });
+
+    runWorkspaceNextStepTransition(update);
+
+    expect(startViewTransition).toHaveBeenCalledOnce();
+    expect(update).toHaveBeenCalledOnce();
+  });
+});

--- a/web_src/src/pages/factories/pages/workspaceNextStepTransition.ts
+++ b/web_src/src/pages/factories/pages/workspaceNextStepTransition.ts
@@ -1,0 +1,17 @@
+import { flushSync } from "react-dom";
+
+function prefersReducedMotion(): boolean {
+  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+}
+
+/** Morph the next-steps badge between the banner and the header. */
+export function runWorkspaceNextStepTransition(update: () => void): void {
+  const startViewTransition = document.startViewTransition?.bind(document);
+  if (!startViewTransition || prefersReducedMotion()) {
+    update();
+    return;
+  }
+  startViewTransition(() => {
+    flushSync(update);
+  });
+}

--- a/web_src/src/pages/factories/pages/workspaceNextSteps.spec.ts
+++ b/web_src/src/pages/factories/pages/workspaceNextSteps.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   isWorkspaceNextStepDeferred,
+  isWorkspaceNextStepsQueryReady,
   runWorkspaceNextStepAction,
   shouldForgetDeferredWorkspaceNextStep,
   workspaceNextStepBanner,
@@ -55,6 +56,23 @@ describe("workspaceNextSteps", () => {
       expect.objectContaining({ id: "pr-comments-handler", done: false }),
       expect.objectContaining({ id: "pr-checks-handler", done: false }),
     ]);
+  });
+});
+
+describe("isWorkspaceNextStepsQueryReady", () => {
+  it("stays hidden while the query is pending or failed without data", () => {
+    expect(isWorkspaceNextStepsQueryReady({ isPending: true, isError: false })).toBe(false);
+    expect(isWorkspaceNextStepsQueryReady({ isPending: false, isError: true })).toBe(false);
+    expect(isWorkspaceNextStepsQueryReady({ isPending: false, isError: true, data: undefined })).toBe(false);
+  });
+
+  it("is ready after a successful load, including an empty list", () => {
+    expect(isWorkspaceNextStepsQueryReady({ isPending: false, isError: false, data: [] })).toBe(true);
+    expect(isWorkspaceNextStepsQueryReady({ isPending: false, data: [{ id: "handler-1" }] })).toBe(true);
+  });
+
+  it("uses cached handlers when a later fetch fails", () => {
+    expect(isWorkspaceNextStepsQueryReady({ isPending: false, isError: true, data: [{ id: "handler-1" }] })).toBe(true);
   });
 });
 

--- a/web_src/src/pages/factories/pages/workspaceNextSteps.spec.ts
+++ b/web_src/src/pages/factories/pages/workspaceNextSteps.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  isWorkspaceNextStepDeferred,
   runWorkspaceNextStepAction,
+  shouldForgetDeferredWorkspaceNextStep,
   workspaceNextStepBanner,
   workspaceNextSteps,
   workspaceNextStepsProgressCopy,
@@ -14,15 +16,30 @@ const ready = {
 };
 
 describe("workspaceNextSteps", () => {
-  it("lists the comments task as not done when no handler exists", () => {
-    expect(workspaceNextSteps(ready)).toEqual([expect.objectContaining({ id: "pr-comments-handler", done: false })]);
+  it("lists comments and status-check tasks as not done when no handler exists", () => {
+    expect(workspaceNextSteps(ready)).toEqual([
+      expect.objectContaining({ id: "pr-comments-handler", done: false }),
+      expect.objectContaining({ id: "pr-checks-handler", done: false }),
+    ]);
   });
 
-  it("hides the list when the comments handler is configured", () => {
+  it("marks comments done and keeps status checks open", () => {
     expect(
       workspaceNextSteps({
         ...ready,
         takenPRFeedbackSources: ["discussion"],
+      }),
+    ).toEqual([
+      expect.objectContaining({ id: "pr-comments-handler", done: true }),
+      expect.objectContaining({ id: "pr-checks-handler", done: false }),
+    ]);
+  });
+
+  it("hides the list when both handlers are configured", () => {
+    expect(
+      workspaceNextSteps({
+        ...ready,
+        takenPRFeedbackSources: ["discussion", "checks"],
       }),
     ).toEqual([]);
   });
@@ -31,6 +48,14 @@ describe("workspaceNextSteps", () => {
     expect(workspaceNextSteps({ ...ready, onboardingComplete: false })).toEqual([]);
     expect(workspaceNextSteps({ ...ready, canConfigure: false })).toEqual([]);
   });
+
+  it("hides the list until handler status is ready", () => {
+    expect(workspaceNextSteps({ ...ready, ready: false })).toEqual([]);
+    expect(workspaceNextSteps({ ...ready, ready: true })).toEqual([
+      expect.objectContaining({ id: "pr-comments-handler", done: false }),
+      expect.objectContaining({ id: "pr-checks-handler", done: false }),
+    ]);
+  });
 });
 
 describe("workspaceNextStepBanner", () => {
@@ -38,20 +63,37 @@ describe("workspaceNextStepBanner", () => {
     const banner = workspaceNextStepBanner(workspaceNextSteps(ready));
     expect(banner?.activeStep.id).toBe("pr-comments-handler");
     expect(banner?.doneCount).toBe(2);
-    expect(banner?.totalCount).toBe(3);
+    expect(banner?.totalCount).toBe(4);
     expect(banner?.title).toBe("How should pull request comments be handled?");
     expect(banner?.description).toBe(
       "SuperPlane can implement tasks and open pull requests, but pull request reviews are not handled yet.",
     );
     expect(banner?.ctaLabel).toBe("Configure");
+    expect(banner?.canDefer).toBe(false);
   });
 
-  it("hides the banner after comments are configured", () => {
+  it("personalizes the banner for status checks after comments are configured", () => {
+    const banner = workspaceNextStepBanner(
+      workspaceNextSteps({
+        ...ready,
+        takenPRFeedbackSources: ["discussion"],
+      }),
+    );
+    expect(banner?.activeStep.id).toBe("pr-checks-handler");
+    expect(banner?.doneCount).toBe(3);
+    expect(banner?.totalCount).toBe(4);
+    expect(banner?.title).toBe("How should failing status checks be handled?");
+    expect(banner?.description).toContain("automatically fix failing pull request status checks");
+    expect(banner?.ctaLabel).toBe("Configure");
+    expect(banner?.canDefer).toBe(true);
+  });
+
+  it("hides the banner after both handlers are configured", () => {
     expect(
       workspaceNextStepBanner(
         workspaceNextSteps({
           ...ready,
-          takenPRFeedbackSources: ["discussion"],
+          takenPRFeedbackSources: ["discussion", "checks"],
         }),
       ),
     ).toBeNull();
@@ -60,7 +102,32 @@ describe("workspaceNextStepBanner", () => {
 
 describe("workspaceNextStepsProgressCopy", () => {
   it("names how many tasks are complete", () => {
-    expect(workspaceNextStepsProgressCopy(2, 3)).toBe("2/3");
+    expect(workspaceNextStepsProgressCopy(2, 4)).toBe("2/4");
+  });
+});
+
+describe("isWorkspaceNextStepDeferred", () => {
+  it("defers only the optional status-checks banner", () => {
+    const comments = workspaceNextStepBanner(workspaceNextSteps(ready));
+    const checks = workspaceNextStepBanner(
+      workspaceNextSteps({
+        ...ready,
+        takenPRFeedbackSources: ["discussion"],
+      }),
+    );
+
+    expect(isWorkspaceNextStepDeferred(comments, "pr-checks-handler")).toBe(false);
+    expect(isWorkspaceNextStepDeferred(checks, "pr-checks-handler")).toBe(true);
+    expect(isWorkspaceNextStepDeferred(checks, "pr-comments-handler")).toBe(false);
+    expect(isWorkspaceNextStepDeferred(null, "pr-checks-handler")).toBe(false);
+  });
+});
+
+describe("shouldForgetDeferredWorkspaceNextStep", () => {
+  it("forgets a deferred checks step after that handler exists", () => {
+    expect(shouldForgetDeferredWorkspaceNextStep("pr-checks-handler", ["discussion"])).toBe(false);
+    expect(shouldForgetDeferredWorkspaceNextStep("pr-checks-handler", ["discussion", "checks"])).toBe(true);
+    expect(shouldForgetDeferredWorkspaceNextStep(null, ["checks"])).toBe(false);
   });
 });
 

--- a/web_src/src/pages/factories/pages/workspaceNextSteps.spec.ts
+++ b/web_src/src/pages/factories/pages/workspaceNextSteps.spec.ts
@@ -83,6 +83,7 @@ describe("workspaceNextStepBanner", () => {
     expect(banner?.doneCount).toBe(3);
     expect(banner?.totalCount).toBe(4);
     expect(banner?.title).toBe("How should failing status checks be handled?");
+    expect(banner?.badgeLabel).toBe("Configure status checks");
     expect(banner?.description).toContain("automatically fix failing pull request status checks");
     expect(banner?.ctaLabel).toBe("Configure");
     expect(banner?.canDefer).toBe(true);


### PR DESCRIPTION
After factory onboarding, SuperPlane already has GitHub and the repository.
Teams still need a clear next step for failing pull request status checks.
This change shows that next step on the board after comments are configured.
Users can configure a checks handler, or choose Later and restore it from a header chip.
The wizard only asks for extra CI access when a suggested tool needs it.
GitHub Actions and unmatched checks finish without extra connections.
If the repository has no status checks yet, Finish returns to the board with no handler.





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62630406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge.

<sub>Reviews (3) · Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/superplanehq/superplane/commit/3ea87364d39cd4e0803169a199acc41aa8f9d084)</sub>

<!-- /greptile_comment -->