### PR TITLE
fix: Skip hosted agent connection step

### DIFF
--- a/pkg/grpc/actions/factories/update_factory_onboarding.go
+++ b/pkg/grpc/actions/factories/update_factory_onboarding.go
@@ -98,13 +98,6 @@ func validateFactoryOnboardingResources(
 			return invalidArgument("coding agent integration does not match the selected agent")
 		}
 	} else {
-		credit, err := models.DescribeOrganizationLLMCredit(db, organizationID)
-		if err != nil {
-			return err
-		}
-		if credit.RemainingMicros <= 0 {
-			return models.ErrFactoryOnboardingAgentIntegrationRequired
-		}
 		offered, hostedErr := models.HasOfferedHostedLLMProvider(db)
 		if hostedErr != nil {
 			return hostedErr

--- a/pkg/grpc/actions/factories/update_factory_onboarding_test.go
+++ b/pkg/grpc/actions/factories/update_factory_onboarding_test.go
@@ -110,7 +110,7 @@ func Test__UpdateFactoryOnboarding(t *testing.T) {
 		assert.Empty(t, response.Factory.Onboarding.AgentIntegrationId)
 	})
 
-	t.Run("complete without agent integration rejects when hosted credit is empty", func(t *testing.T) {
+	t.Run("complete without agent integration succeeds when hosted credit is empty", func(t *testing.T) {
 		emptyOrg := support.CreateOrganization(t, r, r.User)
 		require.NoError(t, db.Where("organization_id = ?", emptyOrg.ID).Delete(&models.OrganizationLLMCreditGrant{}).Error)
 
@@ -124,10 +124,11 @@ func Test__UpdateFactoryOnboarding(t *testing.T) {
 		complete := true
 		req.Complete = &complete
 
-		_, err = UpdateFactoryOnboarding(context.Background(), emptyOrg.ID.String(), req)
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.InvalidArgument, code)
+		upsertHostedOnboardingProvider(t, db)
+		response, err := UpdateFactoryOnboarding(context.Background(), emptyOrg.ID.String(), req)
+		require.NoError(t, err)
+		require.NotNil(t, response.Factory.Onboarding.CompletedAt)
+		assert.Empty(t, response.Factory.Onboarding.AgentIntegrationId)
 	})
 
 	t.Run("complete without agent integration rejects when no hosted provider is offered", func(t *testing.T) {

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
@@ -129,18 +129,43 @@ describe("FirstRunSetup", () => {
     bindMutate.mockReset();
   });
 
-  it("finishes setup from the ticket screen when hosted credentials cover the agent", async () => {
-    const user = userEvent.setup();
-    const model = pageModel({ hostedAgentReady: true });
+  it.each([
+    {
+      scenario: "a new user, organization, and workspace",
+      currentFactory: { onboarding: { initial: true, vcsIntegrationId: "github-1" } },
+      otherFactories: [],
+      otherOrganizations: [],
+    },
+    {
+      scenario: "an existing user and organization with a new workspace",
+      currentFactory: { onboarding: { vcsIntegrationId: "github-1" } },
+      otherFactories: [{ id: "factory-2", key: "CORE", name: "Core" }],
+      otherOrganizations: [],
+    },
+    {
+      scenario: "an existing user with a new organization and workspace",
+      currentFactory: { onboarding: { vcsIntegrationId: "github-1" } },
+      otherFactories: [],
+      otherOrganizations: [{ id: "org-2", name: "Existing organization" }],
+    },
+  ])(
+    "finishes setup without the agent screen for $scenario",
+    async ({ currentFactory, otherFactories, otherOrganizations }) => {
+      factory = { id: "factory-1", key: "PAY", name: "New workspace", ...currentFactory };
+      factories = [factory, ...otherFactories];
+      accountOrganizations = [{ id: "org-1", name: "Acme" }, ...otherOrganizations];
+      const user = userEvent.setup();
+      const model = pageModel({ hostedAgentReady: true });
 
-    renderSetup(model);
+      renderSetup(model);
 
-    await user.click(screen.getByRole("button", { name: FIRST_RUN_COPY.tickets.analyze }));
+      await user.click(screen.getByRole("button", { name: FIRST_RUN_COPY.tickets.analyze }));
 
-    expect(model.saveIssues).toHaveBeenCalledWith("vcs");
-    await waitFor(() => expect(model.finish).toHaveBeenCalledTimes(1));
-    expect(screen.queryByTestId("first-run-agent")).not.toBeInTheDocument();
-  });
+      expect(model.saveIssues).toHaveBeenCalledWith("vcs");
+      await waitFor(() => expect(model.finish).toHaveBeenCalledTimes(1));
+      expect(screen.queryByTestId("first-run-agent")).not.toBeInTheDocument();
+    },
+  );
 
   // Regression: the click that sets the issues choice and the call that
   // provisions the workspace happen in the same handler. `finish` used to
@@ -432,7 +457,7 @@ describe("FirstRunSetup", () => {
     expect(finish).toBeDisabled();
   });
 
-  it("opens the agent screen when the agent needs a connected provider", async () => {
+  it("opens the agent screen when local setup has no hosted agent", async () => {
     const user = userEvent.setup();
     const model = pageModel({ hostedAgentReady: false });
 

--- a/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.spec.ts
@@ -43,7 +43,6 @@ describe("resolveOnboardingAgent", () => {
     expect(
       resolveOnboardingAgent({
         connected: connected("openrouter"),
-        remainingCreditCents: 5000,
         hostedModels: { ...noHostedModels, openrouter: ["openai/gpt-4.1", "anthropic/claude-sonnet-4-6"] },
       }),
     ).toEqual({
@@ -61,7 +60,6 @@ describe("resolveOnboardingAgent", () => {
     expect(
       resolveOnboardingAgent({
         connected: connected("openrouter"),
-        remainingCreditCents: 5000,
         hostedModels: {
           ...noHostedModels,
           openrouter: ["anthropic/claude-opus-4-6", "anthropic/claude-sonnet-4-6"],
@@ -78,7 +76,6 @@ describe("resolveOnboardingAgent", () => {
     expect(
       resolveOnboardingAgent({
         connected: connected("claude"),
-        remainingCreditCents: 0,
         hostedModels: noHostedModels,
       }),
     ).toMatchObject({
@@ -88,11 +85,10 @@ describe("resolveOnboardingAgent", () => {
     });
   });
 
-  it("uses hosted SuperPlane when credit remains and a default model is set", () => {
+  it("uses hosted SuperPlane when a default model is set", () => {
     expect(
       resolveOnboardingAgent({
         connected: connected(),
-        remainingCreditCents: 5000,
         hostedModels: { ...noHostedModels, openrouter: ["openai/gpt-4.1"] },
         defaultHostedProvider: "openrouter",
         defaultHostedModel: "openai/gpt-4.1",
@@ -106,21 +102,19 @@ describe("resolveOnboardingAgent", () => {
     });
   });
 
-  it("does not plan SuperPlane when credit remains without a default model", () => {
+  it("does not plan SuperPlane without a default model", () => {
     expect(
       resolveOnboardingAgent({
         connected: connected(),
-        remainingCreditCents: 5000,
         hostedModels: { ...noHostedModels, openai: ["gpt-5", "gpt-4.1"] },
       }),
     ).toBeUndefined();
   });
 
-  it("uses a connected provider when hosted credit has no default model", () => {
+  it("uses a connected provider when no hosted default is available", () => {
     expect(
       resolveOnboardingAgent({
         connected: connected("openai"),
-        remainingCreditCents: 5000,
         hostedModels: { ...noHostedModels, openrouter: ["anthropic/claude-sonnet-4-6"] },
       })?.providerId,
     ).toBe("openai");
@@ -130,7 +124,6 @@ describe("resolveOnboardingAgent", () => {
     expect(
       resolveOnboardingAgent({
         connected: connected("claude"),
-        remainingCreditCents: 5000,
         hostedModels: noHostedModels,
         defaultHostedProvider: "anthropic",
         defaultHostedModel: "claude-sonnet-4-6",
@@ -219,19 +212,17 @@ describe("firstWorkOrderAgentError", () => {
     ).toBe("Ask an installation admin to set a SuperPlane agent model.");
   });
 
-  it("returns null when a plan is ready", () => {
+  it("allows a hosted plan when credit is empty", () => {
     expect(
       firstWorkOrderAgentError({
-        remainingCreditCents: 5000,
+        remainingCreditCents: 0,
         hostedModelsLoading: false,
         plan: {
-          providerId: "openrouter",
-          component: "runnerOpenRouter",
+          component: "runnerSuperPlane",
           credentialsSource: "hosted",
-          integrationName: "openrouter",
-          harness: "AGENT_HARNESS_CLAUDE_CODE",
-          model: "openai/gpt-4.1",
-          planningModel: "openai/gpt-4.1",
+          harness: "AGENT_HARNESS_SUPERPLANE",
+          model: "",
+          planningModel: "",
         },
       }),
     ).toBeNull();

--- a/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.ts
@@ -80,7 +80,6 @@ export function isAgentStepReady(connected: Set<IntegrationId>, remainingCreditC
 
 export function resolveOnboardingAgent(args: {
   connected: Set<IntegrationId>;
-  remainingCreditCents: number;
   hostedModels: HostedModelsByProvider;
   defaultHostedProvider?: string;
   defaultHostedModel?: string;
@@ -97,12 +96,9 @@ export function resolveOnboardingAgent(args: {
 }
 
 function hostedSuperPlanePlan(args: {
-  remainingCreditCents: number;
   defaultHostedProvider?: string;
   defaultHostedModel?: string;
 }): OnboardingAgentPlan | undefined {
-  if (args.remainingCreditCents <= 0) return undefined;
-
   const defaultProvider = args.defaultHostedProvider?.trim() ?? "";
   const defaultModel = args.defaultHostedModel?.trim() ?? "";
   if (!defaultProvider || !defaultModel) return undefined;
@@ -121,8 +117,9 @@ export function hostedModelsQueriesLoading(needHosted: boolean, queries: Array<{
 }
 
 /**
- * Hosted credit answers the agent question for the organization, so setup has
- * nothing left to ask about the agent.
+ * A hosted default answers the agent question for the organization, so setup
+ * has nothing left to ask about the agent. Billing controls hosted runs after
+ * setup. Installations without a hosted default still use the connection step.
  */
 export function isHostedAgentReady(plan: OnboardingAgentPlan | undefined): boolean {
   return plan?.component === "runnerSuperPlane";

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingAgentPlan.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingAgentPlan.spec.ts
@@ -1,0 +1,34 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useOnboardingAgentPlan } from "./useOnboardingAgentPlan";
+
+vi.mock("@/hooks/useHostedLLMModels", () => ({
+  useHostedLLMModels: () => ({ data: { models: [] }, isFetched: true }),
+}));
+
+describe("useOnboardingAgentPlan", () => {
+  it("uses the hosted agent when credit is empty", () => {
+    const { result } = renderHook(() =>
+      useOnboardingAgentPlan("org-1", new Set(), 0, {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      }),
+    );
+
+    expect(result.current.remainingCreditCents).toBe(0);
+    expect(result.current.plan).toEqual({
+      component: "runnerSuperPlane",
+      credentialsSource: "hosted",
+      harness: "AGENT_HARNESS_SUPERPLANE",
+      model: "",
+      planningModel: "",
+    });
+  });
+
+  it("requires a provider connection when no hosted agent is configured", () => {
+    const { result } = renderHook(() => useOnboardingAgentPlan("org-1", new Set(), 0));
+
+    expect(result.current.plan).toBeUndefined();
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingAgentPlan.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingAgentPlan.ts
@@ -26,7 +26,6 @@ export function useOnboardingAgentPlan(
     hostedModelsLoading: hostedModelsQueriesLoading(needHostedModels, [anthropic, openai, openrouter]),
     plan: resolveOnboardingAgent({
       connected,
-      remainingCreditCents,
       hostedModels: {
         anthropic: hostedModelIds(anthropic.data?.models),
         openai: hostedModelIds(openai.data?.models),


### PR DESCRIPTION
## Summary

Hosted workspaces no longer show the provider connection step when credit is empty. Agent availability now depends on the configured hosted default. Onboarding can finish before the organization receives credit, while billing still controls hosted runs.

## Test plan

- [x] Test a new user with a new organization and workspace.
- [x] Test an existing user with a new workspace.
- [x] Test an existing user with a new organization and workspace.
- [x] Run the targeted onboarding tests.
- [x] Run all factory API tests.
- [x] Run make check.lint.ui.
- [x] Run make check.build.ui.
- [x] Run make lint.
- [x] Run make check.build.app.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62799736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge; the previously reported backend rejection has been fixed while hosted-default validation remains enforced.

<sub>Reviews (2) · Last reviewed commit: ["fix: Let hosted onboarding finish withou..."](https://github.com/superplanehq/superplane/commit/b47d92bea6936f37d75b3c717af9ec21ccfa6805)</sub>

<!-- /greptile_comment -->