### PR TITLE
fix: Redirect GitHub App update callbacks

### DIFF
--- a/pkg/public/github_app.go
+++ b/pkg/public/github_app.go
@@ -24,8 +24,8 @@ const githubInstallApprovedPath = "/github/approved"
 // GitHub sends every install to this one Setup URL. The CSRF state finds
 // the pending SuperPlane connection.
 func (s *Server) HandleGitHubAppSetup(w http.ResponseWriter, r *http.Request) {
-	if isGitHubOwnerApprovedSetup(r) {
-		http.Redirect(w, r, githubInstallApprovedPath, http.StatusFound)
+	if path, ok := githubAppSetupRedirectWithoutState(r); ok {
+		http.Redirect(w, r, path, http.StatusFound)
 		return
 	}
 
@@ -38,19 +38,28 @@ func (s *Server) HandleGitHubAppSetup(w http.ResponseWriter, r *http.Request) {
 	middleware.AccountAuthMiddleware(s.jwt)(http.HandlerFunc(s.dispatchGitHubAppByState)).ServeHTTP(w, r)
 }
 
-// isGitHubOwnerApprovedSetup is the GitHub admin-approve callback. GitHub
-// sends installation_id and setup_action=install and omits the original
-// CSRF state, so this request cannot find the pending SuperPlane connection.
-func isGitHubOwnerApprovedSetup(r *http.Request) bool {
+// githubAppSetupRedirectWithoutState handles completed setup callbacks that
+// GitHub cannot associate with the original SuperPlane connection. GitHub can
+// omit state after an admin approves an install and after a user updates an
+// existing installation. Do not trust or bind the supplied installation ID;
+// signed webhooks synchronize installation updates independently.
+func githubAppSetupRedirectWithoutState(r *http.Request) (string, bool) {
 	query := r.URL.Query()
 	if query.Get("state") != "" {
-		return false
+		return "", false
 	}
-	if query.Get("setup_action") != "install" {
-		return false
+	if strings.TrimSpace(query.Get("installation_id")) == "" {
+		return "", false
 	}
 
-	return strings.TrimSpace(query.Get("installation_id")) != ""
+	switch query.Get("setup_action") {
+	case "install":
+		return githubInstallApprovedPath, true
+	case "update":
+		return "/", true
+	default:
+		return "", false
+	}
 }
 
 func (s *Server) HandleGitHubAppOAuthCallback(w http.ResponseWriter, r *http.Request) {

--- a/pkg/public/github_app_test.go
+++ b/pkg/public/github_app_test.go
@@ -42,9 +42,34 @@ func Test__HandleGitHubAppSetup_ownerApprovedInstallWithoutState(t *testing.T) {
 	assert.Equal(t, "/github/approved", rec.Header().Get("Location"))
 }
 
+func Test__HandleGitHubAppSetup_updateWithoutStateReturnsToApp(t *testing.T) {
+	server := &Server{}
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/github/app/setup?installation_id=159131070&setup_action=update",
+		nil,
+	)
+	rec := httptest.NewRecorder()
+
+	server.HandleGitHubAppSetup(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Equal(t, "/", rec.Header().Get("Location"))
+}
+
 func Test__HandleGitHubAppSetup_installWithoutInstallationIDStaysMissingState(t *testing.T) {
 	server := &Server{}
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/github/app/setup?setup_action=install", nil)
+	rec := httptest.NewRecorder()
+
+	server.HandleGitHubAppSetup(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func Test__HandleGitHubAppSetup_updateWithoutInstallationIDStaysMissingState(t *testing.T) {
+	server := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/github/app/setup?setup_action=update", nil)
 	rec := httptest.NewRecorder()
 
 	server.HandleGitHubAppSetup(rec, req)

--- a/pkg/public/server_auth_test.go
+++ b/pkg/public/server_auth_test.go
@@ -102,6 +102,22 @@ func Test__GitHubAppSetup_ownerApprovedWithoutSession(t *testing.T) {
 	assert.Equal(t, "/github/approved", rec.Header().Get("Location"))
 }
 
+func Test__GitHubAppSetup_updateWithoutSessionReturnsToApp(t *testing.T) {
+	r := support.Setup(t)
+	server, _, _ := setupTestServer(r, t)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		server.BasePath+"/github/app/setup?installation_id=159131070&setup_action=update",
+		nil,
+	)
+	rec := httptest.NewRecorder()
+	server.Router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Equal(t, "/", rec.Header().Get("Location"))
+}
+
 func Test__GetAccount(t *testing.T) {
 	r := support.Setup(t)
 	server, _, token := setupTestServer(r, t)


### PR DESCRIPTION
## Summary

GitHub can omit callback state after users update an existing App installation.

SuperPlane currently displays missing state instead of returning the browser to the application.

This change redirects recognized callback shapes without trusting the supplied installation ID.

## Test plan

- [x] Send an update callback with an installation ID and no state.
- [x] Confirm the callback redirects to SuperPlane without a session.
- [x] Confirm malformed callbacks still return a bad request.
- [x] Run the 230-test public server suite.
- [x] Run Go formatting, lint, and build checks.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62889231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge with no actionable correctness, security, or repository-rule violations identified.

<sub>Reviews (1) · Last reviewed commit: ["fix: Redirect GitHub App update callback..."](https://github.com/superplanehq/superplane/commit/37004b84c6984ab35d44a8cb2c894f624232ca1c)</sub>

<!-- /greptile_comment -->