### PR TITLE
fix: Correct first-run repository intake

### DIFF
--- a/db/migrations/20260910153910_add-factory-intake-initial-import.up.sql
+++ b/db/migrations/20260910153910_add-factory-intake-initial-import.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE factory_intakes
+  ADD COLUMN initial_import_status VARCHAR(32) NOT NULL DEFAULT 'unspecified',
+  ADD COLUMN initial_import_item_count INTEGER,
+  ADD CONSTRAINT factory_intakes_initial_import_status_valid
+    CHECK (initial_import_status IN ('unspecified', 'pending', 'completed', 'failed', 'skipped')),
+  ADD CONSTRAINT factory_intakes_initial_import_count_valid
+    CHECK (
+      (initial_import_status = 'completed' AND initial_import_item_count IS NOT NULL AND initial_import_item_count >= 0)
+      OR (initial_import_status <> 'completed' AND initial_import_item_count IS NULL)
+    );

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -395,7 +395,11 @@ CREATE TABLE public.factory_intakes (
     canvas_id uuid NOT NULL,
     source character varying(64) NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    initial_import_status character varying(32) DEFAULT 'unspecified'::character varying NOT NULL,
+    initial_import_item_count integer,
+    CONSTRAINT factory_intakes_initial_import_count_valid CHECK (((((initial_import_status)::text = 'completed'::text) AND (initial_import_item_count IS NOT NULL) AND (initial_import_item_count >= 0)) OR (((initial_import_status)::text <> 'completed'::text) AND (initial_import_item_count IS NULL)))),
+    CONSTRAINT factory_intakes_initial_import_status_valid CHECK (((initial_import_status)::text = ANY ((ARRAY['unspecified'::character varying, 'pending'::character varying, 'completed'::character varying, 'failed'::character varying, 'skipped'::character varying])::text[])))
 );
 
 
@@ -4377,7 +4381,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260909151005	f
+20260910153910	f
 \.
 
 

--- a/pkg/grpc/actions/factories/create_factory_intake.go
+++ b/pkg/grpc/actions/factories/create_factory_intake.go
@@ -127,9 +127,14 @@ func CreateFactoryIntake(
 	}
 
 	// An intake works without a first batch, so a source that cannot be read
