### PR TITLE
feat: Make column automation rows read as controls

### DIFF
--- a/web_src/src/pages/factories/pages/ColumnAutomationRows.spec.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationRows.spec.tsx
@@ -46,7 +46,18 @@ describe("ColumnAutomationRows", () => {
     render(<ColumnAutomationRows title="Review" automations={[]} rowCount={2} testId="rows" />);
 
     expect(screen.getByTestId("rows-empty")).toHaveTextContent("No automations");
+    expect(screen.queryByRole("button", { name: "Add automation for Review" })).not.toBeInTheDocument();
     expect(screen.getAllByTestId("rows-blank")).toHaveLength(1);
+  });
+
+  it("offers Add automation when the empty row can open a picker", async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    render(<ColumnAutomationRows title="Review" automations={[]} rowCount={1} onAdd={onAdd} testId="rows" />);
+
+    await user.click(screen.getByRole("button", { name: "Add automation for Review" }));
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("rows-empty")).toHaveTextContent("Add automation");
   });
 
   it("marks an automation that needs repair", () => {
@@ -79,7 +90,14 @@ describe("ColumnAutomationRows", () => {
     expect(onRowAction).toHaveBeenCalledWith(GITHUB_INTAKE, "settings");
     expect(screen.queryByTestId("rows-menu-intake-github")).not.toBeInTheDocument();
     expect(screen.queryByTestId("column-automations-popup")).not.toBeInTheDocument();
-    expect(screen.getByTestId("rows-row-intake-github").className).toContain("group/automation");
+    expect(screen.getByTestId("rows-settings-intake-github")).toBeInTheDocument();
+    expect(screen.getByTestId("rows-row-intake-github").className).toContain("hover:bg-black/10");
+  });
+
+  it("hides the settings icon when the row cannot open settings", () => {
+    render(<ColumnAutomationRows title="Backlog" automations={[GITHUB_INTAKE]} rowCount={1} testId="rows" />);
+
+    expect(screen.queryByTestId("rows-settings-intake-github")).not.toBeInTheDocument();
   });
 
   it("does not draw a box around the rows", () => {

--- a/web_src/src/pages/factories/pages/ColumnAutomationRows.stories.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationRows.stories.tsx
@@ -1,0 +1,179 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MoreHorizontal, Plus } from "lucide-react";
+
+import githubIcon from "@/assets/icons/integrations/github.svg";
+
+import { ComponentStoryShell } from "../__fixtures__/ComponentStoryShell";
+import { withFactoriesTheme } from "../__fixtures__/factoriesStoryTheme";
+import type { ColumnAutomation } from "../lib/columnAutomations";
+import { WorkOrderBoardLane, WorkOrderKanbanBoard } from "../workOrders/WorkOrderBoardChrome";
+import { ColumnAutomationRows } from "./ColumnAutomationRows";
+import { lineBoardColumnLaneClassName } from "./lineBoardColumnColors";
+
+const GITHUB_INTAKE: ColumnAutomation = {
+  id: "intake-github",
+  kind: "intake",
+  name: "GitHub issues",
+  trigger: "On GitHub issue",
+  action: "Create a task",
+  iconSrc: githubIcon,
+  iconAlt: "GitHub",
+  health: "healthy",
+  runningCount: 0,
+  catalogId: "github-issues",
+};
+
+const ANALYSIS: ColumnAutomation = {
+  ...GITHUB_INTAKE,
+  id: "analysis",
+  kind: "analysis",
+  name: "Task analysis",
+  trigger: "On task in Backlog",
+  action: "Score the task",
+  iconSrc: "",
+  iconAlt: "",
+  catalogId: "analysis",
+};
+
+const IMPLEMENT: ColumnAutomation = {
+  ...GITHUB_INTAKE,
+  id: "implement-agent",
+  kind: "agent-step",
+  name: "Implement",
+  trigger: "On task in Implement",
+  action: "Run the Implement agent",
+  iconSrc: "",
+  iconAlt: "",
+  catalogId: "agent-step",
+};
+
+const VERIFY: ColumnAutomation = {
+  ...IMPLEMENT,
+  id: "verify-agent",
+  name: "Verify",
+  trigger: "On task in Verify",
+  action: "Run the Verify agent",
+};
+
+const meta = {
+  title: "Factories/Components/ColumnAutomationRows",
+  component: ColumnAutomationRows,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    withFactoriesTheme,
+    (Story) => (
+      <ComponentStoryShell className="min-h-screen bg-background p-6 dark:bg-background">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj;
+
+export const SettingsRows: Story = {
+  name: "Settings rows",
+  render: () => <Board />,
+};
+
+export const EmptyWithAdd: Story = {
+  name: "Empty with Add automation",
+  render: () => (
+    <div className="h-[240px] max-w-xs">
+      <Lane title="Review" automations={[]} onAdd={() => undefined} cards={[]} />
+    </div>
+  ),
+};
+
+function Board() {
+  return (
+    <div className="h-[280px]">
+      <WorkOrderKanbanBoard testId="automation-rows-settings">
+        <Lane
+          title="Backlog"
+          colorId="lime"
+          automations={[GITHUB_INTAKE, ANALYSIS]}
+          showAdd
+          cards={[{ title: "Show a clearer empty state on the setup page", meta: "1 hour ago" }]}
+        />
+        <Lane
+          title="Implement"
+          automations={[IMPLEMENT]}
+          cards={[{ title: "Notify on status change after a refund", meta: "Draft #114" }]}
+        />
+        <Lane
+          title="Verify"
+          automations={[VERIFY]}
+          cards={[{ title: "Add refund reason enum to schema", meta: "Draft #1022" }]}
+        />
+        <Lane
+          title="Review"
+          automations={[]}
+          onAdd={() => undefined}
+          cards={[{ title: "Ship idempotent refund retries", meta: "Review #6812" }]}
+        />
+      </WorkOrderKanbanBoard>
+    </div>
+  );
+}
+
+function Lane({
+  title,
+  colorId,
+  automations,
+  showAdd,
+  onAdd,
+  cards,
+}: {
+  title: string;
+  colorId?: "lime";
+  automations: ColumnAutomation[];
+  showAdd?: boolean;
+  onAdd?: () => void;
+  cards: Array<{ title: string; meta: string }>;
+}) {
+  return (
+    <WorkOrderBoardLane
+      title={title}
+      count={cards.length}
+      emptyDescription={`No tasks in ${title}.`}
+      keepChildrenWhenEmpty
+      surfaceClassName={lineBoardColumnLaneClassName(colorId)}
+      className={colorId ? undefined : "bg-muted"}
+      actions={
+        <div className="flex shrink-0 items-center gap-0.5">
+          {showAdd ? (
+            <span className="flex size-6 items-center justify-center rounded-md text-muted-foreground">
+              <Plus className="size-3.5" aria-hidden />
+            </span>
+          ) : null}
+          <span className="flex size-6 items-center justify-center rounded-md text-muted-foreground">
+            <MoreHorizontal className="size-3.5" aria-hidden />
+          </span>
+        </div>
+      }
+      subheader={
+        <ColumnAutomationRows
+          title={title}
+          automations={automations}
+          rowCount={2}
+          onRowAction={() => undefined}
+          onAdd={onAdd}
+          testId={`${title.toLowerCase()}-rows`}
+        />
+      }
+      testId={`${title.toLowerCase()}-lane`}
+    >
+      <ul className="flex flex-col gap-2 p-0.5">
+        {cards.map((card) => (
+          <li key={card.title} className="rounded-lg border border-border/70 bg-background px-3 py-2.5">
+            <p className="truncate text-[13px] font-medium text-foreground">{card.title}</p>
+            <p className="mt-1 text-[12px] text-muted-foreground">{card.meta}</p>
+          </li>
+        ))}
+      </ul>
+    </WorkOrderBoardLane>
+  );
+}

--- a/web_src/src/pages/factories/pages/ColumnAutomationRows.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationRows.tsx
@@ -1,10 +1,13 @@
+import { Plus, Settings2 } from "lucide-react";
+
 import { cn } from "@/lib/utils";
 
 import { columnAutomationHeadline } from "../lib/columnAutomationHeadline";
 import { COLUMN_AUTOMATIONS_COPY, type ColumnAutomation } from "../lib/columnAutomations";
 import { ColumnAutomationGlyph, type ColumnAutomationRowAction } from "./ColumnAutomationsPopup";
 
-const ROW_CLASSNAME = "flex h-5 w-full items-center gap-1.5 text-left text-[12px] leading-5";
+const ROW_CLASSNAME = "flex h-6 w-full min-w-0 items-center gap-1.5 rounded-md px-1.5 text-left text-[12px] leading-4";
+const ROW_HOVER_CLASSNAME = "transition-colors hover:bg-black/10 dark:hover:bg-black/20";
 
 /**
  * Header rows that name the automations behind a column. Every column on
@@ -16,12 +19,14 @@ export function ColumnAutomationRows({
   automations,
   rowCount,
   onRowAction,
+  onAdd,
   testId,
 }: {
   title: string;
   automations: ColumnAutomation[];
   rowCount: number;
   onRowAction?: (automation: ColumnAutomation, action: ColumnAutomationRowAction) => void;
+  onAdd?: () => void;
   testId: string;
 }) {
   const blankCount = Math.max(0, rowCount - Math.max(1, automations.length));
@@ -29,9 +34,7 @@ export function ColumnAutomationRows({
   return (
     <div role="list" aria-label={`${title} automations`} className="flex flex-col gap-0.5" data-testid={testId}>
       {automations.length === 0 ? (
-        <p className={cn(ROW_CLASSNAME, "text-muted-foreground/70")} data-testid={`${testId}-empty`}>
-          {COLUMN_AUTOMATIONS_COPY.rowsEmpty}
-        </p>
+        <EmptyAutomationRow title={title} onAdd={onAdd} testId={testId} />
       ) : (
         automations.map((automation) => (
           <ColumnAutomationRow key={automation.id} automation={automation} onRowAction={onRowAction} testId={testId} />
@@ -41,6 +44,29 @@ export function ColumnAutomationRows({
         <div key={`blank-${index}`} className={ROW_CLASSNAME} aria-hidden data-testid={`${testId}-blank`} />
       ))}
     </div>
+  );
+}
+
+function EmptyAutomationRow({ title, onAdd, testId }: { title: string; onAdd?: () => void; testId: string }) {
+  if (!onAdd) {
+    return (
+      <p className={cn(ROW_CLASSNAME, "text-muted-foreground")} data-testid={`${testId}-empty`}>
+        {COLUMN_AUTOMATIONS_COPY.rowsEmpty}
+      </p>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid={`${testId}-empty`}
+      aria-label={`${COLUMN_AUTOMATIONS_COPY.addLabel} for ${title}`}
+      onClick={onAdd}
+      className={cn(ROW_CLASSNAME, ROW_HOVER_CLASSNAME, "text-muted-foreground hover:text-foreground")}
+    >
+      <Plus className="size-3.5 shrink-0" aria-hidden />
+      <span className="min-w-0 flex-1 truncate">{COLUMN_AUTOMATIONS_COPY.addLabel}</span>
+    </button>
   );
 }
 
@@ -58,21 +84,26 @@ function ColumnAutomationRow({
   const headline = columnAutomationHeadline(automation);
   const className = cn(
     ROW_CLASSNAME,
-    "min-w-0 text-muted-foreground",
+    "text-foreground",
     disabled && "line-through opacity-60",
-    onRowAction && "group/automation cursor-pointer",
+    onRowAction && ROW_HOVER_CLASSNAME,
   );
   const content = (
     <>
       <ColumnAutomationGlyph automation={automation} className="size-3.5" />
-      <span className={cn("min-w-0 flex-1 truncate", onRowAction && "group-hover/automation:text-foreground")}>
-        {headline}
-      </span>
+      <span className="min-w-0 flex-1 truncate">{headline}</span>
       {needsRepair ? (
         <span
           className="size-1.5 shrink-0 rounded-full bg-amber-500"
           title={COLUMN_AUTOMATIONS_COPY.needsRepairLabel}
           data-testid={`${testId}-needs-repair-${automation.id}`}
+        />
+      ) : null}
+      {onRowAction ? (
+        <Settings2
+          className="size-3.5 shrink-0 text-muted-foreground"
+          aria-hidden
+          data-testid={`${testId}-settings-${automation.id}`}
         />
       ) : null}
     </>

--- a/web_src/src/pages/factories/pages/columnAutomationRowsSubheader.tsx
+++ b/web_src/src/pages/factories/pages/columnAutomationRowsSubheader.tsx
@@ -10,6 +10,7 @@ export function columnAutomationRowsSubheader(args: {
   automations?: ColumnAutomation[];
   rowCount?: number;
   onRowAction?: (automation: ColumnAutomation, action: ColumnAutomationRowAction) => void;
+  onAdd?: () => void;
   testId: string;
 }): ReactNode {
   if (!args.rowCount || !args.automations) {
@@ -21,6 +22,7 @@ export function columnAutomationRowsSubheader(args: {
       automations={args.automations}
       rowCount={args.rowCount}
       onRowAction={args.onRowAction}
+      onAdd={args.onAdd}
       testId={args.testId}
     />
   );


### PR DESCRIPTION
## Summary

- The automation lines under a line board column title are clickable, but they render as muted caption text. Users read them as a description and do not open them.
- Render each row as a settings row: foreground text, a settings icon on every row that can open settings, and a hover shade.
- The hover uses a translucent black wash, not the opaque accent gray. The column tint stays visible and only gets darker.
- The empty row can show "Add automation" when the parent passes an `onAdd` handler. The line board does not pass it yet, so the board copy is unchanged until the add picker is wired per column.
- Add a Storybook story that renders the rows on the real lane chrome.

## Test plan

- [ ] Open a line board with column automations in the names view.
- [ ] Confirm each automation row shows a settings icon at the end.
- [ ] Hover a row on a colored column. Confirm the row gets darker and does not turn gray.
- [ ] Click a row. Confirm the automation settings open.
- [ ] Open a column with no automation. Confirm it still reads "No automations".
- [ ] Open Storybook `Factories/Components/ColumnAutomationRows`. Confirm both stories render.
- [ ] Run `make check.lint.ui` and `make check.build.ui`.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62972928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The behavioral styling change appears low risk, but the explicit UI-component and Storybook callback requirements must be satisfied before merging.

<sub>Reviews (1) · Last reviewed commit: ["feat: Make column automation rows read a..."](https://github.com/superplanehq/superplane/commit/037979d613da2473b3b3a0f7852b62cc3d3f9143)</sub>

<!-- /greptile_comment -->