### PR TITLE
fix: Keep Factory Task Token Counts

### DIFF
--- a/pkg/components/runner/agent_usage_test.go
+++ b/pkg/components/runner/agent_usage_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/usage/pricebook"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
@@ -156,6 +157,40 @@ func TestRecordRunnerLLMUsageFromSuperPlaneFinishedEvent(t *testing.T) {
 	assert.Equal(t, models.UsageProviderOpenRouter, recorder.records[0].Provider)
 	assert.Equal(t, "hosted", recorder.records[0].FundingSource)
 	assert.Equal(t, "anthropic/claude-sonnet-4-6", recorder.records[0].Model)
+}
+
+func TestParsedSuperPlaneOpenRouterModelsArePriced(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		model string
+	}{
+		{name: "anthropic prefix", model: "anthropic/claude-sonnet-4-6"},
+		{name: "openrouter gateway", model: "openrouter/anthropic/claude-sonnet-4-6"},
+		{name: "gemini", model: "google/gemini-3.7-flash"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := json.Marshal(map[string]any{
+				"model": tc.model,
+				"usage": map[string]any{"input_tokens": 5, "output_tokens": 2},
+			})
+			require.NoError(t, err)
+
+			record, ok := ParseRunnerLLMUsage(
+				models.UsageProviderOpenRouter,
+				map[string]any{
+					"model":       tc.model,
+					"credentials": map[string]any{"source": CredentialsSourceHosted},
+				},
+				result,
+			)
+			require.True(t, ok)
+			assert.Equal(t, tc.model, record.Model)
+			assert.True(t, pricebook.IsPriced(record.Model))
+		})
+	}
 }
 
 func TestProcessBrokerTaskStatusRecordsUsageWhenExecutionAlreadyFinished(t *testing.T) {

--- a/pkg/models/usage_price_book_test.go
+++ b/pkg/models/usage_price_book_test.go
@@ -20,6 +20,9 @@ func Test__LoadCurrentPriceBook__MatchesHardcodedRates(t *testing.T) {
 	assert.Equal(t, int64(3_000_000), pricebook.EstimateMicros("anthropic", "claude-sonnet-4-6", 1_000_000, 0, 0, 0, 0))
 	assert.Equal(t, int64(2_500_000), pricebook.EstimateMicros("openai", "gpt-4o", 1_000_000, 0, 0, 0, 0))
 	assert.Equal(t, int64(15_000_000), pricebook.EstimateMicros("anthropic", "claude-3-opus-20240229", 1_000_000, 0, 0, 0, 0))
+	assert.True(t, pricebook.IsPriced("claude-sonnet-4-6"))
+	assert.True(t, pricebook.IsPriced("gpt-4o"))
+	assert.True(t, pricebook.IsPriced("openrouter/anthropic/claude-sonnet-4-6"))
 	assert.Equal(t, 10*pricebook.MicrosPerSecondE1Large, pricebook.EstimateComputeMicros("e1-large-amd64", "e1-large-amd64", 10))
 	assert.Equal(t, int64(0), pricebook.EstimateComputeMicros("e1-large-amd64", "local", 10))
 }

--- a/pkg/models/workspace_usage_event.go
+++ b/pkg/models/workspace_usage_event.go
@@ -1,12 +1,12 @@
 package models
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/usage/pricebook"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -27,8 +27,6 @@ const (
 
 	UsageIdempotencyKeyRunner = "runner"
 )
-
-var ErrHostedUsageUnpriced = errors.New("hosted LLM usage has no price for this model")
 
 // WorkspaceUsageEvent is one append-only spend row (model tokens or VM
 // seconds). It is the source of truth for reports. Factory execution
