### PR TITLE
fix: Align billing tests with catalog rates

### DIFF
--- a/pkg/grpc/actions/factories/describe_factory_usage_test.go
+++ b/pkg/grpc/actions/factories/describe_factory_usage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"github.com/superplanehq/superplane/pkg/usage/pricebook"
 	"github.com/superplanehq/superplane/test/support"
 )
 
@@ -54,14 +55,22 @@ func Test__DescribeFactoryUsage(t *testing.T) {
 		InputTokens:     1_000_000,
 		TotalTokens:     1_000_000,
 	}))
+	const (
+		computeMachineType = "e1-large-amd64"
+		computeSeconds     = int64(300)
+	)
+	computeCostCents := pricebook.MicrosToCents(
+		pricebook.EstimateComputeMicros(computeMachineType, computeMachineType, computeSeconds),
+	)
+	require.Greater(t, computeCostCents, int64(0))
 	require.NoError(t, models.RecordComputeUsage(db, models.ComputeUsageEventInput{
 		OrganizationID:  r.Organization.ID,
 		CanvasRunID:     *execution.RunID,
 		NodeExecutionID: uuid.New(),
 		NodeID:          "runner",
-		MachineType:     "e1-large-amd64",
-		FleetID:         "e1-large-amd64",
-		DurationSeconds: 90,
+		MachineType:     computeMachineType,
+		FleetID:         computeMachineType,
+		DurationSeconds: computeSeconds,
 		IdempotencyKey:  "runner:compute:factory-usage:" + uuid.New().String(),
 	}))
 
@@ -72,12 +81,12 @@ func Test__DescribeFactoryUsage(t *testing.T) {
 	assert.Equal(t, int32(30), resp.PeriodDays)
 	assert.Equal(t, int64(1_000_000), resp.TotalTokens)
 	require.Len(t, resp.ByMachineType, 1)
-	assert.Equal(t, int64(300)+resp.ByMachineType[0].CostCents, resp.TotalCostCents)
+	assert.Equal(t, int64(300)+computeCostCents, resp.TotalCostCents)
 	require.Len(t, resp.ByModel, 1)
 	assert.Equal(t, "anthropic", resp.ByModel[0].Provider)
 	assert.Equal(t, "claude-sonnet-4-6", resp.ByModel[0].Model)
-	assert.Equal(t, int64(90), resp.TotalDurationSeconds)
-	assert.Equal(t, "e1-large-amd64", resp.ByMachineType[0].MachineType)
-	assert.Equal(t, int64(90), resp.ByMachineType[0].DurationSeconds)
-	assert.Positive(t, resp.ByMachineType[0].CostCents)
+	assert.Equal(t, computeSeconds, resp.TotalDurationSeconds)
+	assert.Equal(t, computeMachineType, resp.ByMachineType[0].MachineType)
+	assert.Equal(t, computeSeconds, resp.ByMachineType[0].DurationSeconds)
+	assert.Equal(t, computeCostCents, resp.ByMachineType[0].CostCents)
 }

--- a/pkg/grpc/actions/factories/export_factory_work_order_run_usage_test.go
+++ b/pkg/grpc/actions/factories/export_factory_work_order_run_usage_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"github.com/superplanehq/superplane/pkg/usage/pricebook"
 	"github.com/superplanehq/superplane/test/support"
 )
 
@@ -59,14 +60,22 @@ func Test__ExportFactoryWorkOrderRunUsage(t *testing.T) {
 		InputTokens:     1_000_000,
 		TotalTokens:     1_000_000,
 	}))
+	const (
+		computeMachineType = "e1-large-amd64"
+		computeSeconds     = int64(300)
+	)
+	computeCostCents := pricebook.MicrosToCents(
+		pricebook.EstimateComputeMicros(computeMachineType, computeMachineType, computeSeconds),
+	)
+	require.Greater(t, computeCostCents, int64(0))
 	require.NoError(t, models.RecordComputeUsage(db, models.ComputeUsageEventInput{
 		OrganizationID:  r.Organization.ID,
 		CanvasRunID:     *execution.RunID,
 		NodeExecutionID: uuid.New(),
 		NodeID:          "runner",
-		MachineType:     "e1-large-amd64",
-		FleetID:         "e1-large-amd64",
-		DurationSeconds: 90,
+		MachineType:     computeMachineType,
+		FleetID:         computeMachineType,
+		DurationSeconds: computeSeconds,
 		IdempotencyKey:  "runner:compute:export-usage:" + uuid.New().String(),
 	}))
 