-	// now costs the head start and nothing more.
-	if err := seedIntake(ctx, deps, db, canvasID, source, binding); err != nil {
-		log.Warnf("factory %s: intake %s starts without a first batch: %v", factory.ID, intake.ID, err)
+	// now costs the head start and nothing more. Persist the result so clients
+	// can distinguish an empty source from an import that did not run.
+	seedResult, seedErr := seedIntake(ctx, deps, db, canvasID, source, binding)
+	if err := recordInitialImport(db, intake, seedResult, seedErr); err != nil {
+		return nil, factoryErrorToStatus(err, "failed to record factory intake import")
+	}
+	if seedErr != nil {
+		log.Warnf("factory %s: intake %s starts without a first batch: %v", factory.ID, intake.ID, seedErr)
 	}
 
 	intake, err = factory.FindIntake(db, intake.ID)
@@ -145,6 +150,21 @@ func CreateFactoryIntake(
 	return &pb.CreateFactoryIntakeResponse{
 		Intake: serializeFactoryIntake(intake, spec[canvasID]),
 	}, nil
+}
+
+func recordInitialImport(
+	tx *gorm.DB,
+	intake *models.FactoryIntake,
+	seedResult intakeSeedResult,
+	seedErr error,
+) error {
+	if seedErr != nil {
+		return intake.FailInitialImport(tx)
+	}
+	if seedResult.skipped {
+		return intake.SkipInitialImport(tx)
+	}
+	return intake.CompleteInitialImport(tx, seedResult.itemCount)
 }
 
 // intakeCanvasRequest describes the graph to generate for a new intake.

--- a/pkg/grpc/actions/factories/create_factory_intake.go
+++ b/pkg/grpc/actions/factories/create_factory_intake.go
@@ -131,7 +131,10 @@ func CreateFactoryIntake(
 	// can distinguish an empty source from an import that did not run.
 	seedResult, seedErr := seedIntake(ctx, deps, db, canvasID, source, binding)
 	if err := recordInitialImport(db, intake, seedResult, seedErr); err != nil {
-		return nil, factoryErrorToStatus(err, "failed to record factory intake import")
+		// The intake, canvas, and seed events already exist. Returning an error
+		// would invite a retry that creates a duplicate intake and emits the
+		// same events again.
+		log.Errorf("factory %s: intake %s initial import result was not recorded: %v", factory.ID, intake.ID, err)
 	}
 	if seedErr != nil {
 		log.Warnf("factory %s: intake %s starts without a first batch: %v", factory.ID, intake.ID, seedErr)

--- a/pkg/grpc/actions/factories/factory_intake_test.go
+++ b/pkg/grpc/actions/factories/factory_intake_test.go
@@ -60,6 +60,8 @@ func Test__FactoryIntakeActions(t *testing.T) {
 		assert.True(t, intake.GetSettings().GetReopenedIssues())
 		assert.True(t, intake.GetSettings().GetSuperplaneLabelAdded())
 		assert.False(t, intake.GetSettings().GetAuthorsWithAccess())
+		assert.Equal(t, pb.FactoryIntake_INITIAL_IMPORT_STATUS_SKIPPED, intake.GetInitialImportStatus())
+		assert.Nil(t, intake.InitialImportItemCount)
 
 		// The graph has to be live, not staged: a staged graph never receives
 		// events.
@@ -583,6 +585,24 @@ func Test__FactoryIntakeActions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, response.GetRuns())
 	})
+}
+
+func Test__SerializeFactoryIntakeInitialImport(t *testing.T) {
+	itemCount := 0
+	intake := &models.FactoryIntake{
+		ID:                     uuid.New(),
+		FactoryID:              uuid.New(),
+		CanvasID:               uuid.New(),
+		Source:                 models.FactoryIntakeSourceGitHubIssues,
+		InitialImportStatus:    models.FactoryIntakeInitialImportStatusCompleted,
+		InitialImportItemCount: &itemCount,
+	}
+
+	serialized := serializeFactoryIntake(intake, models.LiveCanvasSpec{})
+
+	assert.Equal(t, pb.FactoryIntake_INITIAL_IMPORT_STATUS_COMPLETED, serialized.GetInitialImportStatus())
+	require.NotNil(t, serialized.InitialImportItemCount)
+	assert.Zero(t, serialized.GetInitialImportItemCount())
 }
 
 func liveBacklogCanvas(t *testing.T, factoryModel *models.Factory) *models.Canvas {

--- a/pkg/grpc/actions/factories/intake_seed.go
+++ b/pkg/grpc/actions/factories/intake_seed.go
@@ -27,6 +27,11 @@ const (
 	intakeGitHubIssuePayloadType = "github.issue"
 )
 
+type intakeSeedResult struct {
+	itemCount int
+	skipped   bool
+}
+
 // seedIntake gives a new intake work at once: the newest open items of the
 // source enter the graph as if they had just arrived. Without a seed the intake
 // stays empty until the source sends its next event, which can take days.
@@ -37,12 +42,12 @@ func seedIntake(
 	canvasID uuid.UUID,
 	source string,
 	binding *intakeBinding,
-) error {
+) (intakeSeedResult, error) {
 	// An unbound intake has nothing to read from. Its items arrive through the
 	// webhook alone.
 	installation := binding.installation()
 	if installation == nil {
-		return nil
+		return intakeSeedResult{skipped: true}, nil
 	}
 
 	switch source {
@@ -53,7 +58,7 @@ func seedIntake(
 	}
 
 	// The remaining sources cannot be read yet, so they start empty.
-	return nil
+	return intakeSeedResult{skipped: true}, nil
 }
 
 func seedGitHubIssues(
@@ -63,19 +68,22 @@ func seedGitHubIssues(
 	canvasID uuid.UUID,
 	binding *intakeBinding,
 	installation *models.Integration,
-) error {
+) (intakeSeedResult, error) {
 	client, err := newIntakeGitHubClient(deps, tx, installation)
 	if err != nil {
-		return err
+		return intakeSeedResult{}, err
 	}
 
 	repository, _ := binding.Configuration["repository"].(string)
 	payloads, err := newestGitHubIssueEvents(ctx, client, repository, intakeSeedSize)
 	if err != nil {
-		return err
+		return intakeSeedResult{}, err
 	}
 
-	return emitIntakeEvents(tx, canvasID, intakeGitHubIssuePayloadType, payloads)
+	if err := emitIntakeEvents(tx, canvasID, intakeGitHubIssuePayloadType, payloads); err != nil {
+		return intakeSeedResult{}, err
+	}
+	return intakeSeedResult{itemCount: len(payloads)}, nil
 }
 
 func seedProductiveTasks(
@@ -84,19 +92,22 @@ func seedProductiveTasks(
 	canvasID uuid.UUID,
 	binding *intakeBinding,
 	installation *models.Integration,
-) error {
+) (intakeSeedResult, error) {
 	client, err := newIntakeProductiveClient(deps, tx, installation)
 	if err != nil {
-		return err
+		return intakeSeedResult{}, err
 	}
 
 	project, _ := binding.Configuration["project"].(string)
 	documents, err := client.ListNewestOpenTaskDocuments(project, intakeSeedSize)
 	if err != nil {
-		return fmt.Errorf("failed to list the tasks of project %s: %w", project, err)
+		return intakeSeedResult{}, fmt.Errorf("failed to list the tasks of project %s: %w", project, err)
 	}
 
-	return emitIntakeEvents(tx, canvasID, productive.TaskPayloadType, productiveTaskEvents(documents))
+	if err := emitIntakeEvents(tx, canvasID, productive.TaskPayloadType, productiveTaskEvents(documents)); err != nil {
+		return intakeSeedResult{}, err
+	}
+	return intakeSeedResult{itemCount: len(documents)}, nil
 }
 
 // productiveTaskEvents shapes each task of a newest-first page like the event

--- a/pkg/grpc/actions/factories/serialization.go
+++ b/pkg/grpc/actions/factories/serialization.go
@@ -143,15 +143,20 @@ func serializeFactoryIntake(intake *models.FactoryIntake, spec models.LiveCanvas
 	graph := resolveIntakeGraph(intake.Source, spec)
 
 	serialized := &pb.FactoryIntake{
-		Id:        intake.ID.String(),
-		FactoryId: intake.FactoryID.String(),
-		CanvasId:  intake.CanvasID.String(),
-		Name:      intake.Name(),
-		Source:    serializeFactoryIntakeSource(intake.Source),
-		Settings:  serializeIntakeSettings(intakeSettingsFromGraph(graph, spec)),
-		Healthy:   graph.Healthy(spec.Edges),
-		CreatedAt: timestamppb.New(intake.CreatedAt),
-		UpdatedAt: timestamppb.New(intake.UpdatedAt),
+		Id:                  intake.ID.String(),
+		FactoryId:           intake.FactoryID.String(),
+		CanvasId:            intake.CanvasID.String(),
+		Name:                intake.Name(),
+		Source:              serializeFactoryIntakeSource(intake.Source),
+		Settings:            serializeIntakeSettings(intakeSettingsFromGraph(graph, spec)),
+		Healthy:             graph.Healthy(spec.Edges),
+		CreatedAt:           timestamppb.New(intake.CreatedAt),
+		UpdatedAt:           timestamppb.New(intake.UpdatedAt),
+		InitialImportStatus: serializeFactoryIntakeInitialImportStatus(intake.InitialImportStatus),
+	}
+	if intake.InitialImportItemCount != nil {
+		itemCount := int32(*intake.InitialImportItemCount)
+		serialized.InitialImportItemCount = &itemCount
 	}
 
 	if intake.Canvas != nil {
@@ -159,6 +164,21 @@ func serializeFactoryIntake(intake *models.FactoryIntake, spec models.LiveCanvas
 	}
 
 	return serialized
+}
+
+func serializeFactoryIntakeInitialImportStatus(status string) pb.FactoryIntake_InitialImportStatus {
+	switch status {
+	case models.FactoryIntakeInitialImportStatusPending:
+		return pb.FactoryIntake_INITIAL_IMPORT_STATUS_PENDING
+	case models.FactoryIntakeInitialImportStatusCompleted:
+		return pb.FactoryIntake_INITIAL_IMPORT_STATUS_COMPLETED
+	case models.FactoryIntakeInitialImportStatusFailed:
+		return pb.FactoryIntake_INITIAL_IMPORT_STATUS_FAILED
+	case models.FactoryIntakeInitialImportStatusSkipped:
+		return pb.FactoryIntake_INITIAL_IMPORT_STATUS_SKIPPED
+	default:
+		return pb.FactoryIntake_INITIAL_IMPORT_STATUS_UNSPECIFIED
+	}
 }
 
 func serializeFactoryIntakeSource(source string) pb.FactoryIntake_Source {

--- a/pkg/models/factory_intake.go
+++ b/pkg/models/factory_intake.go
@@ -17,6 +17,12 @@ const (
 	FactoryIntakeSourcePagerDutyIncidents = "pagerduty-incidents"
 	FactoryIntakeSourceProductiveTasks    = "productive-tasks"
 
+	FactoryIntakeInitialImportStatusUnspecified = "unspecified"
+	FactoryIntakeInitialImportStatusPending     = "pending"
+	FactoryIntakeInitialImportStatusCompleted   = "completed"
+	FactoryIntakeInitialImportStatusFailed      = "failed"
+	FactoryIntakeInitialImportStatusSkipped     = "skipped"
+
 	factoryIntakeCanvasUniqueConstraint = "idx_factory_intakes_canvas_id"
 )
 
@@ -38,13 +44,15 @@ var factoryIntakeSources = []string{
 // scores what it receives, and creates backlog work orders. The row owns
 // identity; the canvas graph owns behavior.
 type FactoryIntake struct {
-	ID             uuid.UUID
-	OrganizationID uuid.UUID
-	FactoryID      uuid.UUID
-	CanvasID       uuid.UUID
-	Source         string
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	ID                     uuid.UUID
+	OrganizationID         uuid.UUID
+	FactoryID              uuid.UUID
+	CanvasID               uuid.UUID
+	Source                 string
+	InitialImportStatus    string
+	InitialImportItemCount *int
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
 
 	Canvas *Canvas `gorm:"foreignKey:CanvasID"`
 }
@@ -89,13 +97,14 @@ func (f *Factory) CreateIntake(tx *gorm.DB, canvasID uuid.UUID, source string) (
 
 	now := time.Now()
 	intake := &FactoryIntake{
-		ID:             uuid.New(),
-		OrganizationID: f.OrganizationID,
-		FactoryID:      f.ID,
-		CanvasID:       canvasID,
-		Source:         source,
-		CreatedAt:      now,
-		UpdatedAt:      now,
+		ID:                  uuid.New(),
+		OrganizationID:      f.OrganizationID,
+		FactoryID:           f.ID,
+		CanvasID:            canvasID,
+		Source:              source,
+		InitialImportStatus: FactoryIntakeInitialImportStatusPending,
+		CreatedAt:           now,
+		UpdatedAt:           now,
 	}
 
 	if err := tx.Clauses(clause.Returning{}).Create(intake).Error; err != nil {
@@ -103,6 +112,34 @@ func (f *Factory) CreateIntake(tx *gorm.DB, canvasID uuid.UUID, source string) (
 	}
 
 	return intake, nil
+}
+
+func (i *FactoryIntake) CompleteInitialImport(tx *gorm.DB, itemCount int) error {
+	return i.updateInitialImport(tx, FactoryIntakeInitialImportStatusCompleted, &itemCount)
+}
+
+func (i *FactoryIntake) FailInitialImport(tx *gorm.DB) error {
+	return i.updateInitialImport(tx, FactoryIntakeInitialImportStatusFailed, nil)
+}
+
+func (i *FactoryIntake) SkipInitialImport(tx *gorm.DB) error {
+	return i.updateInitialImport(tx, FactoryIntakeInitialImportStatusSkipped, nil)
+}
+
+func (i *FactoryIntake) updateInitialImport(tx *gorm.DB, status string, itemCount *int) error {
+	now := time.Now()
+	if err := tx.Model(i).Updates(map[string]any{
+		"initial_import_status":     status,
+		"initial_import_item_count": itemCount,
+		"updated_at":                now,
+	}).Error; err != nil {
+		return err
+	}
+
+	i.InitialImportStatus = status
+	i.InitialImportItemCount = itemCount
+	i.UpdatedAt = now
+	return nil
 }
 
 func (f *Factory) FindIntake(tx *gorm.DB, intakeID uuid.UUID) (*FactoryIntake, error) {

--- a/pkg/models/factory_intake_test.go
+++ b/pkg/models/factory_intake_test.go
@@ -25,10 +25,50 @@ func Test__FactoryIntake(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, canvas.ID, intake.CanvasID)
 		assert.Equal(t, models.FactoryIntakeSourceGitHubIssues, intake.Source)
+		assert.Equal(t, models.FactoryIntakeInitialImportStatusPending, intake.InitialImportStatus)
+		assert.Nil(t, intake.InitialImportItemCount)
 
 		found, err := factory.FindIntake(db, intake.ID)
 		require.NoError(t, err)
 		assert.Equal(t, canvas.Name, found.Name())
+	})
+
+	t.Run("records a completed initial import", func(t *testing.T) {
+		for _, itemCount := range []int{0, 3} {
+			factory, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+			require.NoError(t, err)
+			canvas := support.CreateFactoryCanvas(t, r, factory.ID, support.RandomName("canvas"))
+			intake, err := factory.CreateIntake(db, canvas.ID, models.FactoryIntakeSourceGitHubIssues)
+			require.NoError(t, err)
+
+			require.NoError(t, intake.CompleteInitialImport(db, itemCount))
+
+			stored, err := factory.FindIntake(db, intake.ID)
+			require.NoError(t, err)
+			assert.Equal(t, models.FactoryIntakeInitialImportStatusCompleted, stored.InitialImportStatus)
+			require.NotNil(t, stored.InitialImportItemCount)
+			assert.Equal(t, itemCount, *stored.InitialImportItemCount)
+		}
+	})
+
+	t.Run("records failed and skipped initial imports without a count", func(t *testing.T) {
+		factory, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+		require.NoError(t, err)
+		canvas := support.CreateFactoryCanvas(t, r, factory.ID, support.RandomName("canvas"))
+		intake, err := factory.CreateIntake(db, canvas.ID, models.FactoryIntakeSourceGitHubIssues)
+		require.NoError(t, err)
+
+		require.NoError(t, intake.FailInitialImport(db))
+		stored, err := factory.FindIntake(db, intake.ID)
+		require.NoError(t, err)
+		assert.Equal(t, models.FactoryIntakeInitialImportStatusFailed, stored.InitialImportStatus)
+		assert.Nil(t, stored.InitialImportItemCount)
+
+		require.NoError(t, intake.SkipInitialImport(db))
+		stored, err = factory.FindIntake(db, intake.ID)
+		require.NoError(t, err)
+		assert.Equal(t, models.FactoryIntakeInitialImportStatusSkipped, stored.InitialImportStatus)
+		assert.Nil(t, stored.InitialImportItemCount)
 	})
 
 	t.Run("every known source round-trips through create and find", func(t *testing.T) {

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -956,6 +956,14 @@ message FactoryIntake {
     SOURCE_PRODUCTIVE_TASKS = 4;
   }
 
+  enum InitialImportStatus {
+    INITIAL_IMPORT_STATUS_UNSPECIFIED = 0;
+    INITIAL_IMPORT_STATUS_PENDING = 1;
+    INITIAL_IMPORT_STATUS_COMPLETED = 2;
+    INITIAL_IMPORT_STATUS_FAILED = 3;
+    INITIAL_IMPORT_STATUS_SKIPPED = 4;
+  }
+
   // Settings that change what the intake does. They are stored in the canvas
   // graph, because the canvas is what the workers run. This block is a
   // read/write facade over that graph.
@@ -1007,6 +1015,10 @@ message FactoryIntake {
   bool healthy = 8;
   google.protobuf.Timestamp created_at = 9;
   google.protobuf.Timestamp updated_at = 10;
+  // Result of the one-time import that runs when the intake is created.
+  InitialImportStatus initial_import_status = 11;
+  // Set when the initial import completed, including when it found zero items.
+  optional int32 initial_import_item_count = 12;
 }
 
 message FactoryIntakeRun {

--- a/web_src/src/pages/factories/pages/onboarding/OnboardingPage.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/OnboardingPage.tsx
@@ -1,7 +1,7 @@
 import { useConsumeIntegrationSetupReturnOnArrival } from "@/hooks/useConsumeIntegrationSetupReturnOnArrival";
 import { Loader2 } from "lucide-react";
 
-import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
+import { useFactoriesLayout, type FactoriesLayoutContextValue } from "../../layout/factoriesLayoutContext";
 import { FirstRunSetup } from "./FirstRunSetup";
 import { FirstRunShell } from "./first-run/FirstRunShell";
 import { GithubAppRequiredNotice } from "./GithubAppRequiredNotice";
@@ -12,6 +12,10 @@ import { useOnboardingWorkspaceResolution } from "./useOnboardingWorkspaceResolu
 
 export function OnboardingPage() {
   const layout = useFactoriesLayout();
+  return <WorkspaceOnboardingPage key={layout.factoryId} layout={layout} />;
+}
+
+function WorkspaceOnboardingPage({ layout }: { layout: FactoriesLayoutContextValue }) {
   const onboardingEntryPath = useOnboardingEntryPath();
   const reresolveWorkspace = useOnboardingWorkspaceResolution();
   useConsumeIntegrationSetupReturnOnArrival(layout.organizationId);

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunAnalysisScreen.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunAnalysisScreen.spec.tsx
@@ -74,6 +74,20 @@ describe("FirstRunAnalysisScreen", () => {
     expect(document.querySelector(".animate-spin")).not.toBeInTheDocument();
   });
 
+  it("shows an import failure without the empty result", () => {
+    render(
+      <FirstRunAnalysisScreen
+        progress={{ total: 0, scored: 0, ready: 0, stageIndex: 0, empty: false }}
+        failed
+        onGoToBoard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(FIRST_RUN_COPY.analysis.failure)).toBeInTheDocument();
+    expect(screen.queryByText("🤔")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-analysis-empty")).not.toBeInTheDocument();
+  });
+
   it("omits the ready counter when no ticket scored above the threshold", () => {
     render(
       <FirstRunAnalysisScreen progress={{ total: 3, scored: 3, ready: 0, stageIndex: 2 }} onGoToBoard={vi.fn()} />,

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunAnalysisProgress.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunAnalysisProgress.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { FactoriesFactoryIntake } from "@/api-client";
 
-import { firstRunAnalysisProgress } from "./firstRunAnalysisProgress";
+import { firstRunAnalysisProgress, githubIssuesIntake, type FirstRunInitialImport } from "./firstRunAnalysisProgress";
 
 function run(placement: string, extra: { confidencePct?: number; workOrderId?: string } = {}) {
   return { placement, ...extra } as never;
@@ -29,6 +30,42 @@ describe("firstRunAnalysisProgress", () => {
       stageIndex: 0,
       empty: false,
     });
+  });
+
+  it("reports an empty source immediately after a completed zero-item import", () => {
+    const initialImport: FirstRunInitialImport = { status: "INITIAL_IMPORT_STATUS_COMPLETED", itemCount: 0 };
+
+    expect(firstRunAnalysisProgress([], new Set(), false, initialImport)).toEqual({
+      total: 0,
+      scored: 0,
+      ready: 0,
+      stageIndex: 0,
+      empty: true,
+    });
+  });
+
+  it("uses the completed import count while queued runs become visible", () => {
+    const initialImport: FirstRunInitialImport = { status: "INITIAL_IMPORT_STATUS_COMPLETED", itemCount: 2 };
+
+    expect(firstRunAnalysisProgress([], new Set(), false, initialImport)).toEqual({
+      total: 2,
+      scored: 0,
+      ready: 0,
+      stageIndex: 1,
+      empty: false,
+    });
+  });
+
+  it("does not report failed or skipped imports as empty", () => {
+    for (const status of ["INITIAL_IMPORT_STATUS_FAILED", "INITIAL_IMPORT_STATUS_SKIPPED"] as const) {
+      expect(firstRunAnalysisProgress([], new Set(), true, { status })).toEqual({
+        total: 0,
+        scored: 0,
+        ready: 0,
+        stageIndex: 0,
+        empty: false,
+      });
+    }
   });
 
   // An intake without an analysis node places items on the backlog the
@@ -60,5 +97,16 @@ describe("firstRunAnalysisProgress", () => {
     // Progressed work already moved to a line, so it also counts as ready.
     const runs = [run("PLACEMENT_BELOW_THRESHOLD"), run("PLACEMENT_REJECTED"), run("PLACEMENT_PROGRESSED")];
     expect(firstRunAnalysisProgress(runs)).toEqual({ total: 3, scored: 3, ready: 1, stageIndex: 2 });
+  });
+});
+
+describe("githubIssuesIntake", () => {
+  it("selects the GitHub intake when another source appears first", () => {
+    const intakes: FactoriesFactoryIntake[] = [
+      { id: "sentry-1", source: "SOURCE_SENTRY_EXCEPTIONS" },
+      { id: "github-1", source: "SOURCE_GITHUB_ISSUES" },
+    ];
+
+    expect(githubIssuesIntake(intakes)?.id).toBe("github-1");
   });
 });

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunAnalysisProgress.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunAnalysisProgress.spec.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { FactoriesFactoryIntake } from "@/api-client";
 
-import { firstRunAnalysisProgress, githubIssuesIntake, type FirstRunInitialImport } from "./firstRunAnalysisProgress";
+import {
+  firstRunAnalysisProgress,
+  githubIssuesIntake,
+  initialImportFailed,
+  type FirstRunInitialImport,
+} from "./firstRunAnalysisProgress";
 
 function run(placement: string, extra: { confidencePct?: number; workOrderId?: string } = {}) {
   return { placement, ...extra } as never;
@@ -108,5 +113,18 @@ describe("githubIssuesIntake", () => {
     ];
 
     expect(githubIssuesIntake(intakes)?.id).toBe("github-1");
+  });
+});
+
+describe("initialImportFailed", () => {
+  it("fails a pending import only after its grace period", () => {
+    expect(initialImportFailed("INITIAL_IMPORT_STATUS_PENDING", false)).toBe(false);
+    expect(initialImportFailed("INITIAL_IMPORT_STATUS_PENDING", true)).toBe(true);
+  });
+
+  it("fails terminal import errors without a grace period", () => {
+    expect(initialImportFailed("INITIAL_IMPORT_STATUS_FAILED", false)).toBe(true);
+    expect(initialImportFailed("INITIAL_IMPORT_STATUS_SKIPPED", false)).toBe(true);
+    expect(initialImportFailed("INITIAL_IMPORT_STATUS_COMPLETED", true)).toBe(false);
   });
 });

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunAnalysisProgress.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunAnalysisProgress.ts
@@ -1,4 +1,4 @@
-import type { FactoriesFactoryIntakeRun } from "@/api-client";
+import type { FactoriesFactoryIntake, FactoriesFactoryIntakeRun, FactoryIntakeInitialImportStatus } from "@/api-client";
 
 export type FirstRunAnalysisProgress = {
   total: number;
@@ -10,10 +10,44 @@ export type FirstRunAnalysisProgress = {
   empty?: boolean;
 };
 
+export type FirstRunInitialImport = {
+  status?: FactoryIntakeInitialImportStatus;
+  itemCount?: number;
+};
+
 // Intake decisions that only exist after a score: the item was gated out,
 // or its work order already started on a line.
 const TERMINAL = ["PLACEMENT_BELOW_THRESHOLD", "PLACEMENT_REJECTED", "PLACEMENT_PROGRESSED"];
 const READY = ["PLACEMENT_BACKLOG", "PLACEMENT_PROGRESSED"];
+
+export function githubIssuesIntake(intakes: FactoriesFactoryIntake[] | undefined): FactoriesFactoryIntake | undefined {
+  return intakes?.find((intake) => intake.source === "SOURCE_GITHUB_ISSUES");
+}
+
+function completedImportItemCount(initialImport: FirstRunInitialImport): number | undefined {
+  if (initialImport.status !== "INITIAL_IMPORT_STATUS_COMPLETED") return undefined;
+  return initialImport.itemCount;
+}
+
+function legacyImportIsEmpty(initialImport: FirstRunInitialImport, importSettled: boolean): boolean {
+  const legacyStatus = !initialImport.status || initialImport.status === "INITIAL_IMPORT_STATUS_UNSPECIFIED";
+  return legacyStatus && importSettled;
+}
+
+function initialProgress(
+  runsLoaded: boolean,
+  importedItemCount: number | undefined,
+  legacyEmpty: boolean,
+): FirstRunAnalysisProgress {
+  const empty = runsLoaded && (importedItemCount === 0 || (importedItemCount === undefined && legacyEmpty));
+  return {
+    total: importedItemCount ?? 0,
+    scored: 0,
+    ready: 0,
+    stageIndex: importedItemCount !== undefined && importedItemCount > 0 ? 1 : 0,
+    empty,
+  };
+}
 
 /**
  * An intake without an analysis node places items on the backlog the moment
@@ -34,15 +68,17 @@ export function firstRunAnalysisProgress(
   runs: FactoriesFactoryIntakeRun[] | undefined,
   scoredOrderIds: ReadonlySet<string> = new Set(),
   importSettled = false,
+  initialImport: FirstRunInitialImport = {},
 ): FirstRunAnalysisProgress {
-  // A loaded but empty run list only means "no tickets" once the import had
-  // time to seed (`importSettled`); before that it means "still importing".
+  const importedItemCount = completedImportItemCount(initialImport);
+
   if (!runs || runs.length === 0) {
-    return { total: 0, scored: 0, ready: 0, stageIndex: 0, empty: Boolean(runs) && importSettled };
+    return initialProgress(Boolean(runs), importedItemCount, legacyImportIsEmpty(initialImport, importSettled));
   }
   const scored = runs.filter((run) => isScored(run, scoredOrderIds)).length;
   // Ready means scored and on the board, whichever path produced the score:
   // an intake confidence percentage or a finished Backlog analysis run.
   const ready = runs.filter((run) => READY.includes(String(run.placement)) && isScored(run, scoredOrderIds)).length;
-  return { total: runs.length, scored, ready, stageIndex: scored === runs.length ? 2 : 1 };
+  const total = Math.max(runs.length, importedItemCount ?? 0);
+  return { total, scored, ready, stageIndex: scored === total ? 2 : 1 };
 }

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunAnalysisProgress.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunAnalysisProgress.ts
@@ -24,6 +24,14 @@ export function githubIssuesIntake(intakes: FactoriesFactoryIntake[] | undefined
   return intakes?.find((intake) => intake.source === "SOURCE_GITHUB_ISSUES");
 }
 
+export function initialImportFailed(
+  status: FactoryIntakeInitialImportStatus | undefined,
+  importSettled: boolean,
+): boolean {
+  if (status === "INITIAL_IMPORT_STATUS_FAILED" || status === "INITIAL_IMPORT_STATUS_SKIPPED") return true;
+  return status === "INITIAL_IMPORT_STATUS_PENDING" && importSettled;
+}
+
 function completedImportItemCount(initialImport: FirstRunInitialImport): number | undefined {
   if (initialImport.status !== "INITIAL_IMPORT_STATUS_COMPLETED") return undefined;
   return initialImport.itemCount;

--- a/web_src/src/pages/factories/pages/onboarding/first-run/useFirstRunAnalysis.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/useFirstRunAnalysis.ts
@@ -2,13 +2,15 @@ import { useBacklogAnalysisScoredOrderIds } from "@/hooks/useBacklogAnalysisRuns
 import { useFactoryIntakeRuns, useFactoryIntakes } from "@/hooks/useFactoryIntakeData";
 
 import { lineIntakeSourceForApiSource } from "../../lineIntakeModel";
-import { firstRunAnalysisProgress, type FirstRunAnalysisProgress } from "./firstRunAnalysisProgress";
+import {
+  firstRunAnalysisProgress,
+  githubIssuesIntake,
+  type FirstRunAnalysisProgress,
+} from "./firstRunAnalysisProgress";
 
 /**
- * The API has no "import finished" flag. The seed import starts when
- * provisioning creates the intake, so an intake this old with zero runs
- * means the ticket source had no open tickets. The runs query polls every
- * ten seconds, so the check re-evaluates without its own timer.
+ * Intakes created before initial-import status existed need the old age
+ * fallback. New intakes report their exact import result through the API.
  */
 const IMPORT_GRACE_MS = 30_000;
 
@@ -28,12 +30,23 @@ export function useFirstRunAnalysis(
   factoryId: string,
 ): { progress: FirstRunAnalysisProgress; sourceName?: string; failed: boolean } {
   const intakes = useFactoryIntakes(organizationId, factoryId);
-  const intake = intakes.data?.[0];
+  const intake = githubIssuesIntake(intakes.data);
   const runs = useFactoryIntakeRuns(organizationId, factoryId, intake?.id);
   const scoredOrderIds = useBacklogAnalysisScoredOrderIds(organizationId, factoryId);
+  const initialImportStatus = intake?.initialImportStatus;
+  const githubIntakeMissing = intakes.isSuccess && !intake;
   return {
-    progress: firstRunAnalysisProgress(runs.data, scoredOrderIds, importSettled(intake?.createdAt)),
+    progress: firstRunAnalysisProgress(runs.data, scoredOrderIds, importSettled(intake?.createdAt), {
+      status: initialImportStatus,
+      itemCount: intake?.initialImportItemCount,
+    }),
     sourceName: lineIntakeSourceForApiSource(intake?.source)?.name,
-    failed: Boolean(intakes.isError || runs.isError),
+    failed: Boolean(
+      intakes.isError ||
+        runs.isError ||
+        githubIntakeMissing ||
+        initialImportStatus === "INITIAL_IMPORT_STATUS_FAILED" ||
+        initialImportStatus === "INITIAL_IMPORT_STATUS_SKIPPED",
+    ),
   };
 }

--- a/web_src/src/pages/factories/pages/onboarding/first-run/useFirstRunAnalysis.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/useFirstRunAnalysis.ts
@@ -5,6 +5,7 @@ import { lineIntakeSourceForApiSource } from "../../lineIntakeModel";
 import {
   firstRunAnalysisProgress,
   githubIssuesIntake,
+  initialImportFailed,
   type FirstRunAnalysisProgress,
 } from "./firstRunAnalysisProgress";
 
@@ -35,8 +36,9 @@ export function useFirstRunAnalysis(
   const scoredOrderIds = useBacklogAnalysisScoredOrderIds(organizationId, factoryId);
   const initialImportStatus = intake?.initialImportStatus;
   const githubIntakeMissing = intakes.isSuccess && !intake;
+  const importIsSettled = importSettled(intake?.createdAt);
   return {
-    progress: firstRunAnalysisProgress(runs.data, scoredOrderIds, importSettled(intake?.createdAt), {
+    progress: firstRunAnalysisProgress(runs.data, scoredOrderIds, importIsSettled, {
       status: initialImportStatus,
       itemCount: intake?.initialImportItemCount,
     }),
@@ -45,8 +47,7 @@ export function useFirstRunAnalysis(
       intakes.isError ||
         runs.isError ||
         githubIntakeMissing ||
-        initialImportStatus === "INITIAL_IMPORT_STATUS_FAILED" ||
-        initialImportStatus === "INITIAL_IMPORT_STATUS_SKIPPED",
+        initialImportFailed(initialImportStatus, importIsSettled),
     ),
   };
 }

--- a/web_src/src/pages/factories/pages/onboarding/onboardingGithubCleanup.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingGithubCleanup.ts
@@ -7,6 +7,7 @@ import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import type { QueryClient } from "@tanstack/react-query";
 
 import type { UpdateOnboarding } from "./onboardingProvision";
+import { githubConnectionPatch } from "./onboardingRepository";
 import { unusedOnboardingVcsIntegrationId } from "./unusedOnboardingIntegration";
 import type { OnboardingSetupApi } from "./useOnboardingSetupState";
 
@@ -44,16 +45,13 @@ export async function saveSelectedGithubConnection(
   integrationId: string,
   previousId: string | undefined,
 ): Promise<boolean> {
-  const switchedConnection = Boolean(previousId && previousId !== integrationId);
+  const switchedConnection = previousId !== integrationId;
   if (switchedConnection) {
     args.setup.clearRepository();
   }
 
   try {
-    await args.updateOnboarding({
-      vcsIntegrationId: integrationId,
-      ...(switchedConnection ? { appRepository: "" } : {}),
-    });
+    await args.updateOnboarding(githubConnectionPatch(integrationId, previousId));
     return true;
   } catch (error) {
     showErrorToast(getApiErrorMessage(error, "Could not save the GitHub connection"));

--- a/web_src/src/pages/factories/pages/onboarding/onboardingRepository.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingRepository.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { firstRunRepositoryPatch, githubConnectionPatch } from "./onboardingRepository";
+
+describe("firstRunRepositoryPatch", () => {
+  it("uses the selected repository for code and GitHub issue intake", () => {
+    expect(firstRunRepositoryPatch("github-1", "acme/new")).toEqual({
+      vcsIntegrationId: "github-1",
+      appRepository: "acme/new",
+      backlogRepository: "acme/new",
+    });
+  });
+});
+
+describe("githubConnectionPatch", () => {
+  it("clears repository values when the GitHub connection changes", () => {
+    expect(githubConnectionPatch("github-2", "github-1")).toEqual({
+      vcsIntegrationId: "github-2",
+      appRepository: "",
+      backlogRepository: "",
+      defaultBranch: "",
+    });
+  });
+
+  it("clears stale repository values when the first GitHub connection is selected", () => {
+    expect(githubConnectionPatch("github-1", undefined)).toMatchObject({
+      appRepository: "",
+      backlogRepository: "",
+      defaultBranch: "",
+    });
+  });
+
+  it("keeps repository values when the GitHub connection does not change", () => {
+    expect(githubConnectionPatch("github-1", "github-1")).toEqual({ vcsIntegrationId: "github-1" });
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/onboardingRepository.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingRepository.ts
@@ -1,0 +1,28 @@
+import type { FactoriesUpdateFactoryOnboardingBody } from "@/api-client";
+
+export function firstRunRepositoryPatch(
+  integrationId: string,
+  repository: string,
+): FactoriesUpdateFactoryOnboardingBody {
+  return {
+    vcsIntegrationId: integrationId,
+    appRepository: repository,
+    backlogRepository: repository,
+  };
+}
+
+export function githubConnectionPatch(
+  integrationId: string,
+  previousIntegrationId: string | undefined,
+): FactoriesUpdateFactoryOnboardingBody {
+  if (previousIntegrationId === integrationId) {
+    return { vcsIntegrationId: integrationId };
+  }
+
+  return {
+    vcsIntegrationId: integrationId,
+    appRepository: "",
+    backlogRepository: "",
+    defaultBranch: "",
+  };
+}

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -29,6 +29,7 @@ import type { IntegrationId, IssuesChoiceId, WizardStepId } from "./onboardingFi
 import type { OnboardingWorkspaceResolution } from "./onboardingWorkspaceResolutionContext";
 import { onboardingStepPath } from "./onboardingStepPath";
 import type { UpdateOnboarding } from "./onboardingProvision";
+import { firstRunRepositoryPatch } from "./onboardingRepository";
 import {
   apiIssuesSource,
   initialOnboardingSelections,
@@ -41,7 +42,11 @@ import { useFactoryOnboarding } from "./useFactoryOnboarding";
 import { useFinishOnboarding, type OnboardingDestination } from "./useFinishOnboarding";
 import { useFinishSetupAction } from "./useFinishSetupAction";
 import { useOnboardingAgentPlan } from "./useOnboardingAgentPlan";
-import { useOnboardingSetupState, type OnboardingSetupApi } from "./useOnboardingSetupState";
+import {
+  useOnboardingSetupState,
+  type InitialOnboardingSetupState,
+  type OnboardingSetupApi,
+} from "./useOnboardingSetupState";
 import { persistSelectedGithubConnection } from "./onboardingGithubCleanup";
 import { useOnboardingGithubConnections } from "./useSelectNewGithubConnection";
 
@@ -74,32 +79,25 @@ function useIntegrationSelections(onboarding: FactoriesFactory["onboarding"]) {
   return { selections, connected, setSelections };
 }
 
-function useRestoreSetup(
-  setup: OnboardingSetupApi,
-  onboarding: FactoriesFactory["onboarding"],
-  selections: IntegrationSelections,
-) {
+function initialSetupState(onboarding: FactoriesFactory["onboarding"]): InitialOnboardingSetupState {
+  const appRepository = onboarding?.appRepository || null;
+  return {
+    vcsHost: onboarding?.vcsIntegrationId ? "github" : null,
+    selectedRepo: appRepository,
+    issuesRepo: onboarding?.backlogRepository || appRepository,
+    issuesChoice: localIssuesSource(onboarding?.issuesSource),
+  };
+}
+
+function useRestoreIntegrationReadiness(setup: OnboardingSetupApi, selections: IntegrationSelections) {
+  const { vcsHost, selectVcsHost, setAgent } = setup;
   useEffect(() => {
-    if (selections.github?.ready && setup.vcsHost !== "github") setup.selectVcsHost("github");
-  }, [selections.github?.ready, setup]);
-  useEffect(() => {
-    if (onboarding?.appRepository && setup.selectedRepo !== onboarding.appRepository) {
-      setup.selectRepo(onboarding.appRepository);
-    }
-  }, [onboarding?.appRepository, setup]);
-  useEffect(() => {
-    if (onboarding?.backlogRepository && setup.issuesRepo !== onboarding.backlogRepository) {
-      setup.selectIssuesRepo(onboarding.backlogRepository);
-    }
-  }, [onboarding?.backlogRepository, setup]);
-  useEffect(() => {
-    const source = localIssuesSource(onboarding?.issuesSource);
-    if (source && setup.issuesChoice !== source) setup.setIssuesChoice(source);
-  }, [onboarding?.issuesSource, setup]);
+    if (selections.github?.ready && vcsHost !== "github") selectVcsHost("github");
+  }, [selections.github?.ready, selectVcsHost, vcsHost]);
   useEffect(() => {
     if (!selections.claude?.ready) return;
-    setup.setAgent("claude-code");
-  }, [onboarding?.agentHarness, selections.claude?.ready, setup]);
+    setAgent("claude-code");
+  }, [selections.claude?.ready, setAgent]);
 }
 
 async function runSave(setSaving: (saving: boolean) => void, action: () => Promise<unknown>): Promise<boolean> {
@@ -139,12 +137,7 @@ function useSectionSaves(args: {
   const saveRepository = (repository: string) => {
     const integrationId = args.selections.github?.id;
     if (!repository || !integrationId) return Promise.resolve(false);
-    return runSave(args.setSaving, () =>
-      args.updateOnboarding({
-        vcsIntegrationId: integrationId,
-        appRepository: repository,
-      }),
-    );
+    return runSave(args.setSaving, () => args.updateOnboarding(firstRunRepositoryPatch(integrationId, repository)));
   };
   // The caller passes the source, because a selection made in the same render
   // is not readable from the setup state yet.
@@ -392,8 +385,9 @@ export function useOnboardingPageModel(args: {
     connected: integrations.connected,
     remainingCreditCents: agent.remainingCreditCents,
     simulateDiscovery: false,
+    initial: initialSetupState(onboarding),
   });
-  useRestoreSetup(setup, onboarding, integrations.selections);
+  useRestoreIntegrationReadiness(setup, integrations.selections);
   const [searchParams] = useSearchParams();
   const [openSection, setOpenSection] = useState<WizardStepId>(() => {
     const requestedStep = searchParams.get("step");

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingSetupState.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingSetupState.spec.ts
@@ -5,6 +5,29 @@ import type { IntegrationId } from "./onboardingFixtures";
 import { useOnboardingSetupState } from "./useOnboardingSetupState";
 
 describe("useOnboardingSetupState", () => {
+  it("hydrates saved repository choices only when the state is created", () => {
+    const connected = new Set<IntegrationId>(["github"]);
+    const { result, rerender } = renderHook(() =>
+      useOnboardingSetupState("Payments", {
+        connected,
+        simulateDiscovery: false,
+        initial: {
+          vcsHost: "github",
+          selectedRepo: "acme/old",
+          issuesRepo: "acme/old",
+          issuesChoice: "vcs",
+        },
+      }),
+    );
+
+    expect(result.current.selectedRepo).toBe("acme/old");
+    act(() => result.current.selectRepo("acme/new"));
+    rerender();
+
+    expect(result.current.selectedRepo).toBe("acme/new");
+    expect(result.current.issuesRepo).toBe("acme/new");
+  });
+
   it("uses real connected state and completes discovery without fixture counts", () => {
     const connected = new Set<IntegrationId>(["github", "claude"]);
     const { result } = renderHook(() =>

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingSetupState.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingSetupState.ts
@@ -23,6 +23,10 @@ export type OnboardingSetupState = {
   finished: boolean;
 };
 
+export type InitialOnboardingSetupState = Partial<
+  Pick<OnboardingSetupState, "vcsHost" | "selectedRepo" | "issuesRepo" | "issuesChoice" | "agent">
+>;
+
 function isIssuesReady(issuesChoice: IssuesChoiceId | null, connected: Set<IntegrationId>): boolean {
   if (issuesChoice === "skip" || issuesChoice === "vcs") {
     return true;
@@ -65,6 +69,7 @@ export function useOnboardingSetupState(
     connected?: Set<IntegrationId>;
     remainingCreditCents?: number;
     simulateDiscovery?: boolean;
+    initial?: InitialOnboardingSetupState;
   },
 ) {
   const [workspaceName, setWorkspaceName] = useState(() => initialName.trim());
@@ -74,18 +79,18 @@ export function useOnboardingSetupState(
     () => initialName.trim().length > 0 && !isPlaceholderWorkspaceName(initialName),
   );
   const [localConnected, setLocalConnected] = useState<Set<IntegrationId>>(() => new Set());
-  const [vcsHost, setVcsHost] = useState<VcsHostId | null>(null);
-  const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
+  const [vcsHost, setVcsHost] = useState<VcsHostId | null>(() => options?.initial?.vcsHost ?? null);
+  const [selectedRepo, setSelectedRepo] = useState<string | null>(() => options?.initial?.selectedRepo ?? null);
   /** True after Continue to issues — starts repository analysis. */
   const [repoCommitted, setRepoCommitted] = useState(false);
   /** Backlog repository for GitHub/GitLab Issues (may differ from the app repo). */
-  const [issuesRepo, setIssuesRepo] = useState<string | null>(null);
+  const [issuesRepo, setIssuesRepo] = useState<string | null>(() => options?.initial?.issuesRepo ?? null);
   const [issuesDiscovering, setIssuesDiscovering] = useState(false);
-  const [issuesDiscovered, setIssuesDiscovered] = useState(false);
-  const [issuesChoice, setIssuesChoice] = useState<IssuesChoiceId | null>(null);
+  const [issuesDiscovered, setIssuesDiscovered] = useState(() => Boolean(options?.initial?.issuesChoice));
+  const [issuesChoice, setIssuesChoice] = useState<IssuesChoiceId | null>(() => options?.initial?.issuesChoice ?? null);
   /** True after Continue to coding agent — starts backlog analysis. */
   const [issuesCommitted, setIssuesCommitted] = useState(false);
-  const [agent, setAgent] = useState<AgentHarnessId | null>(null);
+  const [agent, setAgent] = useState<AgentHarnessId | null>(() => options?.initial?.agent ?? null);
   const [finished, setFinished] = useState(false);
   const discoveryTimerRef = useRef<number | null>(null);
   const connected = options?.connected ?? localConnected;


### PR DESCRIPTION
## Summary

- Prevents saved onboarding data from replacing the repository that the user selected.
- Uses the selected repository for the app and GitHub Issues intake.
- Records the initial import result so empty and failed states appear without the legacy polling delay.

## Test plan

- [x] Run focused backend intake and model tests.
- [x] Run focused onboarding and repository tests.
- [x] Run make check.lint.ui.
- [x] Run make check.build.ui.
- [x] Run backend lint, build, protobuf, migration, and generated artifact checks.







<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62706494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge.

<sub>Reviews (4) · Last reviewed commit: ["chore: Retry flaky E2E shard"](https://github.com/superplanehq/superplane/commit/3665efa56beaf3ebda317f34689ba5dbf1580eac)</sub>

<!-- /greptile_comment -->