@@ -131,7 +129,10 @@ func RecordUsage(tx *gorm.DB, in WorkspaceUsageEventInput) error {
 		version = pricebook.Version + "+provider"
 	} else {
 		if fundingSourceIsHosted(in.FundingSource) && !pricebook.IsPriced(in.Model) {
-			return fmt.Errorf("%w: %s %s", ErrHostedUsageUnpriced, in.Provider, in.Model)
+			log.WithFields(log.Fields{
+				"provider": in.Provider,
+				"model":    in.Model,
+			}).Warn("hosted LLM usage has no price for this model; recording tokens at zero cost")
 		}
 		providerCostMicros = pricebook.EstimateMicros(
 			in.Provider,

--- a/pkg/models/workspace_usage_event_test.go
+++ b/pkg/models/workspace_usage_event_test.go
@@ -396,7 +396,7 @@ func Test__RecordUsage__SameIdempotencyKeyRecordsOnce(t *testing.T) {
 	assertInProgressExecutionUsage(t, db, execution.ID, 1_000_000, 300)
 }
 
-func Test__RecordUsage__HostedUnknownModelFailsClosed(t *testing.T) {
+func Test__RecordUsage__HostedUnknownModelStillRecordsTokens(t *testing.T) {
 	r := support.Setup(t)
 	db := database.DB(t.Context())
 	execution := dispatchWorkOrderExecution(t, r)
@@ -412,7 +412,77 @@ func Test__RecordUsage__HostedUnknownModelFailsClosed(t *testing.T) {
 		TotalTokens:     100,
 		FundingSource:   models.UsageFundingSourceHosted,
 	})
-	require.ErrorIs(t, err, models.ErrHostedUsageUnpriced)
+	require.NoError(t, err)
+
+	event := requireUsageEventForRun(t, db, requireExecutionRunID(t, execution))
+	assert.Equal(t, int64(100), event.TotalTokens)
+	assert.Equal(t, int64(0), event.CostMicros)
+	assertInProgressExecutionUsage(t, db, execution.ID, 100, 0)
+}
+
+func Test__RecordUsage__HostedOpenRouterPrefixedModelIsPriced(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	execution := dispatchWorkOrderExecution(t, r)
+
+	err := models.RecordUsage(db, models.WorkspaceUsageEventInput{
+		OrganizationID:  r.Organization.ID,
+		CanvasRunID:     requireExecutionRunID(t, execution),
+		NodeExecutionID: uuid.New(),
+		NodeID:          "prompt",
+		Provider:        models.UsageProviderOpenRouter,
+		Model:           "openrouter/anthropic/claude-sonnet-4-6",
+		InputTokens:     1_000_000,
+		TotalTokens:     1_000_000,
+		FundingSource:   models.UsageFundingSourceHosted,
+	})
+	require.NoError(t, err)
+
+	event := requireUsageEventForRun(t, db, requireExecutionRunID(t, execution))
+	assert.Equal(t, int64(1_000_000), event.TotalTokens)
+	assert.Equal(t, int64(3_000_000), event.ProviderCostMicros)
+	assert.Positive(t, event.CostMicros)
+}
+
+func Test__SumUsageForWorkOrders__IncludesModelTokensAndCompute(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	execution := dispatchWorkOrderExecution(t, r)
+	runID := requireExecutionRunID(t, execution)
+
+	require.NoError(t, models.RecordUsage(db, models.WorkspaceUsageEventInput{
+		OrganizationID:  r.Organization.ID,
+		CanvasRunID:     runID,
+		NodeExecutionID: uuid.New(),
+		NodeID:          "prompt",
+		Provider:        models.UsageProviderAnthropic,
+		Model:           "claude-sonnet-4-6",
+		InputTokens:     1_000_000,
+		TotalTokens:     1_000_000,
+		FundingSource:   models.UsageFundingSourceHosted,
+	}))
+	require.NoError(t, models.RecordComputeUsage(db, models.ComputeUsageEventInput{
+		OrganizationID:  r.Organization.ID,
+		CanvasRunID:     runID,
+		NodeExecutionID: uuid.New(),
+		NodeID:          "runner",
+		MachineType:     "e1-large-amd64",
+		FleetID:         "e1-large-amd64",
+		DurationSeconds: 429,
+		IdempotencyKey:  "runner:compute:" + uuid.New().String(),
+	}))
+
+	var modelEvent, computeEvent models.WorkspaceUsageEvent
+	require.NoError(t, db.Where("canvas_run_id = ? AND usage_kind = ?", runID, models.UsageKindModel).First(&modelEvent).Error)
+	require.NoError(t, db.Where("canvas_run_id = ? AND usage_kind = ?", runID, models.UsageKindCompute).First(&computeEvent).Error)
+
+	sums, err := models.SumUsageForWorkOrders(db, []uuid.UUID{execution.WorkOrderID})
+	require.NoError(t, err)
+	total := sums[execution.WorkOrderID]
+	assert.Equal(t, int64(1_000_000), total.TotalTokens)
+	assert.Equal(t, int64(429), total.DurationSeconds)
+	assert.Equal(t, modelEvent.CostMicros+computeEvent.CostMicros, total.CostMicros)
+	assert.Greater(t, total.CostCents(), pricebook.MicrosToCents(computeEvent.CostMicros))
 }
 
 func assertInProgressExecutionUsage(t *testing.T, db *gorm.DB, executionID uuid.UUID, tokens, cents int64) {

--- a/pkg/usage/pricebook/pricebook.go
+++ b/pkg/usage/pricebook/pricebook.go
@@ -285,6 +285,7 @@ func lookup(model string) (Rate, bool) {
 
 func normalizeModelID(model string) string {
 	normalized := strings.ToLower(strings.TrimSpace(model))
+	normalized = strings.TrimPrefix(normalized, "openrouter/")
 	provider, rest, found := strings.Cut(normalized, "/")
 	if found && provider != "" && rest != "" && !strings.Contains(rest, "/") {
 		return rest

--- a/pkg/usage/pricebook/pricebook_test.go
+++ b/pkg/usage/pricebook/pricebook_test.go
@@ -43,6 +43,15 @@ func TestEstimateMicros_ProviderPrefixedModel(t *testing.T) {
 	assert.Equal(t, int64(250_000), got)
 }
 
+func TestEstimateMicros_OpenRouterGatewayPrefixedModel(t *testing.T) {
+	sonnet := EstimateMicros("openrouter", "openrouter/anthropic/claude-sonnet-4-6", 1_000_000, 0, 0, 0, 0)
+	grok := EstimateMicros("openrouter", "openrouter/x-ai/grok-4.6", 1_000_000, 0, 0, 0, 0)
+	gemini := EstimateMicros("openrouter", "google/gemini-3.7-flash", 1_000_000, 0, 0, 0, 0)
+	assert.Equal(t, int64(3_000_000), sonnet)
+	assert.Equal(t, int64(3_000_000), grok)
+	assert.Equal(t, int64(150_000), gemini)
+}
+
 func TestEstimateMicros_UnknownModelIsZero(t *testing.T) {
 	got := EstimateMicros("openai", "unknown-lab-model", 10_000, 10_000, 0, 0, 0)
 	assert.Equal(t, int64(0), got)
@@ -50,6 +59,9 @@ func TestEstimateMicros_UnknownModelIsZero(t *testing.T) {
 
 func TestIsPriced(t *testing.T) {
 	assert.True(t, IsPriced("claude-sonnet-4-6"))
+	assert.True(t, IsPriced("openrouter/anthropic/claude-sonnet-4-6"))
+	assert.True(t, IsPriced("openrouter/x-ai/grok-4.6"))
+	assert.True(t, IsPriced("google/gemini-3.7-flash"))
 	assert.False(t, IsPriced("unknown-lab-model"))
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Finished factory tasks showed VM cost and zero tokens. Hosted RecordUsage dropped the model row when the price book did not match OpenRouter model ids.

This change records token counts even when a hosted model has no price. It strips the OpenRouter gateway prefix so Claude catalog rates still apply.

## Test plan

- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/usage/pricebook`.
- [ ] Run workspace usage tests for RecordUsage and SumUsageForWorkOrders.
- [ ] Confirm a hosted OpenRouter Claude model id stores tokens and model cents.
- [ ] Confirm an unknown hosted model still stores the token count at zero cost.
- [ ] Open a finished factory task and confirm the header shows tokens, not only VM cost.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f98e006d-99be-4fcb-88cd-3d933a04d848?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f98e006d-99be-4fcb-88cd-3d933a04d848&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63040201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations remain.

<sub>Reviews (1) · Last reviewed commit: ["fix: Keep factory task token counts"](https://github.com/superplanehq/superplane/commit/cf897b3342e3ba090644fcb6cd9cd323a8477d79)</sub>

<!-- /greptile_comment -->