@@ -99,16 +108,13 @@ func Test__ExportFactoryWorkOrderRunUsage(t *testing.T) {
 	assert.Equal(t, factory.WorkOrderKey(order.Number), row[2])
 	assert.Equal(t, "anthropic/claude-sonnet-4-6 (your keys)", row[3])
 	assert.Equal(t, "1000000", row[4])
-	assert.Equal(t, "e1-large-amd64", row[6])
-	assert.Equal(t, "90", row[7])
+	assert.Equal(t, computeMachineType, row[6])
+	assert.Equal(t, strconv.FormatInt(computeSeconds, 10), row[7])
 
 	tokenPriceCents, err := strconv.ParseFloat(row[5], 64)
 	require.NoError(t, err)
 	assert.Greater(t, tokenPriceCents, 0.0)
-
-	vmPriceCents, err := strconv.ParseFloat(row[8], 64)
-	require.NoError(t, err)
-	assert.Greater(t, vmPriceCents, 0.0)
+	assert.Equal(t, formatUsageCSVCents(computeCostCents), row[8])
 }
 
 func Test__ExportFactoryWorkOrderRunUsage__NoRows(t *testing.T) {

--- a/web_src/src/pages/factories/pages/onboarding/AgentStep.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/AgentStep.spec.tsx
@@ -48,7 +48,7 @@ describe("AgentStep", () => {
     expect(screen.getByText("SuperPlane-hosted credit")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "This organization has $41.24 of hosted credit. You can continue without connecting your own keys.",
+        "This organization has $41.24 of trial usage for machines and managed models. Subscribe to Business to keep hosted runs after the trial.",
       ),
     ).toBeInTheDocument();
   });
@@ -78,7 +78,9 @@ describe("AgentStep", () => {
     });
 
     expect(screen.getByTestId("hosted-credit-grant")).toBeInTheDocument();
