### PR TITLE
feat: Show task cards in factory automation runs

### DIFF
--- a/pkg/grpc/actions/factories/serialization.go
+++ b/pkg/grpc/actions/factories/serialization.go
@@ -360,7 +360,15 @@ func serializeWorkOrder(
 		TotalDurationSeconds: usage.DurationSeconds,
 		StatusNotes:          statusNotes,
 		Origin:               serializeWorkOrderOrigin(order),
+		SourceRunId:          serializeWorkOrderSourceRunID(order),
 	}, nil
+}
+
+func serializeWorkOrderSourceRunID(order *models.FactoryWorkOrder) string {
+	if order.SourceRunID == nil {
+		return ""
+	}
+	return order.SourceRunID.String()
 }
 
 func serializeWorkOrderOrigin(order *models.FactoryWorkOrder) *pb.WorkOrderOrigin {

--- a/pkg/grpc/actions/factories/serialization_test.go
+++ b/pkg/grpc/actions/factories/serialization_test.go
@@ -73,6 +73,14 @@ func TestSerializeWorkOrderCreator_NoneReturnsNil(t *testing.T) {
 	assert.Nil(t, mustSerializeWorkOrder(t, nil, order, nil, nil).GetCreatedBy())
 }
 
+func TestSerializeWorkOrder_SourceRunID(t *testing.T) {
+	runID := uuid.New()
+	order := &models.FactoryWorkOrder{ID: uuid.New(), SourceRunID: &runID}
+
+	assert.Equal(t, runID.String(), mustSerializeWorkOrder(t, nil, order, nil, nil).GetSourceRunId())
+	assert.Empty(t, mustSerializeWorkOrder(t, nil, &models.FactoryWorkOrder{ID: uuid.New()}, nil, nil).GetSourceRunId())
+}
+
 func TestSerializeExecutionSteps_UsesCanvasNames(t *testing.T) {
 	steps := []models.FactoryLineStep{
 		{Type: models.FactoryLineStepTypeRunApp},

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -1427,6 +1427,9 @@ message WorkOrder {
   // Ready files for this task. Present on DescribeWorkOrder only.
   // The stored description uses sp-file:// refs, not download URLs.
   repeated Superplane.Files.File files = 18;
+  // Canvas run that created this task, when Create Task produced it.
+  // Empty for tasks opened in the UI or imported without a source run.
+  string source_run_id = 19;
 }
 
 message WorkOrderOrigin {

--- a/web_src/src/pages/factories/__fixtures__/FactoriesHarness.smoke.spec.tsx
+++ b/web_src/src/pages/factories/__fixtures__/FactoriesHarness.smoke.spec.tsx
@@ -75,6 +75,11 @@ describe("FactoriesHarness tasks", () => {
     expect(await screen.findByTestId("factory-app-edit", {}, { timeout: 8000 })).toBeInTheDocument();
     expect(screen.queryByTestId("factory-app-split-run-page")).not.toBeInTheDocument();
     expect(screen.queryByTestId("factory-app-workspace-toggles")).not.toBeInTheDocument();
+
+    const sidebar = await screen.findByTestId("factory-automation-runs-sidebar", {}, { timeout: 8000 });
+    expect(screen.queryByTestId("canvas-runs-sidebar")).not.toBeInTheDocument();
+    expect(within(sidebar).getByTestId("work-order-card-wo-failed-refunds")).toBeInTheDocument();
+    expect(within(sidebar).getByText("Ship idempotent refund retries")).toBeInTheDocument();
   }, 15000);
 
   it("shows the edit workspace chrome in factory Configure", async () => {

--- a/web_src/src/pages/factories/layout/factoriesLayoutContext.ts
+++ b/web_src/src/pages/factories/layout/factoriesLayoutContext.ts
@@ -15,9 +15,13 @@ export interface FactoriesLayoutContextValue {
 export const FactoriesLayoutContext = createContext<FactoriesLayoutContextValue | null>(null);
 
 export function useFactoriesLayout(): FactoriesLayoutContextValue {
-  const context = useContext(FactoriesLayoutContext);
+  const context = useOptionalFactoriesLayout();
   if (!context) {
     throw new Error("useFactoriesLayout must be used within FactoriesLayout");
   }
   return context;
+}
+
+export function useOptionalFactoriesLayout(): FactoriesLayoutContextValue | null {
+  return useContext(FactoriesLayoutContext);
 }

--- a/web_src/src/pages/factories/lib/backlogAnalysis.ts
+++ b/web_src/src/pages/factories/lib/backlogAnalysis.ts
@@ -71,7 +71,7 @@ export function hasActiveBacklogAnalysisRun(runs: BacklogAnalysisRun[]): boolean
   return runs.some((entry) => isActiveCanvasRun(entry.run));
 }
 
-function analyzedWorkOrderId(run: CanvasesCanvasRun): string | undefined {
+export function analyzedWorkOrderId(run: CanvasesCanvasRun): string | undefined {
   const envelope = asRecord(run.rootEvent?.data);
   const payload = asRecord(envelope?.data) ?? envelope;
   const id = asRecord(payload?.workOrder)?.id;

--- a/web_src/src/pages/factories/lib/factoryAppSearchParamFlag.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryAppSearchParamFlag.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { leaveFactoryConfigureSearchParams, setSearchParamFlag } from "./factoryAppSearchParamFlag";
+import {
+  leaveFactoryConfigureSearchParams,
+  setFactoryAppSelectedRun,
+  setSearchParamFlag,
+} from "./factoryAppSearchParamFlag";
 
 describe("leaveFactoryConfigureSearchParams", () => {
   it("drops Configure chrome flags and keeps run context", () => {
@@ -18,6 +22,26 @@ describe("leaveFactoryConfigureSearchParams", () => {
   it("returns the same params when Configure flags are already absent", () => {
     const current = new URLSearchParams("from=automations&run=r1");
     expect(leaveFactoryConfigureSearchParams(current)).toBe(current);
+  });
+});
+
+describe("setFactoryAppSelectedRun", () => {
+  it("sets the run id and keeps other flags", () => {
+    const next = setFactoryAppSelectedRun(new URLSearchParams("from=lines&lineId=l1"), "run-9");
+    expect(next.get("run")).toBe("run-9");
+    expect(next.get("from")).toBe("lines");
+    expect(next.get("lineId")).toBe("l1");
+  });
+
+  it("clears the run id", () => {
+    const next = setFactoryAppSelectedRun(new URLSearchParams("from=automations&run=run-9"), null);
+    expect(next.get("run")).toBeNull();
+    expect(next.get("from")).toBe("automations");
+  });
+
+  it("returns the same params when the run id already matches", () => {
+    const current = new URLSearchParams("run=run-9");
+    expect(setFactoryAppSelectedRun(current, "run-9")).toBe(current);
   });
 });
 

--- a/web_src/src/pages/factories/lib/factoryAppSearchParamFlag.ts
+++ b/web_src/src/pages/factories/lib/factoryAppSearchParamFlag.ts
@@ -20,6 +20,21 @@ export function leaveFactoryConfigureSearchParams(current: URLSearchParams): URL
   return next;
 }
 
+/** Set or clear `run` on the factory canvas URL. Keep other search flags. */
+export function setFactoryAppSelectedRun(params: URLSearchParams, runId: string | null): URLSearchParams {
+  const current = params.get("run");
+  if ((runId || null) === (current || null)) {
+    return params;
+  }
+  const next = new URLSearchParams(params);
+  if (runId) {
+    next.set("run", runId);
+    return next;
+  }
+  next.delete("run");
+  return next;
+}
+
 export function setSearchParamFlag(params: URLSearchParams, key: string, open: boolean): URLSearchParams {
   const isSet = params.get(key) === "1";
   if (open === isSet) {

--- a/web_src/src/pages/factories/lib/factoryAutomationStatus.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryAutomationStatus.spec.ts
@@ -209,4 +209,22 @@ describe("findWorkOrderForAutomationRun", () => {
 
     expect(findWorkOrderForAutomationRun([draft], "run-backlog", run)?.id).toBe("wo-draft");
   });
+
+  it("matches a unique task title when the run has no stored id link", () => {
+    const draft: FactoriesWorkOrder = { id: "wo-timeout", title: "Checkout timeout on large carts" };
+    const run: CanvasesCanvasRun = {
+      id: "run-implement",
+      rootEvent: { customName: "Checkout timeout on large carts" },
+    };
+
+    expect(findWorkOrderForAutomationRun([draft], "run-implement", run)?.id).toBe("wo-timeout");
+  });
+
+  it("does not match a title that belongs to more than one task", () => {
+    const left: FactoriesWorkOrder = { id: "wo-a", title: "Same title" };
+    const right: FactoriesWorkOrder = { id: "wo-b", title: "Same title" };
+    const run: CanvasesCanvasRun = { id: "run-dup", rootEvent: { customName: "Same title" } };
+
+    expect(findWorkOrderForAutomationRun([left, right], "run-dup", run)).toBeUndefined();
+  });
 });

--- a/web_src/src/pages/factories/lib/factoryAutomationStatus.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryAutomationStatus.spec.ts
@@ -189,4 +189,24 @@ describe("findWorkOrderForAutomationRun", () => {
   it("returns undefined when no execution matches the run", () => {
     expect(findWorkOrderForAutomationRun(orders, "run-missing")).toBeUndefined();
   });
+
+  it("matches an intake run by the task source run id", () => {
+    const intakeOrder: FactoriesWorkOrder = {
+      id: "wo-intake",
+      title: "Opened from GitHub",
+      sourceRunId: "run-intake",
+    };
+
+    expect(findWorkOrderForAutomationRun([intakeOrder], "run-intake")?.id).toBe("wo-intake");
+  });
+
+  it("matches a backlog analysis run from the trigger payload", () => {
+    const draft: FactoriesWorkOrder = { id: "wo-draft", title: "Draft from intake" };
+    const run: CanvasesCanvasRun = {
+      id: "run-backlog",
+      rootEvent: { data: { data: { workOrder: { id: "wo-draft" } } } },
+    };
+
+    expect(findWorkOrderForAutomationRun([draft], "run-backlog", run)?.id).toBe("wo-draft");
+  });
 });

--- a/web_src/src/pages/factories/lib/factoryAutomationStatus.ts
+++ b/web_src/src/pages/factories/lib/factoryAutomationStatus.ts
@@ -1,5 +1,6 @@
 import type { CanvasesCanvasRun, FactoriesWorkOrder, FactoriesWorkOrderExecution } from "@/api-client";
 import { shortId } from "@/ui/Runs/runPresentation";
+import { analyzedWorkOrderId } from "./backlogAnalysis";
 import { flattenWorkOrderExecutions } from "./workOrderExecutions";
 
 export type FactoryAutomationTick = "running" | "waiting" | "queued" | "passed" | "failed" | "cancelled" | null;
@@ -179,17 +180,44 @@ function compareRunsNewestFirst(left: FactoryAutomationRunCard, right: FactoryAu
 }
 
 /**
- * Finds the task that produced this canvas run, if any.
- * Trigger-only runs have no task. Match on run id alone: ids are unique
- * and Storybook ListRuns is shared across automations.
+ * Finds the task for this canvas run, if any.
+ * Line and PR steps match on execution run id. Intake matches on
+ * sourceRunId after Create Task. Backlog analysis matches the work
+ * order id in the trigger payload. Trigger-only runs have no task.
  */
 export function findWorkOrderForAutomationRun(
   workOrders: FactoriesWorkOrder[],
   runId: string,
+  run?: Pick<CanvasesCanvasRun, "rootEvent">,
 ): FactoriesWorkOrder | undefined {
   if (!runId) {
     return undefined;
   }
 
-  return workOrders.find((order) => flattenWorkOrderExecutions(order).some((execution) => execution.run?.id === runId));
+  const byStep = workOrders.find((order) =>
+    flattenWorkOrderExecutions(order).some((execution) => execution.run?.id === runId),
+  );
+  if (byStep) {
+    return byStep;
+  }
+
+  const bySource = workOrders.find((order) => workOrderSourceRunId(order) === runId);
+  if (bySource) {
+    return bySource;
+  }
+
+  if (!run) {
+    return undefined;
+  }
+
+  const analyzedId = analyzedWorkOrderId(run);
+  if (!analyzedId) {
+    return undefined;
+  }
+
+  return workOrders.find((order) => order.id === analyzedId);
+}
+
+function workOrderSourceRunId(order: FactoriesWorkOrder): string | undefined {
+  return order.sourceRunId?.trim() || undefined;
 }

--- a/web_src/src/pages/factories/lib/factoryAutomationStatus.ts
+++ b/web_src/src/pages/factories/lib/factoryAutomationStatus.ts
@@ -183,7 +183,8 @@ function compareRunsNewestFirst(left: FactoryAutomationRunCard, right: FactoryAu
  * Finds the task for this canvas run, if any.
  * Line and PR steps match on execution run id. Intake matches on
  * sourceRunId after Create Task. Backlog analysis matches the work
- * order id in the trigger payload. Trigger-only runs have no task.
+ * order id in the trigger payload. A unique task title matches when
+ * a run has no stored id link yet. Trigger-only runs have no task.
  */
 export function findWorkOrderForAutomationRun(
   workOrders: FactoriesWorkOrder[],
@@ -211,13 +212,32 @@ export function findWorkOrderForAutomationRun(
   }
 
   const analyzedId = analyzedWorkOrderId(run);
-  if (!analyzedId) {
-    return undefined;
+  if (analyzedId) {
+    const byAnalyzed = workOrders.find((order) => order.id === analyzedId);
+    if (byAnalyzed) {
+      return byAnalyzed;
+    }
   }
 
-  return workOrders.find((order) => order.id === analyzedId);
+  return findWorkOrderByUniqueRunTitle(workOrders, run);
 }
 
 function workOrderSourceRunId(order: FactoriesWorkOrder): string | undefined {
   return order.sourceRunId?.trim() || undefined;
+}
+
+function findWorkOrderByUniqueRunTitle(
+  workOrders: FactoriesWorkOrder[],
+  run: Pick<CanvasesCanvasRun, "rootEvent">,
+): FactoriesWorkOrder | undefined {
+  const title = run.rootEvent?.customName?.trim();
+  if (!title) {
+    return undefined;
+  }
+
+  const matches = workOrders.filter((order) => order.title?.trim() === title);
+  if (matches.length !== 1) {
+    return undefined;
+  }
+  return matches[0];
 }

--- a/web_src/src/pages/factories/pages/AutomationDetail.tsx
+++ b/web_src/src/pages/factories/pages/AutomationDetail.tsx
@@ -1,4 +1,4 @@
-import type { FactoriesFactory, FactoriesWorkOrder, FactoryApp } from "@/api-client";
+import type { CanvasesCanvasRun, FactoriesFactory, FactoriesWorkOrder, FactoryApp } from "@/api-client";
 import { Link } from "@/components/Link/link";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
@@ -112,6 +112,7 @@ export function AutomationDetail({
           factory={factory}
           workOrders={workOrders}
           workOrderCardContext={workOrderCardContext}
+          canvasRuns={canvasRuns}
           runs={runs}
           runsLoading={runsLoading}
           isFetchingNextPage={isFetchingNextPage}
@@ -130,6 +131,7 @@ function AutomationDetailTabs({
   factory,
   workOrders,
   workOrderCardContext,
+  canvasRuns,
   runs,
   runsLoading,
   isFetchingNextPage,
@@ -142,6 +144,7 @@ function AutomationDetailTabs({
   factory: FactoriesFactory | null | undefined;
   workOrders: FactoriesWorkOrder[];
   workOrderCardContext: WorkOrderCardContext;
+  canvasRuns: CanvasesCanvasRun[];
   runs: FactoryAutomationRunCard[];
   runsLoading: boolean;
   isFetchingNextPage: boolean;
@@ -181,6 +184,7 @@ function AutomationDetailTabs({
                     workOrders={workOrders}
                     workOrderCardContext={workOrderCardContext}
                     run={run}
+                    canvasRun={canvasRuns.find((item) => item.id === run.runId)}
                   />
                 </li>
               ))}
@@ -209,6 +213,7 @@ function AutomationRunCard({
   workOrders,
   workOrderCardContext,
   run,
+  canvasRun,
 }: {
   organizationId: string;
   factoryKey: string;
@@ -217,9 +222,10 @@ function AutomationRunCard({
   workOrders: FactoriesWorkOrder[];
   workOrderCardContext: WorkOrderCardContext;
   run: FactoryAutomationRunCard;
+  canvasRun?: CanvasesCanvasRun;
 }) {
   const href = factoryAppRunPath(organizationId, factoryKey, appId, run.runId, { from: "automations" });
-  const order = findWorkOrderForAutomationRun(workOrders, run.runId);
+  const order = findWorkOrderForAutomationRun(workOrders, run.runId, canvasRun);
   if (order) {
     const entry = buildWorkOrderListEntry(order, factory);
     return <WorkOrderCard {...workOrderCardContext} entry={entry} href={href} />;

--- a/web_src/src/pages/factories/pages/ColumnAutomationViewPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/ColumnAutomationViewPopup.spec.tsx
@@ -127,7 +127,7 @@ describe("ColumnAutomationViewPopup", () => {
     expect(edit.className).toMatch(/absolute/);
     expect(edit.className).toMatch(/right-2/);
     expect(document.querySelector(".sp-canvas-editing")).toBeNull();
-    expect(screen.queryByTestId("canvas-runs-sidebar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("factory-automation-runs-sidebar")).not.toBeInTheDocument();
   });
 
   it("lists canvas runs beside the automation when a canvas id is given", () => {
@@ -136,7 +136,9 @@ describe("ColumnAutomationViewPopup", () => {
       runHrefFor: (runId) => `/org-1/workspaces/RF/apps/app-refund-implementer?run=${runId}`,
     });
 
-    const sidebar = within(screen.getByTestId("column-automation-view-canvas")).getByTestId("canvas-runs-sidebar");
+    const sidebar = within(screen.getByTestId("column-automation-view-canvas")).getByTestId(
+      "factory-automation-runs-sidebar",
+    );
     expect(within(sidebar).getByText("Add refund reconciliation test")).toBeInTheDocument();
     expect(within(sidebar).getByRole("link", { name: "Add refund reconciliation test" })).toHaveAttribute(
       "href",

--- a/web_src/src/pages/factories/pages/FactoryAppCanvasPage.tsx
+++ b/web_src/src/pages/factories/pages/FactoryAppCanvasPage.tsx
@@ -7,12 +7,16 @@ import {
   buildAgentEditPrompt,
 } from "../lib/agentEditPrompt";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
+import { factoryAppRunPath, parseFactoryAppNavFrom } from "../lib/factoryPagePaths";
 import { AgentSetupPromptDialog } from "./AgentSetupPromptDialog";
 import { FactoryAppCanvasHeader } from "./FactoryAppCanvasHeader";
 import { FactoryAppCanvasRedirect } from "./factoryAppCanvasGuards";
 import { FactoryAppResetConfirmDialog } from "./FactoryAppResetConfirmDialog";
 import { FactoryCanvasYamlModal } from "./FactoryCanvasYamlModal";
+import { FactoryAutomationRunsSidebar } from "./factoryAutomationRunsSidebar/FactoryAutomationRunsSidebar";
 import { useFactoryAppCanvasPageModel } from "./useFactoryAppCanvasPageModel";
+
+type FactoryAppCanvasPageModel = ReturnType<typeof useFactoryAppCanvasPageModel>;
 
 /**
  * Factory-shell embed for a factory-owned app/canvas. Configure (`?configure=1`)
@@ -75,20 +79,7 @@ export function FactoryAppCanvasPage() {
         }
       />
       <div className="relative min-h-0 flex-1 overflow-hidden">
-        {model.canvasLoading && !model.canvas ? (
-          <p className="p-5 text-[13px] text-muted-foreground">Loading…</p>
-        ) : (
-          <AppPage
-            factoryEmbed
-            factoryConfigure={model.isConfigure}
-            factoryAgentEnabled={model.isConfigure}
-            factoryEditWorkspace={model.isConfigure}
-            factoryConfigureActionsRef={model.configureActionsRef}
-            onFactoryConfigureBusyChange={model.handleConfigureBusyChange}
-            onFactoryConfigureDone={model.handleConfigureDone}
-            onFactoryConfigureSaved={model.handleConfigureSaved}
-          />
-        )}
+        <FactoryAppCanvasWorkspace model={model} />
       </div>
       <FactoryCanvasYamlModal
         open={model.yamlViewOpen}
@@ -107,6 +98,46 @@ export function FactoryAppCanvasPage() {
         onOpenChange={model.handleResetConfirmOpenChange}
         onConfirm={model.handleResetToFactoryDefaults}
       />
+    </div>
+  );
+}
+
+function FactoryAppCanvasWorkspace({ model }: { model: FactoryAppCanvasPageModel }) {
+  if (model.canvasLoading && !model.canvas) {
+    return <p className="p-5 text-[13px] text-muted-foreground">Loading…</p>;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 min-w-0">
+      {model.appId ? (
+        <FactoryAutomationRunsSidebar
+          canvasId={model.appId}
+          organizationId={model.organizationId}
+          factoryId={model.factoryId}
+          factoryKey={model.factoryKey}
+          selectedRunId={model.runId}
+          onSelectRun={model.handleSelectRun}
+          runHrefFor={(runId) =>
+            factoryAppRunPath(model.organizationId, model.factoryKey, model.appId, runId, {
+              from: parseFactoryAppNavFrom(model.from),
+              lineId: model.lineId ?? undefined,
+              orderNumber: model.orderNumber ?? undefined,
+            })
+          }
+        />
+      ) : null}
+      <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
+        <AppPage
+          factoryEmbed
+          factoryConfigure={model.isConfigure}
+          factoryAgentEnabled={model.isConfigure}
+          factoryEditWorkspace={model.isConfigure}
+          factoryConfigureActionsRef={model.configureActionsRef}
+          onFactoryConfigureBusyChange={model.handleConfigureBusyChange}
+          onFactoryConfigureDone={model.handleConfigureDone}
+          onFactoryConfigureSaved={model.handleConfigureSaved}
+        />
+      </div>
     </div>
   );
 }

--- a/web_src/src/pages/factories/pages/IntakeSettingsHost.spec.tsx
+++ b/web_src/src/pages/factories/pages/IntakeSettingsHost.spec.tsx
@@ -211,7 +211,7 @@ describe("IntakeSettingsHost", () => {
       "/org-1/workspaces/rf/apps/app-github-issues-intake?configure=1&agent=1&from=lines&lineId=line-plan",
     );
     expect(useInfiniteCanvasRuns).toHaveBeenCalledWith("app-github-issues-intake", {}, true);
-    const sidebar = within(automation).getByTestId("canvas-runs-sidebar");
+    const sidebar = within(automation).getByTestId("factory-automation-runs-sidebar");
     expect(within(sidebar).getByText("On mention on Issue")).toBeInTheDocument();
     expect(within(sidebar).getByRole("link", { name: "On mention on Issue" })).toHaveAttribute(
       "href",

--- a/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.spec.tsx
@@ -263,7 +263,7 @@ describe("IntakeSourceSettingsPopup", () => {
     expect(screen.queryByRole("heading", { name: "Accepted events go to Backlog" })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();
     expect(screen.queryByTestId("intake-source-settings-save")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("canvas-runs-sidebar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("factory-automation-runs-sidebar")).not.toBeInTheDocument();
   });
 
   it("lists canvas runs beside the automation when a canvas id is given", async () => {
@@ -275,7 +275,9 @@ describe("IntakeSourceSettingsPopup", () => {
 
     await user.click(screen.getByRole("tab", { name: "Automation" }));
 
-    const sidebar = within(screen.getByTestId("intake-source-automation")).getByTestId("canvas-runs-sidebar");
+    const sidebar = within(screen.getByTestId("intake-source-automation")).getByTestId(
+      "factory-automation-runs-sidebar",
+    );
     expect(within(sidebar).getByText("Runs")).toBeInTheDocument();
     expect(within(sidebar).getByText("feat: Add console empty-state")).toBeInTheDocument();
     expect(within(sidebar).getByRole("link", { name: "feat: Add console empty-state" })).toHaveAttribute(

--- a/web_src/src/pages/factories/pages/PRFeedbackSettingsHost.spec.tsx
+++ b/web_src/src/pages/factories/pages/PRFeedbackSettingsHost.spec.tsx
@@ -146,7 +146,7 @@ describe("PRFeedbackSettingsHost", () => {
       "/org-1/workspaces/rf/apps/app-pr-discussion?configure=1&agent=1&from=lines&lineId=line-plan",
     );
     expect(useInfiniteCanvasRuns).toHaveBeenCalledWith("app-pr-discussion", {}, true);
-    const sidebar = within(automation).getByTestId("canvas-runs-sidebar");
+    const sidebar = within(automation).getByTestId("factory-automation-runs-sidebar");
     expect(within(sidebar).getByRole("link", { name: "Please fix the lint error" })).toHaveAttribute(
       "href",
       "/org-1/workspaces/rf/apps/app-pr-discussion?run=run-pr-1&from=lines&lineId=line-plan",

--- a/web_src/src/pages/factories/pages/PRFeedbackSettingsPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/PRFeedbackSettingsPopup.spec.tsx
@@ -543,7 +543,7 @@ describe("PRFeedbackSettingsPopup automation", () => {
     expect(within(automation).queryByText("passed")).not.toBeInTheDocument();
     expect(within(automation).queryByText("failed")).not.toBeInTheDocument();
     expect(within(automation).queryByText("notFound")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("canvas-runs-sidebar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("factory-automation-runs-sidebar")).not.toBeInTheDocument();
   });
 
   it("lists canvas runs beside the automation when a canvas id is given", () => {
@@ -552,7 +552,7 @@ describe("PRFeedbackSettingsPopup automation", () => {
       runHrefFor: (runId) => `/org-1/workspaces/RF/apps/app-pr-feedback?run=${runId}`,
     });
 
-    const sidebar = within(screen.getByTestId("pr-feedback-automation")).getByTestId("canvas-runs-sidebar");
+    const sidebar = within(screen.getByTestId("pr-feedback-automation")).getByTestId("factory-automation-runs-sidebar");
     expect(within(sidebar).getByText("Runs")).toBeInTheDocument();
     expect(within(sidebar).getByText("Please fix the lint error")).toBeInTheDocument();
     expect(within(sidebar).getByRole("link", { name: "Please fix the lint error" })).toHaveAttribute(

--- a/web_src/src/pages/factories/pages/SettingsAutomationWorkspace.tsx
+++ b/web_src/src/pages/factories/pages/SettingsAutomationWorkspace.tsx
@@ -7,7 +7,7 @@ import { Pencil } from "lucide-react";
 import { useMemo, useState, type ReactNode } from "react";
 
 import { SettingsAutomationCanvas } from "./SettingsAutomationCanvas";
-import { SettingsAutomationRunsSidebar } from "./SettingsAutomationRunsSidebar";
+import { FactoryAutomationRunsSidebar } from "./factoryAutomationRunsSidebar/FactoryAutomationRunsSidebar";
 import type { IntakeAutomationGraph } from "./useIntakeAutomationCanvas";
 import { useSettingsAutomationRunCanvas } from "./useSettingsAutomationRunCanvas";
 
@@ -57,13 +57,12 @@ export function SettingsAutomationCanvasEdit({ href, label, testId }: { href: st
   );
 }
 
-/** Read-only automation canvas with the canvas ListRuns sidebar on the left. */
+/** Read-only automation canvas with the factory task-card runs sidebar. */
 export function SettingsAutomationWorkspace({
   graph,
   testId,
   canvasId,
   runHrefFor,
-  workflowNodes,
   editHref,
   editLabel = DEFAULT_EDIT_LABEL,
   editTestId = DEFAULT_EDIT_TEST_ID,
@@ -91,10 +90,11 @@ export function SettingsAutomationWorkspace({
     >
       <div className="flex min-h-[18rem] min-w-0 flex-1 overflow-hidden">
         {canvasId ? (
-          <SettingsAutomationRunsSidebar
+          <FactoryAutomationRunsSidebar
             canvasId={canvasId}
+            organizationId={graph.organizationId}
+            factoryId={graph.factoryId}
             runHrefFor={runHrefFor}
-            workflowNodes={workflowNodes}
             selectedRunId={selectedRunId}
             onSelectRun={setSelectedRunId}
           />

--- a/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/FactoryAutomationRunItem.tsx
+++ b/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/FactoryAutomationRunItem.tsx
@@ -1,0 +1,118 @@
+import type { CanvasesCanvasRun, FactoriesFactory, FactoriesWorkOrder } from "@/api-client";
+import { Link } from "@/components/Link/link";
+import { formatTimeAgo } from "@/lib/date";
+import { isNormalClick } from "@/lib/linkHelpers";
+import { cn } from "@/lib/utils";
+import { analyzedWorkOrderId } from "../../lib/backlogAnalysis";
+import {
+  findWorkOrderForAutomationRun,
+  listFactoryAutomationRuns,
+  type FactoryAutomationRunCard,
+} from "../../lib/factoryAutomationStatus";
+import { buildWorkOrderListEntry } from "../../lib/workOrderListModel";
+import { isActiveCanvasRun } from "../../lib/workOrderPullRequest";
+import { WorkOrderCard, type WorkOrderCardContext } from "../../workOrders/WorkOrderCard";
+import { StatusTick } from "../automationsPageParts";
+import { factoryAutomationRunCardSurfaceClass } from "./factoryAutomationRunCardSurface";
+import { factoryAutomationRunTitle } from "./factoryAutomationRunSearch";
+
+export function FactoryAutomationRunItem({
+  run,
+  workOrders,
+  factory,
+  workOrderCardContext,
+  runHref,
+  isSelected,
+  onSelect,
+}: {
+  run: CanvasesCanvasRun;
+  workOrders: FactoriesWorkOrder[];
+  factory: FactoriesFactory | null | undefined;
+  workOrderCardContext: WorkOrderCardContext | null;
+  runHref: string;
+  isSelected: boolean;
+  onSelect: (runId: string) => void;
+}) {
+  const runId = run.id ?? "";
+  const order = findWorkOrderForAutomationRun(workOrders, runId, run);
+  const selectRun = () => {
+    if (runId) {
+      onSelect(runId);
+    }
+  };
+
+  if (order && workOrderCardContext) {
+    const entry = buildWorkOrderListEntry(order, factory);
+    const isAnalyzing = analyzedWorkOrderId(run) === order.id && isActiveCanvasRun(run);
+    return (
+      <div data-testid="factory-automation-runs-row" className="px-2 py-1.5">
+        <WorkOrderCard
+          {...workOrderCardContext}
+          entry={entry}
+          isAnalyzing={isAnalyzing}
+          selected={isSelected}
+          className={factoryAutomationRunCardSurfaceClass(isSelected)}
+          onOpen={selectRun}
+        />
+      </div>
+    );
+  }
+
+  return <FactoryAutomationRunFallback run={run} runHref={runHref} isSelected={isSelected} onSelect={selectRun} />;
+}
+
+function FactoryAutomationRunFallback({
+  run,
+  runHref,
+  isSelected,
+  onSelect,
+}: {
+  run: CanvasesCanvasRun;
+  runHref: string;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  const cards = listFactoryAutomationRuns([run]);
+  const card = cards[0];
+  const title = card?.title ?? factoryAutomationRunTitle(run);
+
+  return (
+    <div data-testid="factory-automation-runs-row" className="px-2 py-1.5">
+      <Link
+        href={runHref}
+        data-testid={run.id ? `factory-automation-run-${run.id}` : undefined}
+        data-selected={isSelected || undefined}
+        className={cn(
+          "block w-full rounded-md border border-border bg-card px-3 py-2.5 text-left transition-colors",
+          factoryAutomationRunCardSurfaceClass(isSelected),
+        )}
+        aria-label={title}
+        onClick={(event) => {
+          if (isNormalClick(event)) {
+            event.preventDefault();
+            onSelect();
+          }
+        }}
+      >
+        <div className="truncate text-[13px] font-medium tracking-[-0.01em] text-foreground">{title}</div>
+        {card ? <FactoryAutomationRunFallbackMeta card={card} /> : null}
+      </Link>
+    </div>
+  );
+}
+
+function FactoryAutomationRunFallbackMeta({ card }: { card: FactoryAutomationRunCard }) {
+  const timestamp = card.updatedAt ?? card.finishedAt ?? card.createdAt;
+  const timeLabel =
+    card.tick === "queued" && !timestamp ? "next" : timestamp ? formatTimeAgo(new Date(timestamp), false) : null;
+
+  return (
+    <div className="mt-1.5 flex items-center gap-1.5 text-[12px] text-muted-foreground">
+      <StatusTick tick={card.tick} size="sm" />
+      <span>
+        {card.label}
+        {timeLabel ? ` · ${timeLabel}` : ""}
+      </span>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/FactoryAutomationRunsSidebar.spec.tsx
+++ b/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/FactoryAutomationRunsSidebar.spec.tsx
@@ -1,0 +1,221 @@
+import type { CanvasesCanvasRun, FactoriesWorkOrder } from "@/api-client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+import { TooltipProvider } from "@/ui/tooltip";
+
+import { FactoriesLayoutContext } from "../../layout/factoriesLayoutContext";
+import { FactoryAutomationRunsSidebar } from "./FactoryAutomationRunsSidebar";
+
+const { useInfiniteCanvasRuns, useFactoryWorkOrders } = vi.hoisted(() => ({
+  useInfiniteCanvasRuns: vi.fn(),
+  useFactoryWorkOrders: vi.fn(),
+}));
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useInfiniteCanvasRuns,
+}));
+
+vi.mock("@/hooks/useFactoryData", () => ({
+  useFactoryWorkOrders: (...args: unknown[]) => useFactoryWorkOrders(...args),
+  useFactoryPullRequests: () => ({ data: [] }),
+  useDispatchWorkOrder: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateWorkOrderAssignees: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/useWorkOrderCardActions", () => ({
+  useWorkOrderCardActions: () => ({
+    dispatchingOrderIds: new Set<string>(),
+    isAssigneesSaving: false,
+    onDispatch: vi.fn(),
+    onAssigneesSave: vi.fn(),
+  }),
+}));
+
+function makeRun(overrides: Partial<CanvasesCanvasRun> = {}): CanvasesCanvasRun {
+  return {
+    id: "run-1",
+    canvasId: "app-github-issues-intake",
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    createdAt: "2026-05-01T12:00:00Z",
+    rootEvent: {
+      id: "event-1",
+      nodeId: "trigger",
+      customName: "feat: Add console empty-state",
+      createdAt: "2026-05-01T12:00:00Z",
+    },
+    executions: [],
+    ...overrides,
+  };
+}
+
+function mockRuns(runs: CanvasesCanvasRun[]) {
+  useInfiniteCanvasRuns.mockReturnValue({
+    data: { pages: [{ runs, totalCount: runs.length }] },
+    isPending: false,
+    isError: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    refetch: vi.fn(),
+  });
+}
+
+function mockWorkOrders(orders: FactoriesWorkOrder[]) {
+  useFactoryWorkOrders.mockReturnValue({ data: orders });
+}
+
+function renderSidebar(
+  props: Partial<Parameters<typeof FactoryAutomationRunsSidebar>[0]> = {},
+  options?: { withLayout?: boolean; workOrders?: FactoriesWorkOrder[] },
+) {
+  mockWorkOrders(options?.workOrders ?? []);
+  const sidebar = (
+    <FactoryAutomationRunsSidebar
+      canvasId="app-github-issues-intake"
+      selectedRunId={null}
+      onSelectRun={vi.fn()}
+      {...props}
+    />
+  );
+  const tree = options?.withLayout ? (
+    <FactoriesLayoutContext.Provider
+      value={{
+        organizationId: "org-1",
+        factoryId: "factory-1",
+        factoryKey: "RF",
+        factory: { id: "factory-1", key: "RF", name: "Refunds", lines: [] },
+        factories: [],
+        openCreateWorkOrder: () => {},
+      }}
+    >
+      {sidebar}
+    </FactoriesLayoutContext.Provider>
+  ) : (
+    sidebar
+  );
+
+  return render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter>
+        <ThemeProvider>
+          <TooltipProvider>
+            <div className="flex h-[32rem]">{tree}</div>
+          </TooltipProvider>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  useFactoryWorkOrders.mockReturnValue({ data: [] });
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("FactoryAutomationRunsSidebar", () => {
+  it("lists factory runs without using the standalone canvas sidebar", () => {
+    mockRuns([
+      makeRun(),
+      makeRun({
+        id: "run-2",
+        state: "STATE_STARTED",
+        result: "RESULT_UNKNOWN",
+        rootEvent: { id: "event-2", nodeId: "trigger", customName: "On Issue Labeled" },
+      }),
+    ]);
+
+    renderSidebar();
+
+    expect(useInfiniteCanvasRuns).toHaveBeenCalledWith("app-github-issues-intake", {}, true);
+    const sidebar = screen.getByTestId("factory-automation-runs-sidebar");
+    expect(screen.queryByTestId("canvas-runs-sidebar")).not.toBeInTheDocument();
+    expect(within(sidebar).getByText("Runs")).toBeInTheDocument();
+    expect(within(sidebar).getByLabelText("Search runs")).toBeInTheDocument();
+    expect(within(sidebar).getByText("feat: Add console empty-state")).toBeInTheDocument();
+    expect(within(sidebar).getByText("On Issue Labeled")).toBeInTheDocument();
+  });
+
+  it("keeps the selected run in the sidebar without leaving the page", async () => {
+    const user = userEvent.setup();
+    mockRuns([makeRun()]);
+
+    function ControlledSidebar() {
+      const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+      return (
+        <FactoryAutomationRunsSidebar
+          canvasId="app-github-issues-intake"
+          selectedRunId={selectedRunId}
+          onSelectRun={setSelectedRunId}
+          runHrefFor={(runId) => `/org-1/workspaces/RF/apps/app-github-issues-intake?run=${runId}&from=lines`}
+        />
+      );
+    }
+
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter>
+          <ThemeProvider>
+            <TooltipProvider>
+              <div className="flex h-[32rem]">
+                <ControlledSidebar />
+              </div>
+            </TooltipProvider>
+          </ThemeProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const row = screen.getByTestId("factory-automation-runs-row");
+    const link = within(row).getByRole("link", { name: "feat: Add console empty-state" });
+    expect(link).toHaveAttribute("href", "/org-1/workspaces/RF/apps/app-github-issues-intake?run=run-1&from=lines");
+
+    await user.click(link);
+    expect(row.className).not.toMatch(/bg-sky-50/);
+    expect(link.className).toMatch(/bg-slate-200/);
+    expect(link).toHaveAttribute("data-selected", "true");
+  });
+
+  it("shows the Kanban task card when the run belongs to a task", () => {
+    mockRuns([makeRun({ id: "run-intake" })]);
+    renderSidebar(
+      {},
+      {
+        withLayout: true,
+        workOrders: [
+          {
+            id: "wo-1",
+            number: "12",
+            key: "RF-12",
+            title: "feat: Add console empty-state",
+            state: "STATE_DRAFT",
+            sourceRunId: "run-intake",
+          },
+        ],
+      },
+    );
+
+    const card = screen.getByTestId("work-order-card-wo-1");
+    expect(card).toHaveTextContent("feat: Add console empty-state");
+    expect(card).not.toHaveAttribute("data-selected");
+    expect(screen.getByTestId("factory-automation-runs-row").className).not.toMatch(/bg-sky-50/);
+    expect(screen.queryByTestId("factory-automation-run-run-intake")).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state when the canvas has no runs", () => {
+    mockRuns([]);
+
+    renderSidebar();
+
+    expect(screen.getByText("No runs")).toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/FactoryAutomationRunsSidebar.spec.tsx
+++ b/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/FactoryAutomationRunsSidebar.spec.tsx
@@ -188,9 +188,8 @@ describe("FactoryAutomationRunsSidebar", () => {
   it("shows the Kanban task card when the run belongs to a task", () => {
     mockRuns([makeRun({ id: "run-intake" })]);
     renderSidebar(
-      {},
+      { organizationId: "org-1", factoryId: "factory-1", factoryKey: "RF" },
       {
-        withLayout: true,
         workOrders: [
           {
             id: "wo-1",

--- a/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/FactoryAutomationRunsSidebar.tsx
+++ b/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/FactoryAutomationRunsSidebar.tsx
@@ -26,6 +26,7 @@ interface FactoryAutomationRunsSidebarProps {
   canvasId: string;
   organizationId?: string;
   factoryId?: string;
+  factoryKey?: string;
   runHrefFor?: RunsSidebarHrefForRun;
   selectedRunId: string | null;
   onSelectRun: (runId: string | null) => void;
@@ -36,6 +37,7 @@ export function FactoryAutomationRunsSidebar({
   canvasId,
   organizationId: organizationIdProp,
   factoryId: factoryIdProp,
+  factoryKey: factoryKeyProp,
   runHrefFor,
   selectedRunId,
   onSelectRun,
@@ -43,7 +45,7 @@ export function FactoryAutomationRunsSidebar({
   const layout = useOptionalFactoriesLayout();
   const organizationId = layout?.organizationId ?? organizationIdProp ?? "";
   const factoryId = layout?.factoryId ?? factoryIdProp ?? "";
-  const factoryKey = layout?.factoryKey ?? "";
+  const factoryKey = layout?.factoryKey ?? factoryKeyProp ?? "";
   const factory = layout?.factory ?? null;
   const { sidebarRef, width, isResizing, handleMouseDown } = useAuxiliarySidebarWidth(
     true,
@@ -68,8 +70,8 @@ export function FactoryAutomationRunsSidebar({
       factoryId,
       factoryKey,
       factoryLines: factory?.lines ?? [],
-      canDispatch: Boolean(layout),
-      canAssign: Boolean(layout),
+      canDispatch: Boolean(organizationId && factoryKey),
+      canAssign: Boolean(organizationId && factoryKey),
       addressingFeedbackOrderIds: attention.addressingFeedbackOrderIds,
       addressingFeedbackLabels: attention.addressingFeedbackLabels,
       waitingOnChecksOrderIds: attention.waitingOnChecksOrderIds,
@@ -78,7 +80,7 @@ export function FactoryAutomationRunsSidebar({
       pullRequests,
       ...cardActions,
     };
-  }, [attention, cardActions, factory?.lines, factoryId, factoryKey, layout, organizationId, pullRequests]);
+  }, [attention, cardActions, factory?.lines, factoryId, factoryKey, organizationId, pullRequests]);
 
   const visibleRuns = useMemo(
     () =>

--- a/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/FactoryAutomationRunsSidebar.tsx
+++ b/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/FactoryAutomationRunsSidebar.tsx
@@ -1,0 +1,274 @@
+import type { CanvasesCanvasRun, FactoriesFactory, FactoriesWorkOrder } from "@/api-client";
+import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
+import type { RunsSidebarHrefForRun } from "@/components/CanvasToolSidebar/runsSidebarHref";
+import { Input } from "@/components/ui/input";
+import { useInfiniteCanvasRuns } from "@/hooks/useCanvasData";
+import { useFactoryPullRequests, useFactoryWorkOrders } from "@/hooks/useFactoryData";
+import { useWorkOrderCardActions } from "@/hooks/useWorkOrderCardActions";
+import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
+import { cn } from "@/lib/utils";
+import { useAuxiliarySidebarWidth } from "@/stores/useAuxiliarySidebarWidth";
+import { AlertCircle, Loader2, Search } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type UIEvent } from "react";
+
+import { findWorkOrderForAutomationRun } from "../../lib/factoryAutomationStatus";
+import { useOptionalFactoriesLayout } from "../../layout/factoriesLayoutContext";
+import type { WorkOrderCardContext } from "../../workOrders/WorkOrderCard";
+import { usePRFeedbackWorkOrderAttention } from "../useWorkOrderPRFeedbackRunHref";
+import { FactoryAutomationRunItem } from "./FactoryAutomationRunItem";
+import { factoryAutomationRunMatchesQuery } from "./factoryAutomationRunSearch";
+
+export const FACTORY_AUTOMATION_RUNS_SIDEBAR_TEST_ID = "factory-automation-runs-sidebar";
+const WIDTH_STORAGE_KEY = "factory-automation-runs-sidebar-width";
+const DEFAULT_WIDTH = 320;
+
+interface FactoryAutomationRunsSidebarProps {
+  canvasId: string;
+  organizationId?: string;
+  factoryId?: string;
+  runHrefFor?: RunsSidebarHrefForRun;
+  selectedRunId: string | null;
+  onSelectRun: (runId: string | null) => void;
+}
+
+/** Task-card run list for factory line automations. Not the standalone canvas sidebar. */
+export function FactoryAutomationRunsSidebar({
+  canvasId,
+  organizationId: organizationIdProp,
+  factoryId: factoryIdProp,
+  runHrefFor,
+  selectedRunId,
+  onSelectRun,
+}: FactoryAutomationRunsSidebarProps) {
+  const layout = useOptionalFactoriesLayout();
+  const organizationId = layout?.organizationId ?? organizationIdProp ?? "";
+  const factoryId = layout?.factoryId ?? factoryIdProp ?? "";
+  const factoryKey = layout?.factoryKey ?? "";
+  const factory = layout?.factory ?? null;
+  const { sidebarRef, width, isResizing, handleMouseDown } = useAuxiliarySidebarWidth(
+    true,
+    WIDTH_STORAGE_KEY,
+    DEFAULT_WIDTH,
+  );
+
+  const runsQuery = useInfiniteCanvasRuns(canvasId, {}, Boolean(canvasId));
+  const runs = useMemo(() => runsQuery.data?.pages.flatMap((page) => page?.runs ?? []) ?? [], [runsQuery.data]);
+  const { data: workOrders = [] } = useFactoryWorkOrders(organizationId, factoryId);
+  const { data: pullRequests = [] } = useFactoryPullRequests(organizationId, factoryId);
+  const cardActions = useWorkOrderCardActions(organizationId, factoryId);
+  const attention = usePRFeedbackWorkOrderAttention(pullRequests);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const workOrderCardContext = useMemo(() => {
+    if (!organizationId || !factoryKey) {
+      return null;
+    }
+    return {
+      organizationId,
+      factoryId,
+      factoryKey,
+      factoryLines: factory?.lines ?? [],
+      canDispatch: Boolean(layout),
+      canAssign: Boolean(layout),
+      addressingFeedbackOrderIds: attention.addressingFeedbackOrderIds,
+      addressingFeedbackLabels: attention.addressingFeedbackLabels,
+      waitingOnChecksOrderIds: attention.waitingOnChecksOrderIds,
+      checksPassedOrderIds: attention.checksPassedOrderIds,
+      fixesPausedOrderIds: attention.fixesPausedOrderIds,
+      pullRequests,
+      ...cardActions,
+    };
+  }, [attention, cardActions, factory?.lines, factoryId, factoryKey, layout, organizationId, pullRequests]);
+
+  const visibleRuns = useMemo(
+    () =>
+      runs.filter((run) => {
+        if (!run.id) {
+          return false;
+        }
+        const order = findWorkOrderForAutomationRun(workOrders, run.id, run);
+        return factoryAutomationRunMatchesQuery(searchQuery, run, order);
+      }),
+    [runs, searchQuery, workOrders],
+  );
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const loadMoreIfNeeded = useAutoLoadMoreOnScroll({
+    hasMore: runsQuery.hasNextPage,
+    isLoading: runsQuery.isFetchingNextPage,
+    onLoadMore: () => void runsQuery.fetchNextPage(),
+  });
+
+  useEffect(() => {
+    loadMoreIfNeeded(scrollRef.current);
+  }, [visibleRuns.length, loadMoreIfNeeded]);
+
+  const handleScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      loadMoreIfNeeded(event.currentTarget);
+    },
+    [loadMoreIfNeeded],
+  );
+
+  return (
+    <aside
+      ref={sidebarRef}
+      data-testid={FACTORY_AUTOMATION_RUNS_SIDEBAR_TEST_ID}
+      className={cn(
+        "relative z-30 flex h-full min-w-0 shrink-0 flex-col border-r bg-background",
+        appDarkModeClasses.sidebarEdge,
+      )}
+      style={{ width, maxWidth: width }}
+    >
+      <FactoryAutomationRunsToolbar searchQuery={searchQuery} onSearchQueryChange={setSearchQuery} />
+      <div
+        ref={scrollRef}
+        className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto"
+        data-testid="factory-automation-runs-scroll"
+        onScroll={handleScroll}
+      >
+        <FactoryAutomationRunsList
+          runs={visibleRuns}
+          allRunsCount={runs.length}
+          workOrders={workOrders}
+          factory={factory}
+          workOrderCardContext={workOrderCardContext}
+          selectedRunId={selectedRunId}
+          onSelectRun={onSelectRun}
+          runHrefFor={runHrefFor}
+          isLoading={runsQuery.isPending}
+          isError={runsQuery.isError}
+          onRetry={() => void runsQuery.refetch()}
+        />
+      </div>
+      <FactoryAutomationRunsResizeHandle isResizing={isResizing} onMouseDown={handleMouseDown} />
+    </aside>
+  );
+}
+
+function FactoryAutomationRunsToolbar({
+  searchQuery,
+  onSearchQueryChange,
+}: {
+  searchQuery: string;
+  onSearchQueryChange: (query: string) => void;
+}) {
+  return (
+    <div
+      className="flex h-10 shrink-0 items-center gap-2 border-b px-3 pr-1.5"
+      data-testid="factory-automation-runs-toolbar"
+    >
+      <span className="shrink-0 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Runs</span>
+      <div className="relative min-w-0 flex-1">
+        <Search className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          type="text"
+          value={searchQuery}
+          onChange={(event) => onSearchQueryChange(event.target.value)}
+          aria-label="Search runs"
+          placeholder="Search…"
+          className="h-7 rounded-none border-0 bg-transparent pr-2 pl-7 text-[13px] shadow-none"
+        />
+      </div>
+    </div>
+  );
+}
+
+function FactoryAutomationRunsList({
+  runs,
+  allRunsCount,
+  workOrders,
+  factory,
+  workOrderCardContext,
+  selectedRunId,
+  onSelectRun,
+  runHrefFor,
+  isLoading,
+  isError,
+  onRetry,
+}: {
+  runs: CanvasesCanvasRun[];
+  allRunsCount: number;
+  workOrders: FactoriesWorkOrder[];
+  factory: FactoriesFactory | null;
+  workOrderCardContext: WorkOrderCardContext | null;
+  selectedRunId: string | null;
+  onSelectRun: (runId: string | null) => void;
+  runHrefFor?: RunsSidebarHrefForRun;
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+}) {
+  if (isError && allRunsCount === 0) {
+    return (
+      <div
+        role="alert"
+        className="flex flex-col items-center gap-2 px-3 py-6 text-center text-xs text-muted-foreground"
+      >
+        <AlertCircle className="h-5 w-5 text-destructive" aria-hidden />
+        <span>The runs failed to load.</span>
+        <button type="button" onClick={onRetry} className="text-[11px] text-sky-600 hover:text-sky-800">
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (allRunsCount === 0) {
+    return <p className="px-3 py-6 text-center text-[13px] text-muted-foreground">No runs</p>;
+  }
+
+  if (runs.length === 0) {
+    return <p className="px-3 py-6 text-center text-xs text-muted-foreground">No runs match your search.</p>;
+  }
+
+  return (
+    <>
+      {runs.map((run) => (
+        <FactoryAutomationRunItem
+          key={run.id}
+          run={run}
+          workOrders={workOrders}
+          factory={factory}
+          workOrderCardContext={workOrderCardContext}
+          runHref={runHrefFor?.(run.id ?? "") ?? "#"}
+          isSelected={run.id === selectedRunId}
+          onSelect={onSelectRun}
+        />
+      ))}
+    </>
+  );
+}
+
+function FactoryAutomationRunsResizeHandle({
+  isResizing,
+  onMouseDown,
+}: {
+  isResizing: boolean;
+  onMouseDown: (event: React.MouseEvent) => void;
+}) {
+  return (
+    <div
+      onMouseDown={onMouseDown}
+      className="group absolute top-0 right-0 bottom-0 z-50 w-4 cursor-col-resize bg-transparent"
+      style={{ marginRight: "-8px" }}
+      data-testid="factory-automation-runs-sidebar-resize-handle"
+    >
+      <div
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute top-0 bottom-0 left-[calc(50%+1px)] w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-slate-950/50 dark:group-hover:bg-gray-500/50",
+          isResizing && "bg-slate-950/50 dark:bg-gray-500/50",
+        )}
+      />
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/factoryAutomationRunCardSurface.spec.ts
+++ b/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/factoryAutomationRunCardSurface.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { factoryAutomationRunCardSurfaceClass } from "./factoryAutomationRunCardSurface";
+
+describe("factoryAutomationRunCardSurfaceClass", () => {
+  it("keeps hover on the card and does not paint the column", () => {
+    const idle = factoryAutomationRunCardSurfaceClass(false);
+    expect(idle).toContain("hover:bg-slate-100");
+    expect(idle).not.toContain("bg-sky-50");
+    expect(idle).not.toContain("bg-slate-200");
+  });
+
+  it("marks the selected card without a sky column wash", () => {
+    const selected = factoryAutomationRunCardSurfaceClass(true);
+    expect(selected).toContain("bg-slate-200/80");
+    expect(selected).not.toContain("bg-sky-50");
+  });
+});

--- a/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/factoryAutomationRunCardSurface.ts
+++ b/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/factoryAutomationRunCardSurface.ts
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils";
+
+import { WORK_ORDER_CARD_HOVER_SURFACE_CLASS } from "../../workOrders/workOrderCardSurface";
+
+/** Selected fill lives on the card, not on the sidebar column. */
+export function factoryAutomationRunCardSurfaceClass(isSelected: boolean): string {
+  return cn(
+    "shadow-none hover:shadow-none hover:border-border",
+    isSelected
+      ? "border-foreground/15 bg-slate-200/80 hover:bg-slate-200/80 dark:border-foreground/20 dark:bg-slate-800 dark:hover:bg-slate-800"
+      : WORK_ORDER_CARD_HOVER_SURFACE_CLASS,
+  );
+}

--- a/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/factoryAutomationRunSearch.spec.ts
+++ b/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/factoryAutomationRunSearch.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { factoryAutomationRunMatchesQuery, factoryAutomationRunTitle } from "./factoryAutomationRunSearch";
+
+describe("factoryAutomationRunTitle", () => {
+  it("uses the trigger custom name when present", () => {
+    expect(factoryAutomationRunTitle({ rootEvent: { customName: "Opened issue" } })).toBe("Opened issue");
+  });
+
+  it("falls back to a short run id", () => {
+    expect(factoryAutomationRunTitle({ id: "run-abcdef12" })).toBe("Run run-abcd");
+  });
+});
+
+describe("factoryAutomationRunMatchesQuery", () => {
+  it("matches the run title or the linked task title", () => {
+    const run = { id: "run-1", rootEvent: { customName: "Event received" } };
+
+    expect(factoryAutomationRunMatchesQuery("refund", run, { title: "Ship refund retries" })).toBe(true);
+    expect(factoryAutomationRunMatchesQuery("event", run)).toBe(true);
+    expect(factoryAutomationRunMatchesQuery("missing", run, { title: "Ship refund retries" })).toBe(false);
+  });
+});

--- a/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/factoryAutomationRunSearch.ts
+++ b/web_src/src/pages/factories/pages/factoryAutomationRunsSidebar/factoryAutomationRunSearch.ts
@@ -1,0 +1,29 @@
+import type { CanvasesCanvasRun, FactoriesWorkOrder } from "@/api-client";
+import { shortId } from "@/ui/Runs/runPresentation";
+
+/** Title shown when a factory run has no linked task yet. */
+export function factoryAutomationRunTitle(run: CanvasesCanvasRun): string {
+  const customName = run.rootEvent?.customName?.trim();
+  if (customName) {
+    return customName;
+  }
+  return run.id ? `Run ${shortId(run.id)}` : "Run";
+}
+
+export function factoryAutomationRunMatchesQuery(
+  query: string,
+  run: CanvasesCanvasRun,
+  order?: FactoriesWorkOrder,
+): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) {
+    return true;
+  }
+
+  const haystack = [factoryAutomationRunTitle(run), order?.title, order?.key, run.id]
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+    .toLowerCase();
+
+  return haystack.includes(needle);
+}

--- a/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
@@ -2,6 +2,7 @@ import { usePermissions } from "@/contexts/usePermissions";
 import type { FactoryConfigureActions } from "@/pages/app";
 import { useCallback, useRef, useState } from "react";
 import { useNavigate } from "react-router";
+import { setFactoryAppSelectedRun } from "../lib/factoryAppSearchParamFlag";
 import { factoryAppViewPath, parseFactoryAppNavFrom } from "../lib/factoryPagePaths";
 import { useFactoryAppCanvasEditActions } from "./useFactoryAppCanvasEditActions";
 import { useFactoryAppCanvasRoute } from "./useFactoryAppCanvasRoute";
@@ -67,6 +68,12 @@ export function useFactoryAppCanvasPageModel() {
   const handleConfigureBusyChange = useCallback((busy: boolean) => {
     setConfigureBusy(busy);
   }, []);
+  const handleSelectRun = useCallback(
+    (runId: string | null) => {
+      route.setSearchParams((current) => setFactoryAppSelectedRun(current, runId), { replace: true });
+    },
+    [route.setSearchParams],
+  );
   const editActions = useFactoryAppCanvasEditActions({
     organizationId: route.organizationId,
     factoryId: route.factoryId,
@@ -117,5 +124,6 @@ export function useFactoryAppCanvasPageModel() {
     agentOpen: route.agentOpen,
     componentsOpen: route.componentsOpen,
     ...editActions,
+    handleSelectRun,
   };
 }

--- a/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
@@ -68,11 +68,12 @@ export function useFactoryAppCanvasPageModel() {
   const handleConfigureBusyChange = useCallback((busy: boolean) => {
     setConfigureBusy(busy);
   }, []);
+  const setSearchParams = route.setSearchParams;
   const handleSelectRun = useCallback(
     (runId: string | null) => {
-      route.setSearchParams((current) => setFactoryAppSelectedRun(current, runId), { replace: true });
+      setSearchParams((current) => setFactoryAppSelectedRun(current, runId), { replace: true });
     },
-    [route.setSearchParams],
+    [setSearchParams],
   );
   const editActions = useFactoryAppCanvasEditActions({
     organizationId: route.organizationId,
@@ -89,7 +90,7 @@ export function useFactoryAppCanvasPageModel() {
     canvas: route.canvas,
     canUpdateCanvas,
     configureActionsRef,
-    setSearchParams: route.setSearchParams,
+    setSearchParams,
     navigate,
   });
 

--- a/web_src/src/pages/factories/workOrders/WorkOrderCard.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderCard.tsx
@@ -1,5 +1,6 @@
 import type { FactoriesFactoryLine, FactoriesFactoryPullRequest } from "@/api-client";
 import { formatRelative } from "@/lib/datetime";
+import { cn } from "@/lib/utils";
 import { Link } from "react-router";
 import { getWorkOrderAttentionReasons, type WorkOrderAttentionReason } from "../lib/workOrderAttention";
 import { selectWorkOrderCardPullRequest, visibleWorkOrderCardAttentionReasons } from "../lib/workOrderCardPullRequest";
@@ -11,6 +12,7 @@ import { WorkOrderAttentionChip, WorkOrderChecksPassedMark } from "./WorkOrderAt
 import { WorkOrderPullRequestChip } from "./WorkOrderPullRequestChip";
 import { CardOwnerMark, StartDraftButton, type WorkOrderRowCallbacks } from "./WorkOrderRowActions";
 import { WorkOrderStatusIcon } from "./WorkOrderStatusIcon";
+import { WORK_ORDER_CARD_HOVER_SURFACE_CLASS } from "./workOrderCardSurface";
 
 const EMPTY_ADDRESSING_FEEDBACK_IDS: ReadonlySet<string> = new Set();
 const EMPTY_ADDRESSING_FEEDBACK_LABELS: ReadonlyMap<string, string> = new Map();
@@ -61,6 +63,10 @@ export interface WorkOrderCardProps extends WorkOrderCardContext {
    * shows a spinner in the meter slot until the score arrives.
    */
   isAnalyzing?: boolean;
+  /** Extra surface classes. Use for sidebar hover and selected fills. */
+  className?: string;
+  /** True when this card is the active item in a list. */
+  selected?: boolean;
 }
 
 /**
@@ -93,6 +99,8 @@ export function WorkOrderCard({
   onOpen,
   confidenceScore,
   isAnalyzing = false,
+  className,
+  selected = false,
 }: WorkOrderCardProps) {
   const meta = getWorkOrderDisplayStatusMeta(entry.displayStatus);
   const destination = href ?? workOrderOpenPath(organizationId, factoryKey, entry.order.number, factoryLines[0]?.id);
@@ -111,8 +119,13 @@ export function WorkOrderCard({
 
   return (
     <article
-      className="group relative w-full rounded-md border border-border bg-card p-2.5 shadow-sm transition hover:border-foreground/20 hover:shadow"
+      className={cn(
+        "group relative w-full rounded-md border border-border bg-card p-2.5 shadow-sm transition hover:border-foreground/20 hover:shadow",
+        WORK_ORDER_CARD_HOVER_SURFACE_CLASS,
+        className,
+      )}
       data-testid={`work-order-card-${entry.id}`}
+      data-selected={selected || undefined}
     >
       <WorkOrderCardOpenControl onOpen={onOpen} destination={destination} title={entry.title} />
 

--- a/web_src/src/pages/factories/workOrders/WorkOrderCardAnalyzing.spec.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderCardAnalyzing.spec.tsx
@@ -64,4 +64,10 @@ describe("Confidence score on a backlog card", () => {
     expect(screen.queryByTestId("work-order-card-analyzing-wo-1")).not.toBeInTheDocument();
     expect(screen.queryByTestId("work-order-card-score-wo-1")).not.toBeInTheDocument();
   });
+
+  it("uses the same gray-blue hover fill as the factory run list", () => {
+    renderCard({});
+
+    expect(screen.getByTestId("work-order-card-wo-1").className).toContain("hover:bg-slate-100");
+  });
 });

--- a/web_src/src/pages/factories/workOrders/workOrderCardSurface.ts
+++ b/web_src/src/pages/factories/workOrders/workOrderCardSurface.ts
@@ -1,0 +1,2 @@
+/** Gentle gray with a touch of blue. Shared by the board and factory run list. */
+export const WORK_ORDER_CARD_HOVER_SURFACE_CLASS = "hover:bg-slate-100 dark:hover:bg-slate-800/55";


### PR DESCRIPTION
## Summary

Factory automation run lists showed generic run rows. Operators could not match a run to the Kanban task. This change shows the same work order card in factory run lists when a task exists.

The standalone canvas sidebar stays unchanged. Hover and selected fills apply on the card, not the column.

The factory canvas page also shows this list. A unique task title matches a run when the stored id link is missing.

## Test plan

- [ ] Open an Implement automation from the line board.
- [ ] Open the Automation tab.
- [ ] Confirm the RUNS list shows work order cards.
- [ ] Hover a card and confirm the fill stays on the card.
- [ ] Click a card and confirm the selected fill stays on the card.
- [ ] Click Edit automation.
- [ ] Confirm the factory canvas page shows the same card list.
- [ ] Open a standalone canvas and confirm the generic run list is unchanged.


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62999777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR is not ready to merge because run selection still leaves Configure mode active and the new retry control violates an explicit UI-component requirement.

<sub>Reviews (2) · Last reviewed commit: ["fix: Satisfy ESLint exhaustive-deps on r..."](https://github.com/superplanehq/superplane/commit/f7690633c248c298e601a553f0eb905f2ee1b2cc)</sub>

<!-- /greptile_comment -->