-    expect(screen.getByText("Hosted credit is empty. Connect a provider to continue.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Trial credit is used up. Subscribe to Business or connect a provider to continue."),
+    ).toBeInTheDocument();
   });
 
   it("connects OpenAI without selecting a single harness", async () => {

--- a/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.spec.ts
@@ -249,7 +249,7 @@ describe("hosted credit grant copy", () => {
 
   it("explains that remaining credit lets the user continue without keys", () => {
     expect(hostedCreditGrantCopy(5000)).toBe(
-      "This organization has $50.00 of hosted credit. You can continue without connecting your own keys.",
+      "This organization has $50.00 of trial usage for machines and managed models. Subscribe to Business to keep hosted runs after the trial.",
     );
   });
 

--- a/web_src/src/pages/factories/pages/organizationSettings/BillingCreditHistoryCard.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/BillingCreditHistoryCard.tsx
@@ -1,0 +1,58 @@
+import type { OrganizationsOrganizationCreditGrant } from "@/api-client";
+import { Badge } from "@/components/ui/badge";
+
+import { creditGrantDetails, creditGrantSourceLabel, formatCreditGrantAmount } from "../../lib/hostedCreditGrants";
+import { parseWorkOrderMetric } from "../../lib/workOrderUsage";
+import { FactorySettingsCard } from "../settings/FactorySettingsCard";
+
+export function BillingCreditHistoryCard({ grants }: { grants: OrganizationsOrganizationCreditGrant[] }) {
+  return (
+    <FactorySettingsCard title="Credit history" data-testid="billing-credit-history">
+      {grants.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No credit grants yet.</p>
+      ) : (
+        <CreditGrantTable grants={grants} />
+      )}
+    </FactorySettingsCard>
+  );
+}
+
+function CreditGrantTable({ grants }: { grants: OrganizationsOrganizationCreditGrant[] }) {
+  return (
+    <table className="mt-1 w-full text-left text-[13px]">
+      <thead>
+        <tr className="border-b border-border text-muted-foreground">
+          <th className="py-2 pr-3 font-medium">Date</th>
+          <th className="py-2 pr-3 font-medium">Source</th>
+          <th className="py-2 pr-3 font-medium">Amount</th>
+          <th className="py-2 font-medium">Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {grants.map((grant) => (
+          <tr key={grant.id ?? `${grant.kind}-${grant.createdAt}`} className="border-b border-border last:border-0">
+            <td className="py-2 pr-3 whitespace-nowrap">{formatGrantDate(grant.createdAt)}</td>
+            <td className="py-2 pr-3">
+              <Badge variant="secondary">{creditGrantSourceLabel(grant.kind)}</Badge>
+            </td>
+            <td className="py-2 pr-3 whitespace-nowrap">
+              {formatCreditGrantAmount(parseWorkOrderMetric(grant.amountCents))}
+            </td>
+            <td className="py-2 text-muted-foreground">{creditGrantDetails(grant) || "—"}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function formatGrantDate(value: string | undefined) {
+  if (!value) {
+    return "—";
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleDateString();
+}

--- a/web_src/src/pages/factories/pages/organizationSettings/BillingInvoicesCard.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/BillingInvoicesCard.tsx
@@ -1,0 +1,135 @@
+import { Check, ExternalLink, Receipt } from "lucide-react";
+
+import type { OrganizationsHostedCreditInvoice } from "@/api-client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+import { formatUsdCents, parseWorkOrderMetric } from "../../lib/workOrderUsage";
+import { FactorySettingsCard } from "../settings/FactorySettingsCard";
+
+const INVOICES_DESCRIPTION = "Recent paid invoices for this organization.";
+const INVOICES_EMPTY_TITLE = "No invoices yet";
+const INVOICES_EMPTY_BODY = "Paid invoices appear here after checkout.";
+
+export function BillingInvoicesCard({
+  invoices,
+  portalPending,
+  onManageInvoices,
+}: {
+  invoices: OrganizationsHostedCreditInvoice[];
+  portalPending: boolean;
+  onManageInvoices: () => void | Promise<void>;
+}) {
+  return (
+    <FactorySettingsCard
+      title="Invoices"
+      data-testid="billing-polar-invoices"
+      action={
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          disabled={portalPending}
+          onClick={() => void onManageInvoices()}
+        >
+          {portalPending ? "Opening invoices..." : "Manage invoices"}
+          <ExternalLink className="size-3.5" aria-hidden />
+        </Button>
+      }
+    >
+      <p className="text-[12px] text-muted-foreground">{INVOICES_DESCRIPTION}</p>
+      {invoices.length === 0 ? <InvoiceEmptyState /> : <InvoiceList invoices={invoices} />}
+    </FactorySettingsCard>
+  );
+}
+
+function InvoiceEmptyState() {
+  return (
+    <div className="mt-4 flex flex-col items-center rounded-lg border border-dashed border-border px-6 py-8 text-center">
+      <Receipt className="size-5 text-muted-foreground" aria-hidden />
+      <p className="mt-2 text-sm font-medium text-foreground">{INVOICES_EMPTY_TITLE}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{INVOICES_EMPTY_BODY}</p>
+    </div>
+  );
+}
+
+function InvoiceList({ invoices }: { invoices: OrganizationsHostedCreditInvoice[] }) {
+  return (
+    <ul className="mt-3 divide-y divide-border">
+      {invoices.map((invoice) => (
+        <InvoiceRow key={invoice.id} invoice={invoice} />
+      ))}
+    </ul>
+  );
+}
+
+function InvoiceRow({ invoice }: { invoice: OrganizationsHostedCreditInvoice }) {
+  const productName = invoice.productName || "Hosted credit";
+  const amount = formatUsdCents(parseWorkOrderMetric(invoice.amountCents));
+  const dateLabel = formatInvoiceDate(invoice.createdAt);
+
+  return (
+    <li className="flex items-center gap-3 py-3 first:pt-1 last:pb-0">
+      <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted">
+        <Receipt className="size-3.5 text-muted-foreground" aria-hidden />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-[13px] font-medium tracking-[-0.01em]">{productName}</p>
+        {invoice.createdAt ? (
+          <time className="mt-0.5 block text-xs text-muted-foreground" dateTime={invoice.createdAt}>
+            {dateLabel}
+          </time>
+        ) : (
+          <p className="mt-0.5 text-xs text-muted-foreground">{dateLabel}</p>
+        )}
+      </div>
+      <p className="shrink-0 text-[13px] font-medium tracking-[-0.01em] tabular-nums">{amount}</p>
+      <InvoiceStatusBadge status={invoice.status} />
+    </li>
+  );
+}
+
+function InvoiceStatusBadge({ status }: { status: string | undefined }) {
+  const label = invoiceStatusLabel(status);
+  if (status === "paid") {
+    return (
+      <Badge
+        variant="outline"
+        className="border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+      >
+        <Check aria-hidden />
+        {label}
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="outline" className="text-muted-foreground">
+      {label}
+    </Badge>
+  );
+}
+
+function formatInvoiceDate(value: string | undefined) {
+  if (!value) {
+    return "—";
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
+function invoiceStatusLabel(status: string | undefined) {
+  switch (status) {
+    case "paid":
+      return "Paid";
+    case "refunded":
+      return "Refunded";
+    case "partially_refunded":
+      return "Partially refunded";
+    default:
+      return status || "Unknown";
+  }
+}

--- a/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettingsBillingPage.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettingsBillingPage.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronRight, ExternalLink, Receipt } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import { useParams } from "react-router";
 
@@ -8,7 +8,6 @@ import type {
   OrganizationsOrganizationCreditGrant,
 } from "@/api-client";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { getApiErrorMessage } from "@/lib/errors";
@@ -24,9 +23,10 @@ import {
   type BillingCreditBucketView,
 } from "../../lib/billingCreditBuckets";
 import { hostedCreditBillingBalanceCopy } from "../../lib/hostedCreditEmpty";
-import { creditGrantDetails, creditGrantSourceLabel, formatCreditGrantAmount } from "../../lib/hostedCreditGrants";
 import { formatUsdCents, parseWorkOrderMetric } from "../../lib/workOrderUsage";
 import { FactorySettingsCard, FactorySettingsPageFrame } from "../settings/FactorySettingsCard";
+import { BillingCreditHistoryCard } from "./BillingCreditHistoryCard";
+import { BillingInvoicesCard } from "./BillingInvoicesCard";
 import { BillingPlansSection } from "./BillingPlansSection";
 import { useOrganizationBillingPageModel } from "./useOrganizationBillingPageModel";
 
@@ -34,9 +34,6 @@ const BUY_MORE_PACK_CENTS = [5_000, 10_000, 50_000] as const;
 const HOSTED_CREDIT_EXPLANATION =
   "Hosted credit pays SuperPlane-hosted machines and managed models for this organization.";
 const HOSTED_CREDIT_REMAINING_CAPTION = "Remaining hosted credit";
-const INVOICES_DESCRIPTION = "Recent paid invoices for this organization.";
-const INVOICES_EMPTY_TITLE = "No invoices yet";
-const INVOICES_EMPTY_BODY = "Paid invoices appear here after checkout.";
 
 export function OrganizationSettingsBillingPage() {
   const { organizationId = "" } = useParams<{ organizationId: string }>();
@@ -182,9 +179,9 @@ function BillingPageBody({
         onAddCredit={onAddCredit}
       />
       {showInvoices ? (
-        <PolarInvoicesCard invoices={invoices} portalPending={portalPending} onManageInvoices={onManageInvoices} />
+        <BillingInvoicesCard invoices={invoices} portalPending={portalPending} onManageInvoices={onManageInvoices} />
       ) : null}
-      <CreditHistoryCard grants={grants} />
+      <BillingCreditHistoryCard grants={grants} />
     </>
   );
 }
@@ -442,157 +439,6 @@ function HostedCreditTopUpBanner({
   );
 }
 
-function PolarInvoicesCard({
-  invoices,
-  portalPending,
-  onManageInvoices,
-}: {
-  invoices: OrganizationsHostedCreditInvoice[];
-  portalPending: boolean;
-  onManageInvoices: () => void | Promise<void>;
-}) {
-  return (
-    <FactorySettingsCard
-      title="Invoices"
-      data-testid="billing-polar-invoices"
-      action={
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          disabled={portalPending}
-          onClick={() => void onManageInvoices()}
-        >
-          {portalPending ? "Opening invoices..." : "Manage invoices"}
-          <ExternalLink className="size-3.5" aria-hidden />
-        </Button>
-      }
-    >
-      <p className="text-[12px] text-muted-foreground">{INVOICES_DESCRIPTION}</p>
-      {invoices.length === 0 ? <InvoiceEmptyState /> : <InvoiceList invoices={invoices} />}
-    </FactorySettingsCard>
-  );
-}
-
-function InvoiceEmptyState() {
-  return (
-    <div className="mt-4 flex flex-col items-center rounded-lg border border-dashed border-border px-6 py-8 text-center">
-      <Receipt className="size-5 text-muted-foreground" aria-hidden />
-      <p className="mt-2 text-sm font-medium text-foreground">{INVOICES_EMPTY_TITLE}</p>
-      <p className="mt-1 text-xs text-muted-foreground">{INVOICES_EMPTY_BODY}</p>
-    </div>
-  );
-}
-
-function InvoiceList({ invoices }: { invoices: OrganizationsHostedCreditInvoice[] }) {
-  return (
-    <ul className="mt-3 divide-y divide-border">
-      {invoices.map((invoice) => (
-        <InvoiceRow key={invoice.id} invoice={invoice} />
-      ))}
-    </ul>
-  );
-}
-
-function InvoiceRow({ invoice }: { invoice: OrganizationsHostedCreditInvoice }) {
-  const productName = invoice.productName || "Hosted credit";
-  const amount = formatUsdCents(parseWorkOrderMetric(invoice.amountCents));
-  const dateLabel = formatInvoiceDate(invoice.createdAt);
-
-  return (
-    <li className="flex items-center gap-3 py-3 first:pt-1 last:pb-0">
-      <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted">
-        <Receipt className="size-3.5 text-muted-foreground" aria-hidden />
-      </div>
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-[13px] font-medium tracking-[-0.01em]">{productName}</p>
-        {invoice.createdAt ? (
-          <time className="mt-0.5 block text-xs text-muted-foreground" dateTime={invoice.createdAt}>
-            {dateLabel}
-          </time>
-        ) : (
-          <p className="mt-0.5 text-xs text-muted-foreground">{dateLabel}</p>
-        )}
-      </div>
-      <p className="shrink-0 text-[13px] font-medium tracking-[-0.01em] tabular-nums">{amount}</p>
-      <InvoiceStatusBadge status={invoice.status} />
-    </li>
-  );
-}
-
-function InvoiceStatusBadge({ status }: { status: string | undefined }) {
-  const label = invoiceStatusLabel(status);
-  if (status === "paid") {
-    return (
-      <Badge
-        variant="outline"
-        className="border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
-      >
-        <Check aria-hidden />
-        {label}
-      </Badge>
-    );
-  }
-
-  return (
-    <Badge variant="outline" className="text-muted-foreground">
-      {label}
-    </Badge>
-  );
-}
-
-function CreditHistoryCard({ grants }: { grants: OrganizationsOrganizationCreditGrant[] }) {
-  return (
-    <FactorySettingsCard title="Credit history" data-testid="billing-credit-history">
-      {grants.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No credit grants yet.</p>
-      ) : (
-        <CreditGrantTable grants={grants} />
-      )}
-    </FactorySettingsCard>
-  );
-}
-
-function CreditGrantTable({ grants }: { grants: OrganizationsOrganizationCreditGrant[] }) {
-  return (
-    <table className="mt-1 w-full text-left text-[13px]">
-      <thead>
-        <tr className="border-b border-border text-muted-foreground">
-          <th className="py-2 pr-3 font-medium">Date</th>
-          <th className="py-2 pr-3 font-medium">Source</th>
-          <th className="py-2 pr-3 font-medium">Amount</th>
-          <th className="py-2 font-medium">Details</th>
-        </tr>
-      </thead>
-      <tbody>
-        {grants.map((grant) => (
-          <tr key={grant.id ?? `${grant.kind}-${grant.createdAt}`} className="border-b border-border last:border-0">
-            <td className="py-2 pr-3 whitespace-nowrap">{formatGrantDate(grant.createdAt)}</td>
-            <td className="py-2 pr-3">
-              <Badge variant="secondary">{creditGrantSourceLabel(grant.kind)}</Badge>
-            </td>
-            <td className="py-2 pr-3 whitespace-nowrap">
-              {formatCreditGrantAmount(parseWorkOrderMetric(grant.amountCents))}
-            </td>
-            <td className="py-2 text-muted-foreground">{creditGrantDetails(grant) || "—"}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
-}
-
-function formatInvoiceDate(value: string | undefined) {
-  if (!value) {
-    return "—";
-  }
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return value;
-  }
-  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
-}
-
 function findPackForCents(packs: OrganizationsHostedCreditProduct[], cents: number) {
   return packs.find((product) => Boolean(product.id) && parseWorkOrderMetric(product.amountCents) === cents);
 }
@@ -610,28 +456,4 @@ function creditRefreshClassName(status: HostedCreditRefreshStatus) {
     return "text-emerald-700 dark:text-emerald-400";
   }
   return "text-muted-foreground";
-}
-
-function formatGrantDate(value: string | undefined) {
-  if (!value) {
-    return "—";
-  }
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return value;
-  }
-  return parsed.toLocaleDateString();
-}
-
-function invoiceStatusLabel(status: string | undefined) {
-  switch (status) {
-    case "paid":
-      return "Paid";
-    case "refunded":
-      return "Refunded";
-    case "partially_refunded":
-      return "Partially refunded";
-    default:
-      return status || "Unknown";
-  }
 }

--- a/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettingsUsagePage.spec.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettingsUsagePage.spec.tsx
@@ -54,7 +54,7 @@ describe("OrganizationSettingsUsagePage", () => {
     expect(rows[0]).toHaveTextContent("$0.03");
     expect(rows[0]).toHaveTextContent("$0.50");
     expect(rows[0]).toHaveTextContent("anthropic/claude-sonnet-4-6 (your keys)");
-    expect(rows[0]).toHaveTextContent("e1-large-amd64");
+    expect(rows[0]).toHaveTextContent("Large x64");
     expect(rows[0]).toHaveTextContent("Leonardo DiCaprio");
     expect(within(rows[0]).getByRole("link", { name: "RF-101" })).toHaveAttribute(
       "href",
@@ -73,7 +73,7 @@ describe("OrganizationSettingsUsagePage", () => {
     expect(rows[1]).toHaveTextContent("Arnold Schwarzenegger");
 
     expect(rows[2]).toHaveTextContent("anthropic/claude-haiku-4-5 · anthropic/claude-sonnet-4-6 (your keys)");
-    expect(rows[2]).toHaveTextContent("e1-large-amd64");
+    expect(rows[2]).toHaveTextContent("Large x64");
     expect(rows[2]).toHaveTextContent("$1.23");
     expect(rows[2]).toHaveTextContent("$0.17");
   }, 10000);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 7342 lowered VM catalog rates and changed trial copy. Unit tests still expected a 90-second VM cost of at least one cent, the old hosted-credit strings, and raw machine ids. ESLint also went one file over the max-lines budget.

This change records five minutes of large-x64 usage so VM cents stay positive. It updates onboarding and usage tests to the new copy and labels. It also splits invoices and credit history out of the billing page so ESLint stays inside the budget.

## Test plan

- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/factories`.
- [ ] Confirm `Test__DescribeFactoryUsage` and `Test__ExportFactoryWorkOrderRunUsage` pass.
- [ ] Run the onboarding AgentStep and usage page unit tests.
- [ ] Run `make check.lint.ui` and confirm the ESLint budget does not grow.
- [ ] Confirm Billing still shows invoices and credit history.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27a7bbc7-6cfe-456e-85c3-631418ba6260?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27a7bbc7-6cfe-456e-85c3-631418ba6260&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

