### PR TITLE
fix: Show Usage User from the First Assignee

### DIFF
--- a/pkg/components/runner/agent_task.go
+++ b/pkg/components/runner/agent_task.go
@@ -170,10 +170,17 @@ cd "$_sp_root"/` + ShellSingleQuote(dir) + ` && ` + command
 // SUPERPLANE_RESULT_FILE even when command exits non-zero.
 func WrapAgentStepCommand(command string) string {
 	return `_sp_status=0
+_sp_merge_llm_usage() {
+  node "$SUPERPLANE_TASK_DIR/llm_usage.js" merge || true
+}
+trap '_sp_merge_llm_usage' EXIT
+trap 'exit 143' TERM
+trap 'exit 130' INT
 {
 ` + WithTaskBinOnPath(command) + `
 } || _sp_status=$?
-node "$SUPERPLANE_TASK_DIR/llm_usage.js" merge || true
+_sp_merge_llm_usage
+trap - EXIT TERM INT
 if [ "$_sp_status" -ne 0 ]; then
   return "$_sp_status" 2>/dev/null || exit "$_sp_status"
 fi`

--- a/pkg/components/runner/agent_usage_test.go
+++ b/pkg/components/runner/agent_usage_test.go
@@ -109,7 +109,8 @@ func TestParseRunnerLLMUsageFromMergedPlanResult(t *testing.T) {
 }
 
 type recordingUsage struct {
-	records []core.UsageRecord
+	records  []core.UsageRecord
+	computes []core.ComputeUsageRecord
 }
 
 func (r *recordingUsage) Record(record core.UsageRecord) error {
@@ -117,7 +118,8 @@ func (r *recordingUsage) Record(record core.UsageRecord) error {
 	return nil
 }
 
-func (r *recordingUsage) RecordCompute(core.ComputeUsageRecord) error {
+func (r *recordingUsage) RecordCompute(record core.ComputeUsageRecord) error {
+	r.computes = append(r.computes, record)
 	return nil
 }
 

--- a/pkg/components/runner/claude/component.go
+++ b/pkg/components/runner/claude/component.go
@@ -219,7 +219,7 @@ func (c *RunClaudeCode) HandleWebhook(ctx core.WebhookRequestContext) (int, *cor
 }
 
 func (c *RunClaudeCode) Cancel(ctx core.ExecutionContext) error {
-	return runner.CancelBrokerTask(ctx)
+	return runner.CancelBrokerTask(ctx, FinishedEventType)
 }
 
 func (c *RunClaudeCode) Cleanup(ctx core.SetupContext) error { return nil }

--- a/pkg/components/runner/codex/component.go
+++ b/pkg/components/runner/codex/component.go
@@ -196,7 +196,7 @@ func (c *RunCodex) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.Web
 }
 
 func (c *RunCodex) Cancel(ctx core.ExecutionContext) error {
-	return runner.CancelBrokerTask(ctx)
+	return runner.CancelBrokerTask(ctx, FinishedEventType)
 }
 
 func (c *RunCodex) Cleanup(ctx core.SetupContext) error { return nil }

--- a/pkg/components/runner/llm_usage.js
+++ b/pkg/components/runner/llm_usage.js
@@ -126,7 +126,7 @@ function mergeResult(resultFile, taskDir) {
     try {
       parsed = JSON.parse(fs.readFileSync(resultFile, "utf8"));
     } catch (_err) {
-      return;
+      parsed = {};
     }
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       return;

--- a/pkg/components/runner/llm_usage.js
+++ b/pkg/components/runner/llm_usage.js
@@ -107,6 +107,7 @@ function accumulate(taskDir, payload) {
     current.total_cost_usd = asNumber(current.total_cost_usd) + asNumber(payload.total_cost_usd);
   }
   fs.writeFileSync(sidecarPath(taskDir), `${JSON.stringify(current)}\n`);
+  mergeResult(process.env.SUPERPLANE_RESULT_FILE, taskDir);
   return current;
 }
 
@@ -117,17 +118,19 @@ function mergeResult(resultFile, taskDir) {
   const sidecar = readSidecar(taskDir);
   const series = readPromptSeries(taskDir);
   const telemetry = telemetryForResult(series);
-  if ((!sidecarHasUsage(sidecar) && !telemetry) || !fs.existsSync(resultFile)) {
+  if (!sidecarHasUsage(sidecar) && !telemetry) {
     return;
   }
-  let parsed;
-  try {
-    parsed = JSON.parse(fs.readFileSync(resultFile, "utf8"));
-  } catch (_err) {
-    return;
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return;
+  let parsed = {};
+  if (fs.existsSync(resultFile)) {
+    try {
+      parsed = JSON.parse(fs.readFileSync(resultFile, "utf8"));
+    } catch (_err) {
+      return;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return;
+    }
   }
   const merged = Object.assign({}, parsed);
   if (sidecarHasUsage(sidecar)) {

--- a/pkg/components/runner/llm_usage_test.go
+++ b/pkg/components/runner/llm_usage_test.go
@@ -150,6 +150,26 @@ func TestAccumulateLLMUsageCreatesResultFileWhenMissing(t *testing.T) {
 	assert.Equal(t, float64(3), usage["input_tokens"])
 }
 
+func TestMergeLLMUsageWritesSidecarWhenResultJSONIsInvalid(t *testing.T) {
+	t.Parallel()
+
+	taskDir := t.TempDir()
+	writeLLMUsageScript(t, taskDir)
+	resultFile := filepath.Join(taskDir, "result.json")
+	require.NoError(t, os.WriteFile(resultFile, []byte(`{"plan":"partial"`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(taskDir, "llm_usage.json"), []byte(`{"model":"sonnet","usage":{"input_tokens":6,"output_tokens":2,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"reasoning_tokens":0},"total_cost_usd":0.003}`+"\n"), 0o644))
+
+	runMerge(t, taskDir, resultFile)
+
+	merged := readJSONFile(t, resultFile)
+	assert.Nil(t, merged["plan"])
+	assert.Equal(t, "sonnet", merged["model"])
+	usage := merged["usage"].(map[string]any)
+	assert.Equal(t, float64(6), usage["input_tokens"])
+	assert.Equal(t, float64(2), usage["output_tokens"])
+	assert.InDelta(t, 0.003, merged["total_cost_usd"], 1e-9)
+}
+
 func TestWrapAgentStepCommandMergesUsageAfterFailedStep(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/components/runner/llm_usage_test.go
+++ b/pkg/components/runner/llm_usage_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -108,6 +110,46 @@ func TestMergeLLMUsageLeavesFileUnchangedWithoutSidecar(t *testing.T) {
 	assert.Equal(t, original, string(body))
 }
 
+func TestAccumulateLLMUsageMergesIntoResultFile(t *testing.T) {
+	t.Parallel()
+
+	taskDir := t.TempDir()
+	writeLLMUsageScript(t, taskDir)
+	resultFile := filepath.Join(taskDir, "result.json")
+	require.NoError(t, os.WriteFile(resultFile, []byte(`{"plan":"abc"}`+"\n"), 0o644))
+
+	runAccumulate(t, taskDir, map[string]any{
+		"model":          "google/gemini-3.7-flash",
+		"usage":          map[string]any{"input_tokens": 9, "output_tokens": 4},
+		"total_cost_usd": 0.002,
+	}, resultFile)
+
+	merged := readJSONFile(t, resultFile)
+	assert.Equal(t, "abc", merged["plan"])
+	assert.Equal(t, "google/gemini-3.7-flash", merged["model"])
+	usage := merged["usage"].(map[string]any)
+	assert.Equal(t, float64(9), usage["input_tokens"])
+	assert.Equal(t, float64(4), usage["output_tokens"])
+}
+
+func TestAccumulateLLMUsageCreatesResultFileWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	taskDir := t.TempDir()
+	writeLLMUsageScript(t, taskDir)
+	resultFile := filepath.Join(taskDir, "result.json")
+
+	runAccumulate(t, taskDir, map[string]any{
+		"model": "sonnet",
+		"usage": map[string]any{"input_tokens": 3, "output_tokens": 1},
+	}, resultFile)
+
+	merged := readJSONFile(t, resultFile)
+	assert.Equal(t, "sonnet", merged["model"])
+	usage := merged["usage"].(map[string]any)
+	assert.Equal(t, float64(3), usage["input_tokens"])
+}
+
 func TestWrapAgentStepCommandMergesUsageAfterFailedStep(t *testing.T) {
 	t.Parallel()
 
@@ -139,17 +181,53 @@ func TestWrapAgentStepCommandMergesUsageAfterFailedStep(t *testing.T) {
 	assert.Equal(t, float64(7), usage["output_tokens"])
 }
 
+func TestWrapAgentStepCommandMergesUsageOnSIGTERM(t *testing.T) {
+	t.Parallel()
+
+	taskDir := t.TempDir()
+	writeLLMUsageScript(t, taskDir)
+	resultFile := filepath.Join(taskDir, "result.json")
+	require.NoError(t, os.WriteFile(resultFile, []byte(`{"plan":"partial"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(taskDir, "llm_usage.json"), []byte(`{"model":"sonnet","usage":{"input_tokens":6,"output_tokens":2,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"reasoning_tokens":0}}`+"\n"), 0o644))
+
+	wrapped := WrapAgentStepCommand(`sleep 30`)
+	assert.Contains(t, wrapped, "trap '_sp_merge_llm_usage' EXIT")
+	assert.Contains(t, wrapped, "trap 'exit 143' TERM")
+	assert.Contains(t, wrapped, "trap 'exit 130' INT")
+	cmd := exec.Command("bash", "-c", wrapped)
+	cmd.Env = append(os.Environ(),
+		"SUPERPLANE_TASK_DIR="+taskDir,
+		"SUPERPLANE_RESULT_FILE="+resultFile,
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	require.NoError(t, cmd.Start())
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM))
+	err := cmd.Wait()
+	require.Error(t, err)
+
+	merged := readJSONFile(t, resultFile)
+	assert.Equal(t, "partial", merged["plan"])
+	usage := merged["usage"].(map[string]any)
+	assert.Equal(t, float64(6), usage["input_tokens"])
+	assert.Equal(t, float64(2), usage["output_tokens"])
+}
+
 func writeLLMUsageScript(t *testing.T, taskDir string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(filepath.Join(taskDir, "llm_usage.js"), []byte(LLMUsageScript), 0o644))
 }
 
-func runAccumulate(t *testing.T, taskDir string, payload map[string]any) {
+func runAccumulate(t *testing.T, taskDir string, payload map[string]any, resultFile ...string) {
 	t.Helper()
 	raw, err := json.Marshal(payload)
 	require.NoError(t, err)
 	cmd := exec.Command("node", filepath.Join(taskDir, "llm_usage.js"), "accumulate", string(raw))
-	cmd.Env = append(os.Environ(), "SUPERPLANE_TASK_DIR="+taskDir)
+	env := append(os.Environ(), "SUPERPLANE_TASK_DIR="+taskDir)
+	if len(resultFile) > 0 {
+		env = append(env, "SUPERPLANE_RESULT_FILE="+resultFile[0])
+	}
+	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 }

--- a/pkg/components/runner/openrouter/component.go
+++ b/pkg/components/runner/openrouter/component.go
@@ -199,7 +199,7 @@ func (c *RunOpenRouter) HandleWebhook(ctx core.WebhookRequestContext) (int, *cor
 }
 
 func (c *RunOpenRouter) Cancel(ctx core.ExecutionContext) error {
-	return runner.CancelBrokerTask(ctx)
+	return runner.CancelBrokerTask(ctx, FinishedEventType)
 }
 
 func (c *RunOpenRouter) Cleanup(ctx core.SetupContext) error { return nil }

--- a/pkg/components/runner/openrouter_child_key_test.go
+++ b/pkg/components/runner/openrouter_child_key_test.go
@@ -128,6 +128,7 @@ func TestPollBrokerTaskSchedulesRevokeRetryWhenAlreadyFinishedAndDeleteFails(t *
 	t.Setenv("TASK_BROKER_BASE_URL", "https://broker.example")
 	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
 	httpContext := &contexts.HTTPContext{Responses: []*http.Response{
+		{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"task-1","status":"canceled"}`))},
 		openRouterChildKeyDeleteErrorResponse(),
 		openRouterChildKeyDeleteErrorResponse(),
 		openRouterChildKeyDeleteErrorResponse(),
@@ -154,7 +155,8 @@ func TestPollBrokerTaskSchedulesRevokeRetryWhenAlreadyFinishedAndDeleteFails(t *
 		Requests: requests,
 	}, "runnerSuperPlane.finished")
 	require.NoError(t, err)
-	require.Len(t, httpContext.Requests, childKeyDeleteMaxAttempts)
+	require.Len(t, httpContext.Requests, 1+childKeyDeleteMaxAttempts)
+	assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
 	assert.Equal(t, hookActionPoll, requests.Action)
 	assert.Equal(t, "task-1", requests.Params["task_id"])
 	assert.Equal(t, "or-hash-1", state.KVs[OpenRouterChildKeyHashKV])
@@ -198,6 +200,7 @@ func TestCancelBrokerTaskDeletesOpenRouterChildKey(t *testing.T) {
 	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
 	httpContext := &contexts.HTTPContext{Responses: []*http.Response{
 		{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
+		{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"task-1","status":"canceled"}`))},
 		openRouterChildKeyDeletedResponse(),
 	}}
 	state := &contexts.ExecutionStateContext{KVs: map[string]string{
@@ -212,13 +215,15 @@ func TestCancelBrokerTaskDeletesOpenRouterChildKey(t *testing.T) {
 			Access: core.HostedLLMAccess{ManagementKey: "sk-or-mgmt"},
 		},
 		Logger: log.NewEntry(log.New()),
-	})
+	}, "runnerClaudeCode.finished")
 	require.NoError(t, err)
-	require.Len(t, httpContext.Requests, 2)
+	require.Len(t, httpContext.Requests, 3)
 	assert.Equal(t, http.MethodPost, httpContext.Requests[0].Method)
 	assert.Equal(t, "https://broker.example/v1/tasks/task-1/cancel", httpContext.Requests[0].URL.String())
-	assert.Equal(t, http.MethodDelete, httpContext.Requests[1].Method)
-	assert.Equal(t, "https://openrouter.ai/api/v1/keys/or-hash-1", httpContext.Requests[1].URL.String())
+	assert.Equal(t, http.MethodGet, httpContext.Requests[1].Method)
+	assert.Equal(t, "https://broker.example/v1/tasks/task-1", httpContext.Requests[1].URL.String())
+	assert.Equal(t, http.MethodDelete, httpContext.Requests[2].Method)
+	assert.Equal(t, "https://openrouter.ai/api/v1/keys/or-hash-1", httpContext.Requests[2].URL.String())
 	assert.Empty(t, state.KVs[OpenRouterChildKeyHashKV])
 }
 
@@ -240,7 +245,7 @@ func TestCancelBrokerTaskKeepsChildKeyWhenBrokerCancelFails(t *testing.T) {
 			Access: core.HostedLLMAccess{ManagementKey: "sk-or-mgmt"},
 		},
 		Logger: log.NewEntry(log.New()),
-	})
+	}, "runnerClaudeCode.finished")
 	require.Error(t, err)
 	require.Len(t, httpContext.Requests, 1)
 	assert.Equal(t, http.MethodPost, httpContext.Requests[0].Method)
@@ -264,7 +269,7 @@ func TestCancelBrokerTaskDeletesOpenRouterChildKeyWhenAlreadyFinished(t *testing
 		HostedLLM: &contexts.HostedLLMContext{
 			Access: core.HostedLLMAccess{ManagementKey: "sk-or-mgmt"},
 		},
-	})
+	}, "runnerClaudeCode.finished")
 	require.NoError(t, err)
 	require.Len(t, httpContext.Requests, 1)
 	assert.Equal(t, "https://openrouter.ai/api/v1/keys/or-hash-1", httpContext.Requests[0].URL.String())

--- a/pkg/components/runner/run_bash.go
+++ b/pkg/components/runner/run_bash.go
@@ -370,7 +370,7 @@ func (c *RunBash) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.Webh
 }
 
 func (c *RunBash) Cancel(ctx core.ExecutionContext) error {
-	return cancelBrokerTask(ctx)
+	return cancelBrokerTask(ctx, RunBashFinishedEventType)
 }
 
 func (c *RunBash) Cleanup(ctx core.SetupContext) error { return nil }

--- a/pkg/components/runner/run_commands.go
+++ b/pkg/components/runner/run_commands.go
@@ -362,7 +362,7 @@ func brokerResultAsAny(raw json.RawMessage) any {
 }
 
 func (c *Runner) Cancel(ctx core.ExecutionContext) error {
-	return cancelBrokerTask(ctx)
+	return cancelBrokerTask(ctx, RunnerFinishedEventType)
 }
 
 func (c *Runner) Cleanup(ctx core.SetupContext) error { return nil }

--- a/pkg/components/runner/run_commands_test.go
+++ b/pkg/components/runner/run_commands_test.go
@@ -681,6 +681,7 @@ func TestRunnerCancelCallsBroker(t *testing.T) {
 	httpContext := &contexts.HTTPContext{
 		Responses: []*http.Response{
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"up-1","state":"already_terminal","status":"succeeded"}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"broker-42","status":"canceled"}`))},
 		},
 	}
 
@@ -690,8 +691,9 @@ func TestRunnerCancelCallsBroker(t *testing.T) {
 		ExecutionState: state,
 	})
 	require.NoError(t, err)
-	require.Len(t, httpContext.Requests, 1)
+	require.Len(t, httpContext.Requests, 2)
 	assert.Equal(t, "/v1/tasks/broker-42/cancel", httpContext.Requests[0].URL.Path)
+	assert.Equal(t, "/v1/tasks/broker-42", httpContext.Requests[1].URL.Path)
 }
 
 func TestBrokerListActiveTasks(t *testing.T) {

--- a/pkg/components/runner/run_javascript.go
+++ b/pkg/components/runner/run_javascript.go
@@ -368,7 +368,7 @@ func (c *RunJS) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.Webhoo
 }
 
 func (c *RunJS) Cancel(ctx core.ExecutionContext) error {
-	return cancelBrokerTask(ctx)
+	return cancelBrokerTask(ctx, RunJSFinishedEventType)
 }
 
 func (c *RunJS) Cleanup(ctx core.SetupContext) error { return nil }

--- a/pkg/components/runner/run_python.go
+++ b/pkg/components/runner/run_python.go
@@ -363,7 +363,7 @@ func (c *RunPython) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.We
 }
 
 func (c *RunPython) Cancel(ctx core.ExecutionContext) error {
-	return cancelBrokerTask(ctx)
+	return cancelBrokerTask(ctx, RunPythonFinishedEventType)
 }
 
 func (c *RunPython) Cleanup(ctx core.SetupContext) error { return nil }

--- a/pkg/components/runner/runner_task_lifecycle.go
+++ b/pkg/components/runner/runner_task_lifecycle.go
@@ -23,10 +23,7 @@ func afterRunnerTaskCreated(ctx core.ExecutionContext, taskID string) error {
 	if err := mergeRunnerBrokerTaskID(ctx.Metadata, taskID); err != nil {
 		return fmt.Errorf("runner execution metadata: %w", err)
 	}
-	return ctx.Requests.ScheduleActionCall(hookActionPoll, map[string]any{
-		"task_id":         taskID,
-		"organization_id": ctx.OrganizationID,
-	}, pollInterval)
+	return scheduleBrokerPoll(ctx.Requests, taskID, ctx.OrganizationID)
 }
 
 func pollBrokerTask(ctx core.ActionHookContext, finishedEventType string) error {
@@ -51,17 +48,13 @@ func pollBrokerTask(ctx core.ActionHookContext, finishedEventType string) error 
 
 	task, err := broker.FetchTaskStatus(taskID)
 	if err != nil {
-		if ctx.ExecutionState.IsFinished() {
-			revokeOpenRouterChildKeyOrReschedule(ctx)
-			return nil
-		}
 		if ctx.Logger != nil {
 			ctx.Logger.WithError(err).Warn("runner: broker poll failed, will retry")
 		}
-		return ctx.Requests.ScheduleActionCall(hookActionPoll, map[string]any{
-			"task_id":         taskID,
-			"organization_id": organizationID,
-		}, pollInterval)
+		if ctx.ExecutionState.IsFinished() {
+			revokeOpenRouterChildKeyOrReschedule(ctx)
+		}
+		return scheduleBrokerPoll(ctx.Requests, taskID, organizationID)
 	}
 
 	sink := taskLogFromBrokerTask(task)
@@ -77,13 +70,8 @@ func pollBrokerTask(ctx core.ActionHookContext, finishedEventType string) error 
 
 	if ctx.ExecutionState.IsFinished() {
 		revokeOpenRouterChildKeyOrReschedule(ctx)
-		return nil
 	}
-
-	return ctx.Requests.ScheduleActionCall(hookActionPoll, map[string]any{
-		"task_id":         taskID,
-		"organization_id": organizationID,
-	}, pollInterval)
+	return scheduleBrokerPoll(ctx.Requests, taskID, organizationID)
 }
 
 func handleBrokerWebhook(ctx core.WebhookRequestContext, finishedEventType string) (int, *core.WebhookResponseBody, error) {
@@ -248,10 +236,10 @@ func recordTerminalBrokerUsage(ctx core.ExecutionContext, broker *BrokerClient, 
 		if ctx.Logger != nil {
 			ctx.Logger.WithError(err).Warn("runner: fetch after cancel failed")
 		}
-		return nil
+		return scheduleBrokerPollAfterCancel(ctx, taskID)
 	}
 	if !task.IsInTerminalState() {
-		return nil
+		return scheduleBrokerPollAfterCancel(ctx, taskID)
 	}
 	return processBrokerTaskStatus(
 		ctx.ExecutionState,
@@ -262,4 +250,21 @@ func recordTerminalBrokerUsage(ctx core.ExecutionContext, broker *BrokerClient, 
 		ctx.Usage,
 		ctx.Configuration,
 	)
+}
+
+func scheduleBrokerPoll(requests core.RequestContext, taskID, organizationID string) error {
+	if requests == nil {
+		return nil
+	}
+	return requests.ScheduleActionCall(hookActionPoll, map[string]any{
+		"task_id":         taskID,
+		"organization_id": organizationID,
+	}, pollInterval)
+}
+
+func scheduleBrokerPollAfterCancel(ctx core.ExecutionContext, taskID string) error {
+	if err := scheduleBrokerPoll(ctx.Requests, taskID, ctx.OrganizationID); err != nil && ctx.Logger != nil {
+		ctx.Logger.WithError(err).Warn("runner: failed to schedule poll after cancel")
+	}
+	return nil
 }

--- a/pkg/components/runner/runner_task_lifecycle.go
+++ b/pkg/components/runner/runner_task_lifecycle.go
@@ -30,25 +30,34 @@ func afterRunnerTaskCreated(ctx core.ExecutionContext, taskID string) error {
 }
 
 func pollBrokerTask(ctx core.ActionHookContext, finishedEventType string) error {
-	if ctx.ExecutionState.IsFinished() {
-		revokeOpenRouterChildKeyOrReschedule(ctx)
-		return nil
-	}
-
 	taskID, ok := ctx.Parameters["task_id"].(string)
-	if !ok {
+	if !ok || strings.TrimSpace(taskID) == "" {
+		if ctx.ExecutionState.IsFinished() {
+			revokeOpenRouterChildKeyOrReschedule(ctx)
+			return nil
+		}
 		return fmt.Errorf("task_id is missing from parameters")
 	}
 	organizationID, _ := ctx.Parameters["organization_id"].(string)
 
 	broker, err := NewBrokerClient(ctx.HTTP)
 	if err != nil {
+		if ctx.ExecutionState.IsFinished() {
+			revokeOpenRouterChildKeyOrReschedule(ctx)
+			return nil
+		}
 		return fmt.Errorf("new broker client: %w", err)
 	}
 
 	task, err := broker.FetchTaskStatus(taskID)
 	if err != nil {
-		ctx.Logger.WithError(err).Warn("runner: broker poll failed, will retry")
+		if ctx.ExecutionState.IsFinished() {
+			revokeOpenRouterChildKeyOrReschedule(ctx)
+			return nil
+		}
+		if ctx.Logger != nil {
+			ctx.Logger.WithError(err).Warn("runner: broker poll failed, will retry")
+		}
 		return ctx.Requests.ScheduleActionCall(hookActionPoll, map[string]any{
 			"task_id":         taskID,
 			"organization_id": organizationID,
@@ -56,7 +65,7 @@ func pollBrokerTask(ctx core.ActionHookContext, finishedEventType string) error 
 	}
 
 	sink := taskLogFromBrokerTask(task)
-	if err := mergeRunnerTaskLog(ctx.Metadata, taskID, sink); err != nil {
+	if err := mergeRunnerTaskLog(ctx.Metadata, taskID, sink); err != nil && ctx.Logger != nil {
 		ctx.Logger.WithError(err).Warn("runner: execution metadata update failed")
 	}
 
@@ -64,6 +73,11 @@ func pollBrokerTask(ctx core.ActionHookContext, finishedEventType string) error 
 		err := processBrokerTaskStatus(ctx.ExecutionState, task, finishedEventType, organizationID, ctx.Logger, ctx.Usage, ctx.Configuration)
 		revokeOpenRouterChildKeyOrReschedule(ctx)
 		return err
+	}
+
+	if ctx.ExecutionState.IsFinished() {
+		revokeOpenRouterChildKeyOrReschedule(ctx)
+		return nil
 	}
 
 	return ctx.Requests.ScheduleActionCall(hookActionPoll, map[string]any{
@@ -195,7 +209,7 @@ func billableSeconds(duration time.Duration) int64 {
 	return seconds
 }
 
-func cancelBrokerTask(ctx core.ExecutionContext) error {
+func cancelBrokerTask(ctx core.ExecutionContext, finishedEventType string) error {
 	if ctx.ExecutionState.IsFinished() {
 		_ = revokeOpenRouterChildKey(ctx.HTTP, ctx.ExecutionState, ctx.HostedLLM, ctx.Logger)
 		return nil
@@ -219,6 +233,33 @@ func cancelBrokerTask(ctx core.ExecutionContext) error {
 		return fmt.Errorf("cancel task: %w", err)
 	}
 
+	if err := recordTerminalBrokerUsage(ctx, broker, taskID, finishedEventType); err != nil {
+		_ = revokeOpenRouterChildKey(ctx.HTTP, ctx.ExecutionState, ctx.HostedLLM, ctx.Logger)
+		return err
+	}
+
 	_ = revokeOpenRouterChildKey(ctx.HTTP, ctx.ExecutionState, ctx.HostedLLM, ctx.Logger)
 	return nil
+}
+
+func recordTerminalBrokerUsage(ctx core.ExecutionContext, broker *BrokerClient, taskID, finishedEventType string) error {
+	task, err := broker.FetchTaskStatus(taskID)
+	if err != nil {
+		if ctx.Logger != nil {
+			ctx.Logger.WithError(err).Warn("runner: fetch after cancel failed")
+		}
+		return nil
+	}
+	if !task.IsInTerminalState() {
+		return nil
+	}
+	return processBrokerTaskStatus(
+		ctx.ExecutionState,
+		task,
+		finishedEventType,
+		ctx.OrganizationID,
+		ctx.Logger,
+		ctx.Usage,
+		ctx.Configuration,
+	)
 }

--- a/pkg/components/runner/runner_task_lifecycle_test.go
+++ b/pkg/components/runner/runner_task_lifecycle_test.go
@@ -63,6 +63,65 @@ func TestPollBrokerTaskRecordsUsageWhenSuperPlaneAlreadyFinished(t *testing.T) {
 	assert.True(t, state.Finished)
 }
 
+func TestPollBrokerTaskKeepsPollingWhenFinishedAndBrokerNotTerminal(t *testing.T) {
+	t.Setenv("TASK_BROKER_BASE_URL", "https://broker.example")
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
+
+	recorder := &recordingUsage{}
+	requests := &contexts.RequestContext{}
+	state := &contexts.ExecutionStateContext{Finished: true}
+	httpContext := &contexts.HTTPContext{Responses: []*http.Response{runningBrokerTaskResponse()}}
+
+	err := pollBrokerTask(core.ActionHookContext{
+		Parameters: map[string]any{
+			"task_id":         "task-1",
+			"organization_id": "org-1",
+		},
+		HTTP:           httpContext,
+		ExecutionState: state,
+		Usage:          recorder,
+		Configuration:  hostedClaudeConfiguration(),
+		Logger:         log.NewEntry(log.New()),
+		Requests:       requests,
+	}, "runnerClaudeCode.finished")
+	require.NoError(t, err)
+	assert.Empty(t, recorder.records)
+	assert.Empty(t, recorder.computes)
+	assert.Equal(t, hookActionPoll, requests.Action)
+	assert.Equal(t, "task-1", requests.Params["task_id"])
+	assert.Equal(t, "org-1", requests.Params["organization_id"])
+	assert.Equal(t, pollInterval, requests.Duration)
+}
+
+func TestPollBrokerTaskKeepsPollingWhenFinishedAndFetchFails(t *testing.T) {
+	t.Setenv("TASK_BROKER_BASE_URL", "https://broker.example")
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
+
+	recorder := &recordingUsage{}
+	requests := &contexts.RequestContext{}
+	state := &contexts.ExecutionStateContext{Finished: true}
+	httpContext := &contexts.HTTPContext{Responses: []*http.Response{
+		{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader(`error`))},
+	}}
+
+	err := pollBrokerTask(core.ActionHookContext{
+		Parameters: map[string]any{
+			"task_id":         "task-1",
+			"organization_id": "org-1",
+		},
+		HTTP:           httpContext,
+		ExecutionState: state,
+		Usage:          recorder,
+		Configuration:  hostedClaudeConfiguration(),
+		Logger:         log.NewEntry(log.New()),
+		Requests:       requests,
+	}, "runnerClaudeCode.finished")
+	require.NoError(t, err)
+	assert.Empty(t, recorder.records)
+	assert.Equal(t, hookActionPoll, requests.Action)
+	assert.Equal(t, "task-1", requests.Params["task_id"])
+}
+
 func TestCancelBrokerTaskRecordsUsageWhenBrokerAlreadyTerminal(t *testing.T) {
 	t.Setenv("TASK_BROKER_BASE_URL", "https://broker.example")
 	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
@@ -88,10 +147,48 @@ func TestCancelBrokerTaskRecordsUsageWhenBrokerAlreadyTerminal(t *testing.T) {
 	assert.Equal(t, FailedOutputChannel, state.Channel)
 }
 
+func TestCancelBrokerTaskSchedulesPollWhenBrokerNotTerminal(t *testing.T) {
+	t.Setenv("TASK_BROKER_BASE_URL", "https://broker.example")
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
+
+	recorder := &recordingUsage{}
+	requests := &contexts.RequestContext{}
+	state := &contexts.ExecutionStateContext{KVs: map[string]string{"task_id": "task-1"}}
+	httpContext := &contexts.HTTPContext{Responses: []*http.Response{
+		{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
+		runningBrokerTaskResponse(),
+	}}
+
+	err := cancelBrokerTask(core.ExecutionContext{
+		HTTP:           httpContext,
+		ExecutionState: state,
+		Usage:          recorder,
+		Configuration:  hostedClaudeConfiguration(),
+		Logger:         log.NewEntry(log.New()),
+		Requests:       requests,
+		OrganizationID: "org-1",
+	}, "runnerClaudeCode.finished")
+	require.NoError(t, err)
+	assert.Empty(t, recorder.records)
+	assert.Empty(t, recorder.computes)
+	assert.Empty(t, state.Channel)
+	assert.Equal(t, hookActionPoll, requests.Action)
+	assert.Equal(t, "task-1", requests.Params["task_id"])
+	assert.Equal(t, "org-1", requests.Params["organization_id"])
+	assert.Equal(t, pollInterval, requests.Duration)
+}
+
 func hostedClaudeConfiguration() map[string]any {
 	return map[string]any{
 		"credentials": map[string]any{"source": "hosted"},
 		"model":       "sonnet",
+	}
+}
+
+func runningBrokerTaskResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"id":"task-1","status":"running"}`)),
 	}
 }
 

--- a/pkg/components/runner/runner_task_lifecycle_test.go
+++ b/pkg/components/runner/runner_task_lifecycle_test.go
@@ -1,10 +1,18 @@
 package runner
 
 import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
 func TestBillableSeconds(t *testing.T) {
@@ -25,4 +33,75 @@ func TestBillableSeconds(t *testing.T) {
 			assert.Equal(t, tc.expected, billableSeconds(tc.duration))
 		})
 	}
+}
+
+func TestPollBrokerTaskRecordsUsageWhenSuperPlaneAlreadyFinished(t *testing.T) {
+	t.Setenv("TASK_BROKER_BASE_URL", "https://broker.example")
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
+
+	recorder := &recordingUsage{}
+	state := &contexts.ExecutionStateContext{Finished: true}
+	httpContext := &contexts.HTTPContext{Responses: []*http.Response{canceledBrokerTaskWithUsageResponse()}}
+
+	err := pollBrokerTask(core.ActionHookContext{
+		Parameters: map[string]any{
+			"task_id":         "task-1",
+			"organization_id": "org-1",
+		},
+		HTTP:           httpContext,
+		ExecutionState: state,
+		Usage:          recorder,
+		Configuration:  hostedClaudeConfiguration(),
+		Logger:         log.NewEntry(log.New()),
+		Requests:       &contexts.RequestContext{},
+	}, "runnerClaudeCode.finished")
+	require.NoError(t, err)
+	require.Len(t, recorder.records, 1)
+	assert.Equal(t, int64(1280), recorder.records[0].TotalTokens)
+	require.Len(t, recorder.computes, 1)
+	assert.Empty(t, state.Payloads)
+	assert.True(t, state.Finished)
+}
+
+func TestCancelBrokerTaskRecordsUsageWhenBrokerAlreadyTerminal(t *testing.T) {
+	t.Setenv("TASK_BROKER_BASE_URL", "https://broker.example")
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
+
+	recorder := &recordingUsage{}
+	state := &contexts.ExecutionStateContext{KVs: map[string]string{"task_id": "task-1"}}
+	httpContext := &contexts.HTTPContext{Responses: []*http.Response{
+		{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
+		canceledBrokerTaskWithUsageResponse(),
+	}}
+
+	err := cancelBrokerTask(core.ExecutionContext{
+		HTTP:           httpContext,
+		ExecutionState: state,
+		Usage:          recorder,
+		Configuration:  hostedClaudeConfiguration(),
+		Logger:         log.NewEntry(log.New()),
+	}, "runnerClaudeCode.finished")
+	require.NoError(t, err)
+	require.Len(t, recorder.records, 1)
+	assert.Equal(t, int64(1280), recorder.records[0].TotalTokens)
+	require.Len(t, recorder.computes, 1)
+	assert.Equal(t, FailedOutputChannel, state.Channel)
+}
+
+func hostedClaudeConfiguration() map[string]any {
+	return map[string]any{
+		"credentials": map[string]any{"source": "hosted"},
+		"model":       "sonnet",
+	}
+}
+
+func canceledBrokerTaskWithUsageResponse() *http.Response {
+	claimed := time.Now().Add(-2 * time.Second).UTC().Format(time.RFC3339Nano)
+	finished := time.Now().UTC().Format(time.RFC3339Nano)
+	body := fmt.Sprintf(
+		`{"id":"task-1","status":"canceled","exit_code":130,"claimed_at":%q,"finished_at":%q,"result":{"usage":{"input_tokens":1200,"output_tokens":80},"model":"claude-sonnet-4-6"}}`,
+		claimed,
+		finished,
+	)
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
 }

--- a/pkg/components/runner/subcomponents.go
+++ b/pkg/components/runner/subcomponents.go
@@ -32,8 +32,8 @@ func HandleBrokerWebhook(ctx core.WebhookRequestContext, finishedEventType strin
 	return handleBrokerWebhook(ctx, finishedEventType)
 }
 
-func CancelBrokerTask(ctx core.ExecutionContext) error {
-	return cancelBrokerTask(ctx)
+func CancelBrokerTask(ctx core.ExecutionContext, finishedEventType string) error {
+	return cancelBrokerTask(ctx, finishedEventType)
 }
 
 func RevokeOpenRouterChildKey(httpCtx core.HTTPContext, state core.ExecutionStateContext, hosted core.HostedLLMContext, logger *logrus.Entry) {

--- a/pkg/components/runner/superplane/component.go
+++ b/pkg/components/runner/superplane/component.go
@@ -217,7 +217,7 @@ func (c *RunSuperPlane) HandleWebhook(ctx core.WebhookRequestContext) (int, *cor
 }
 
 func (c *RunSuperPlane) Cancel(ctx core.ExecutionContext) error {
-	return runner.CancelBrokerTask(ctx)
+	return runner.CancelBrokerTask(ctx, FinishedEventType)
 }
 
 func (c *RunSuperPlane) Cleanup(ctx core.SetupContext) error { return nil }

--- a/pkg/grpc/actions/factories/export_factory_work_order_run_usage_test.go
+++ b/pkg/grpc/actions/factories/export_factory_work_order_run_usage_test.go
@@ -27,7 +27,7 @@ func Test__ExportFactoryWorkOrderRunUsage(t *testing.T) {
 	factory, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
 	require.NoError(t, err)
 
-	order, err := factory.CreateWorkOrder(db, "Publish draft", "", &r.User, nil, nil)
+	order, err := factory.CreateWorkOrder(db, "Publish draft", "", &r.User, []uuid.UUID{r.User}, nil)
 	require.NoError(t, err)
 
 	line, err := factory.CreateLine(db, "ship", nil)

--- a/pkg/grpc/actions/factories/list_factory_work_order_run_usage.go
+++ b/pkg/grpc/actions/factories/list_factory_work_order_run_usage.go
@@ -98,22 +98,24 @@ func serializeWorkOrderRunUsageRows(factory *models.Factory, rows []models.WorkO
 
 func serializeWorkOrderRunUsageRow(factory *models.Factory, row models.WorkOrderRunUsage) *pb.WorkOrderRunUsageRow {
 	item := &pb.WorkOrderRunUsageRow{
-		WorkOrderExecutionId: row.WorkOrderExecutionID.String(),
-		WorkOrderId:          row.WorkOrderID.String(),
-		WorkOrderNumber:      row.WorkOrderNumber,
-		WorkOrderKey:         factory.WorkOrderKey(row.WorkOrderNumber),
-		Title:                row.Title,
-		LastOccurredAt:       timestamppb.New(row.LastOccurredAt),
-		UserName:             row.UserName,
-		UserEmail:            row.UserEmail,
-		TotalTokens:          row.TotalTokens,
-		DurationSeconds:      row.DurationSeconds,
-		CostCents:            row.CostCents(),
-		HostedCostCents:      row.HostedCostCents(),
-		ByokCostCents:        row.BYOKCostCents(),
-		Models:               row.Models,
-		ByokModels:           row.BYOKModels,
-		MachineTypes:         row.MachineTypes,
+		WorkOrderId:     row.WorkOrderID.String(),
+		WorkOrderNumber: row.WorkOrderNumber,
+		WorkOrderKey:    factory.WorkOrderKey(row.WorkOrderNumber),
+		Title:           row.Title,
+		LastOccurredAt:  timestamppb.New(row.LastOccurredAt),
+		UserName:        row.UserName,
+		UserEmail:       row.UserEmail,
+		TotalTokens:     row.TotalTokens,
+		DurationSeconds: row.DurationSeconds,
+		CostCents:       row.CostCents(),
+		HostedCostCents: row.HostedCostCents(),
+		ByokCostCents:   row.BYOKCostCents(),
+		Models:          row.Models,
+		ByokModels:      row.BYOKModels,
+		MachineTypes:    row.MachineTypes,
+	}
+	if row.WorkOrderExecutionID != uuid.Nil {
+		item.WorkOrderExecutionId = row.WorkOrderExecutionID.String()
 	}
 	if row.UserID != nil && *row.UserID != uuid.Nil {
 		item.UserId = row.UserID.String()

--- a/pkg/grpc/actions/factories/list_factory_work_order_run_usage_test.go
+++ b/pkg/grpc/actions/factories/list_factory_work_order_run_usage_test.go
@@ -24,7 +24,7 @@ func Test__ListFactoryWorkOrderRunUsage(t *testing.T) {
 	factory, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
 	require.NoError(t, err)
 
-	order, err := factory.CreateWorkOrder(db, "Publish draft", "", &r.User, nil, nil)
+	order, err := factory.CreateWorkOrder(db, "Publish draft", "", &r.User, []uuid.UUID{r.User}, nil)
 	require.NoError(t, err)
 
 	line, err := factory.CreateLine(db, "ship", nil)
@@ -79,6 +79,8 @@ func Test__ListFactoryWorkOrderRunUsage(t *testing.T) {
 	assert.Equal(t, factory.WorkOrderKey(order.Number), row.WorkOrderKey)
 	assert.Equal(t, "Publish draft", row.Title)
 	assert.Equal(t, r.UserModel.GetEmail(), row.UserEmail)
+	assert.Equal(t, r.UserModel.Name, row.UserName)
+	assert.Equal(t, r.User.String(), row.UserId)
 	assert.Equal(t, int64(1_000_000), row.TotalTokens)
 	assert.Equal(t, int64(90), row.DurationSeconds)
 	assert.Contains(t, row.ByokModels, "anthropic/claude-sonnet-4-6")

--- a/pkg/models/factory.go
+++ b/pkg/models/factory.go
@@ -580,6 +580,12 @@ func (f *Factory) createWorkOrder(
 		return nil, err
 	}
 
+	if sourceRunID != nil {
+		if err := attachUsageEventsToWorkOrder(tx, f.ID, order.ID, *sourceRunID); err != nil {
+			return nil, err
+		}
+	}
+
 	if len(assignees) > 0 {
 		if err := order.ReplaceAssignees(tx, assignees); err != nil {
 			return nil, err

--- a/pkg/models/spending_report_test.go
+++ b/pkg/models/spending_report_test.go
@@ -111,6 +111,61 @@ func TestSummarizeSpendingKPITotalsAndExplorer(t *testing.T) {
 	assert.Equal(t, r.UserModel.Name, catalogs.Users[0].Label)
 }
 
+func TestSummarizeSpendingKPITotals__IncludesCancelledCanvasRun(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+
+	factory, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+
+	order, err := factory.CreateWorkOrder(db, "Canceled run", "", &r.User, []uuid.UUID{r.User}, nil)
+	require.NoError(t, err)
+
+	line, err := factory.CreateLine(db, "ship", nil)
+	require.NoError(t, err)
+
+	app, entry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "build", "start")
+	require.NoError(t, line.Update(db, nil, []models.FactoryLineStep{
+		{Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: entry},
+	}, nil))
+
+	var execution *models.FactoryWorkOrderExecution
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		_, result, dispatchErr := line.Dispatch(tx, order)
+		if dispatchErr != nil {
+			return dispatchErr
+		}
+		execution = result.Execution
+		return nil
+	}))
+	require.NotNil(t, execution.RunID)
+
+	require.NoError(t, models.RecordUsage(db, models.WorkspaceUsageEventInput{
+		OrganizationID:  r.Organization.ID,
+		CanvasRunID:     *execution.RunID,
+		NodeExecutionID: uuid.New(),
+		NodeID:          "prompt",
+		Provider:        models.UsageProviderOpenAI,
+		Model:           "gpt-4o",
+		FundingSource:   models.UsageFundingSourceHosted,
+		InputTokens:     2500,
+		TotalTokens:     2500,
+	}))
+	require.NoError(t, db.Model(&models.CanvasRun{}).Where("id = ?", *execution.RunID).Updates(map[string]any{
+		"state":  models.CanvasRunStateFinished,
+		"result": models.CanvasRunResultCancelled,
+	}).Error)
+
+	kpi, err := models.SummarizeSpendingKPITotals(db, models.UsageReportFilter{
+		OrganizationID: r.Organization.ID,
+		Since:          time.Now().AddDate(0, 0, -7),
+		Until:          time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2500), kpi.TotalTokens)
+	assert.Positive(t, kpi.CostMicros)
+}
+
 func TestSummarizeSpendingKPITotalsIgnoresFactoryFilter(t *testing.T) {
 	r := support.Setup(t)
 	db := database.DB(t.Context())

--- a/pkg/models/workspace_usage_event.go
+++ b/pkg/models/workspace_usage_event.go
@@ -651,6 +651,8 @@ func SummarizeComputeUsage(tx *gorm.DB, filter UsageReportFilter) (UsageTotals, 
 	return totals, byMachine, nil
 }
 
+const workOrderRunUsageGroupKey = `COALESCE(workspace_usage_events.work_order_execution_id, workspace_usage_events.canvas_run_id)`
+
 const workOrderRunUsageSelect = `
 	workspace_usage_events.work_order_execution_id,
 	factory_work_orders.id AS work_order_id,
@@ -705,7 +707,7 @@ func workOrderRunUsageQuery(tx *gorm.DB, filter UsageReportFilter) *gorm.DB {
 		Where("workspace_usage_events.work_order_id IS NOT NULL")
 }
 
-const workOrderRunUsageGroupBy = `workspace_usage_events.work_order_execution_id, factory_work_orders.id, factory_work_orders.number, factory_work_orders.title, first_assignee.user_id, users.name, users.email`
+const workOrderRunUsageGroupBy = workOrderRunUsageGroupKey + `, workspace_usage_events.work_order_execution_id, factory_work_orders.id, factory_work_orders.number, factory_work_orders.title, first_assignee.user_id, users.name, users.email`
 
 // ListWorkOrderRunUsage returns paginated task-run spend from the ledger.
 // It does not write usage or change remaining hosted credit.
@@ -714,7 +716,7 @@ func ListWorkOrderRunUsage(tx *gorm.DB, filter UsageReportFilter, limit, offset 
 		Count int64
 	}
 	err := workOrderRunUsageQuery(tx, filter).
-		Select("COUNT(DISTINCT COALESCE(workspace_usage_events.work_order_execution_id, workspace_usage_events.work_order_id)) AS count").
+		Select("COUNT(DISTINCT " + workOrderRunUsageGroupKey + ") AS count").
 		Scan(&totalRow).Error
 	if err != nil {
 		return nil, 0, err

--- a/pkg/models/workspace_usage_event.go
+++ b/pkg/models/workspace_usage_event.go
@@ -264,6 +264,39 @@ func persistUsageEvent(tx *gorm.DB, event WorkspaceUsageEvent, execution *Factor
 	return nil
 }
 
+func attachUsageEventsToWorkOrder(tx *gorm.DB, factoryID, workOrderID, sourceRunID uuid.UUID) error {
+	runIDs, err := canvasRunIDsInTree(tx, sourceRunID)
+	if err != nil || len(runIDs) == 0 {
+		return err
+	}
+	return tx.Model(&WorkspaceUsageEvent{}).
+		Where("factory_id = ? AND canvas_run_id IN ? AND work_order_id IS NULL AND work_order_execution_id IS NULL", factoryID, runIDs).
+		Update("work_order_id", workOrderID).Error
+}
+
+func canvasRunIDsInTree(tx *gorm.DB, rootID uuid.UUID) ([]uuid.UUID, error) {
+	ids := []uuid.UUID{rootID}
+	seen := map[uuid.UUID]struct{}{rootID: {}}
+	frontier := []uuid.UUID{rootID}
+	for len(frontier) > 0 {
+		var children []CanvasRun
+		err := tx.Select("id").Where("parent_run_id IN ?", frontier).Find(&children).Error
+		if err != nil {
+			return nil, err
+		}
+		frontier = frontier[:0]
+		for _, child := range children {
+			if _, exists := seen[child.ID]; exists {
+				continue
+			}
+			seen[child.ID] = struct{}{}
+			ids = append(ids, child.ID)
+			frontier = append(frontier, child.ID)
+		}
+	}
+	return ids, nil
+}
+
 func fundingSourceIsHosted(source string) bool {
 	return strings.TrimSpace(source) == UsageFundingSourceHosted
 }
@@ -691,7 +724,7 @@ type workOrderRunUsageScanRow struct {
 func workOrderRunUsageQuery(tx *gorm.DB, filter UsageReportFilter) *gorm.DB {
 	return spendingScopedQuery(tx, filter, true).
 		Joins("LEFT JOIN users ON users.id = factory_work_orders.created_by_id").
-		Where("workspace_usage_events.work_order_execution_id IS NOT NULL")
+		Where("workspace_usage_events.work_order_id IS NOT NULL")
 }
 
 const workOrderRunUsageGroupBy = `workspace_usage_events.work_order_execution_id, factory_work_orders.id, factory_work_orders.number, factory_work_orders.title, factory_work_orders.created_by_id, users.name, users.email`
@@ -703,7 +736,7 @@ func ListWorkOrderRunUsage(tx *gorm.DB, filter UsageReportFilter, limit, offset 
 		Count int64
 	}
 	err := workOrderRunUsageQuery(tx, filter).
-		Select("COUNT(DISTINCT workspace_usage_events.work_order_execution_id) AS count").
+		Select("COUNT(DISTINCT COALESCE(workspace_usage_events.work_order_execution_id, workspace_usage_events.work_order_id)) AS count").
 		Scan(&totalRow).Error
 	if err != nil {
 		return nil, 0, err

--- a/pkg/models/workspace_usage_event.go
+++ b/pkg/models/workspace_usage_event.go
@@ -657,7 +657,7 @@ const workOrderRunUsageSelect = `
 	factory_work_orders.number AS work_order_number,
 	factory_work_orders.title AS title,
 	MAX(workspace_usage_events.occurred_at) AS last_occurred_at,
-	factory_work_orders.created_by_id AS user_id,
+	first_assignee.user_id AS user_id,
 	COALESCE(users.name, '') AS user_name,
 	COALESCE(users.email, '') AS user_email,
 	COALESCE(SUM(workspace_usage_events.total_tokens), 0) AS total_tokens,
@@ -688,13 +688,24 @@ type workOrderRunUsageScanRow struct {
 	MachineTypes         string
 }
 
+// First assignee by assignment time, then user id. Usage names the owner,
+// not the creator. Analysis rows with no assignee stay empty.
+const firstWorkOrderAssigneeJoin = `LEFT JOIN LATERAL (
+	SELECT user_id
+	FROM factory_work_order_assignees
+	WHERE work_order_id = factory_work_orders.id
+	ORDER BY created_at ASC, user_id ASC
+	LIMIT 1
+) first_assignee ON TRUE`
+
 func workOrderRunUsageQuery(tx *gorm.DB, filter UsageReportFilter) *gorm.DB {
 	return spendingScopedQuery(tx, filter, true).
-		Joins("LEFT JOIN users ON users.id = factory_work_orders.created_by_id").
+		Joins(firstWorkOrderAssigneeJoin).
+		Joins("LEFT JOIN users ON users.id = first_assignee.user_id").
 		Where("workspace_usage_events.work_order_id IS NOT NULL")
 }
 
-const workOrderRunUsageGroupBy = `workspace_usage_events.work_order_execution_id, factory_work_orders.id, factory_work_orders.number, factory_work_orders.title, factory_work_orders.created_by_id, users.name, users.email`
+const workOrderRunUsageGroupBy = `workspace_usage_events.work_order_execution_id, factory_work_orders.id, factory_work_orders.number, factory_work_orders.title, first_assignee.user_id, users.name, users.email`
 
 // ListWorkOrderRunUsage returns paginated task-run spend from the ledger.
 // It does not write usage or change remaining hosted credit.

--- a/pkg/models/workspace_usage_event.go
+++ b/pkg/models/workspace_usage_event.go
@@ -264,39 +264,6 @@ func persistUsageEvent(tx *gorm.DB, event WorkspaceUsageEvent, execution *Factor
 	return nil
 }
 
-func attachUsageEventsToWorkOrder(tx *gorm.DB, factoryID, workOrderID, sourceRunID uuid.UUID) error {
-	runIDs, err := canvasRunIDsInTree(tx, sourceRunID)
-	if err != nil || len(runIDs) == 0 {
-		return err
-	}
-	return tx.Model(&WorkspaceUsageEvent{}).
-		Where("factory_id = ? AND canvas_run_id IN ? AND work_order_id IS NULL AND work_order_execution_id IS NULL", factoryID, runIDs).
-		Update("work_order_id", workOrderID).Error
-}
-
-func canvasRunIDsInTree(tx *gorm.DB, rootID uuid.UUID) ([]uuid.UUID, error) {
-	ids := []uuid.UUID{rootID}
-	seen := map[uuid.UUID]struct{}{rootID: {}}
-	frontier := []uuid.UUID{rootID}
-	for len(frontier) > 0 {
-		var children []CanvasRun
-		err := tx.Select("id").Where("parent_run_id IN ?", frontier).Find(&children).Error
-		if err != nil {
-			return nil, err
-		}
-		frontier = frontier[:0]
-		for _, child := range children {
-			if _, exists := seen[child.ID]; exists {
-				continue
-			}
-			seen[child.ID] = struct{}{}
-			ids = append(ids, child.ID)
-			frontier = append(frontier, child.ID)
-		}
-	}
-	return ids, nil
-}
-
 func fundingSourceIsHosted(source string) bool {
 	return strings.TrimSpace(source) == UsageFundingSourceHosted
 }
@@ -855,4 +822,37 @@ func (e *FactoryWorkOrderExecution) RollupUsage(tx *gorm.DB) error {
 			"updated_at":       now,
 		}).Error
 	})
+}
+
+func attachUsageEventsToWorkOrder(tx *gorm.DB, factoryID, workOrderID, sourceRunID uuid.UUID) error {
+	runIDs, err := canvasRunIDsInTree(tx, sourceRunID)
+	if err != nil || len(runIDs) == 0 {
+		return err
+	}
+	return tx.Model(&WorkspaceUsageEvent{}).
+		Where("factory_id = ? AND canvas_run_id IN ? AND work_order_id IS NULL AND work_order_execution_id IS NULL", factoryID, runIDs).
+		Update("work_order_id", workOrderID).Error
+}
+
+func canvasRunIDsInTree(tx *gorm.DB, rootID uuid.UUID) ([]uuid.UUID, error) {
+	ids := []uuid.UUID{rootID}
+	seen := map[uuid.UUID]struct{}{rootID: {}}
+	frontier := []uuid.UUID{rootID}
+	for len(frontier) > 0 {
+		var children []CanvasRun
+		err := tx.Select("id").Where("parent_run_id IN ?", frontier).Find(&children).Error
+		if err != nil {
+			return nil, err
+		}
+		frontier = frontier[:0]
+		for _, child := range children {
+			if _, exists := seen[child.ID]; exists {
+				continue
+			}
+			seen[child.ID] = struct{}{}
+			ids = append(ids, child.ID)
+			frontier = append(frontier, child.ID)
+		}
+	}
+	return ids, nil
 }

--- a/pkg/models/workspace_usage_event_test.go
+++ b/pkg/models/workspace_usage_event_test.go
@@ -960,6 +960,41 @@ func Test__ListWorkOrderRunUsage__KeepsAnalysisApartFromLineExecution(t *testing
 	assert.Equal(t, order.ID, executionRow.WorkOrderID)
 }
 
+func Test__ListWorkOrderRunUsage__KeepsAnalysisRunsApart(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, order := createFactoryOrder(t, r)
+	event := map[string]any{
+		"type": "workOrder.created",
+		"data": map[string]any{
+			"workOrder": map[string]any{"id": order.ID.String()},
+		},
+	}
+	firstRun := startFactoryCanvasRun(t, r, factory.ID, event)
+	secondRun := startFactoryCanvasRun(t, r, factory.ID, event)
+
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, firstRun.ID)))
+	second := sonnetUsage(t, r, secondRun.ID)
+	second.InputTokens = 500_000
+	second.TotalTokens = 500_000
+	require.NoError(t, models.RecordUsage(db, second))
+
+	rows, total, err := models.ListWorkOrderRunUsage(db, models.UsageReportFilter{
+		OrganizationID: r.Organization.ID,
+		FactoryID:      &factory.ID,
+	}, 50, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), total)
+	require.Len(t, rows, 2)
+	assert.Equal(t, uuid.Nil, rows[0].WorkOrderExecutionID)
+	assert.Equal(t, uuid.Nil, rows[1].WorkOrderExecutionID)
+	assert.Equal(t, order.ID, rows[0].WorkOrderID)
+	assert.Equal(t, order.ID, rows[1].WorkOrderID)
+
+	tokens := []int64{rows[0].TotalTokens, rows[1].TotalTokens}
+	assert.ElementsMatch(t, []int64{1_000_000, 500_000}, tokens)
+}
+
 func Test__CreateWorkOrder__AttachesPriorCanvasUsage(t *testing.T) {
 	r := support.Setup(t)
 	db := database.DB(t.Context())

--- a/pkg/models/workspace_usage_event_test.go
+++ b/pkg/models/workspace_usage_event_test.go
@@ -860,6 +860,64 @@ func Test__ListWorkOrderRunUsage__IncludesAnalysisWithoutExecution(t *testing.T)
 	assert.Equal(t, int64(1_000_000), rows[0].TotalTokens)
 	assert.Contains(t, rows[0].BYOKModels, "anthropic/claude-sonnet-4-6")
 	assert.Empty(t, rows[0].MachineTypes)
+	assert.Empty(t, rows[0].UserName)
+	assert.Empty(t, rows[0].UserEmail)
+	assert.Nil(t, rows[0].UserID)
+}
+
+func Test__ListWorkOrderRunUsage__NamesTheFirstAssigneeNotTheCreator(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, line := setupFactoryLine(t, r)
+	assignee := support.CreateUser(t, r, r.Organization.ID)
+
+	order, err := factory.CreateWorkOrder(db, "Assigned run", "", &r.User, []uuid.UUID{assignee.ID}, nil)
+	require.NoError(t, err)
+	execution := dispatchExistingOrder(t, db, line, order)
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, requireExecutionRunID(t, execution))))
+
+	rows, total, err := models.ListWorkOrderRunUsage(db, models.UsageReportFilter{
+		OrganizationID: r.Organization.ID,
+		FactoryID:      &factory.ID,
+	}, 50, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, rows, 1)
+	require.NotNil(t, rows[0].UserID)
+	assert.Equal(t, assignee.ID, *rows[0].UserID)
+	assert.Equal(t, assignee.Name, rows[0].UserName)
+	assert.Equal(t, assignee.GetEmail(), rows[0].UserEmail)
+	assert.NotEqual(t, r.UserModel.GetEmail(), rows[0].UserEmail)
+}
+
+func Test__ListWorkOrderRunUsage__NamesTheEarliestAssignee(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, line := setupFactoryLine(t, r)
+	first := support.CreateUser(t, r, r.Organization.ID)
+	second := support.CreateUser(t, r, r.Organization.ID)
+
+	order, err := factory.CreateWorkOrder(db, "Two owners", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, order.ReplaceAssignees(db, []uuid.UUID{second.ID, first.ID}))
+	earlier := time.Now().Add(-time.Hour)
+	require.NoError(t, db.Model(&models.FactoryWorkOrderAssignee{}).
+		Where("work_order_id = ? AND user_id = ?", order.ID, first.ID).
+		Update("created_at", earlier).Error)
+
+	execution := dispatchExistingOrder(t, db, line, order)
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, requireExecutionRunID(t, execution))))
+
+	rows, total, err := models.ListWorkOrderRunUsage(db, models.UsageReportFilter{
+		OrganizationID: r.Organization.ID,
+		FactoryID:      &factory.ID,
+	}, 50, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, rows, 1)
+	require.NotNil(t, rows[0].UserID)
+	assert.Equal(t, first.ID, *rows[0].UserID)
+	assert.Equal(t, first.Name, rows[0].UserName)
 }
 
 func Test__ListWorkOrderRunUsage__KeepsAnalysisApartFromLineExecution(t *testing.T) {
@@ -1059,8 +1117,18 @@ func dispatchNamedOrder(
 ) *models.FactoryWorkOrderExecution {
 	t.Helper()
 	db := database.DB(t.Context())
-	order, err := factory.CreateWorkOrder(db, title, "", &r.User, nil, nil)
+	order, err := factory.CreateWorkOrder(db, title, "", &r.User, []uuid.UUID{r.User}, nil)
 	require.NoError(t, err)
+	return dispatchExistingOrder(t, db, line, order)
+}
+
+func dispatchExistingOrder(
+	t *testing.T,
+	db *gorm.DB,
+	line *models.FactoryLine,
+	order *models.FactoryWorkOrder,
+) *models.FactoryWorkOrderExecution {
+	t.Helper()
 	var execution *models.FactoryWorkOrderExecution
 	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
 		_, result, dispatchErr := line.Dispatch(tx, order)

--- a/pkg/models/workspace_usage_event_test.go
+++ b/pkg/models/workspace_usage_event_test.go
@@ -836,6 +836,103 @@ func Test__ListWorkOrderRunUsage__OmitsOtherFactoriesAndRowsWithoutExecution(t *
 	assert.Equal(t, kept.ID, rows[0].WorkOrderExecutionID)
 }
 
+func Test__ListWorkOrderRunUsage__IncludesAnalysisWithoutExecution(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, order := createFactoryOrder(t, r)
+	run := startFactoryCanvasRun(t, r, factory.ID, map[string]any{
+		"type": "workOrder.created",
+		"data": map[string]any{
+			"workOrder": map[string]any{"id": order.ID.String()},
+		},
+	})
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, run.ID)))
+
+	rows, total, err := models.ListWorkOrderRunUsage(db, models.UsageReportFilter{
+		OrganizationID: r.Organization.ID,
+		FactoryID:      &factory.ID,
+	}, 50, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, rows, 1)
+	assert.Equal(t, uuid.Nil, rows[0].WorkOrderExecutionID)
+	assert.Equal(t, order.ID, rows[0].WorkOrderID)
+	assert.Equal(t, int64(1_000_000), rows[0].TotalTokens)
+	assert.Contains(t, rows[0].BYOKModels, "anthropic/claude-sonnet-4-6")
+	assert.Empty(t, rows[0].MachineTypes)
+}
+
+func Test__ListWorkOrderRunUsage__KeepsAnalysisApartFromLineExecution(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, line := setupFactoryLine(t, r)
+	execution := dispatchNamedOrder(t, r, factory, line, "Ship it")
+	order, err := factory.FindWorkOrder(db, execution.WorkOrderID)
+	require.NoError(t, err)
+
+	analysis := startFactoryCanvasRun(t, r, factory.ID, map[string]any{
+		"type": "workOrder.created",
+		"data": map[string]any{
+			"workOrder": map[string]any{"id": order.ID.String()},
+		},
+	})
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, analysis.ID)))
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, requireExecutionRunID(t, execution))))
+
+	rows, total, err := models.ListWorkOrderRunUsage(db, models.UsageReportFilter{
+		OrganizationID: r.Organization.ID,
+		FactoryID:      &factory.ID,
+	}, 50, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), total)
+	require.Len(t, rows, 2)
+
+	var analysisRow, executionRow *models.WorkOrderRunUsage
+	for i := range rows {
+		if rows[i].WorkOrderExecutionID == uuid.Nil {
+			analysisRow = &rows[i]
+			continue
+		}
+		executionRow = &rows[i]
+	}
+	require.NotNil(t, analysisRow)
+	require.NotNil(t, executionRow)
+	assert.Equal(t, order.ID, analysisRow.WorkOrderID)
+	assert.Equal(t, execution.ID, executionRow.WorkOrderExecutionID)
+	assert.Equal(t, order.ID, executionRow.WorkOrderID)
+}
+
+func Test__CreateWorkOrder__AttachesPriorCanvasUsage(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	run := startFactoryCanvasRun(t, r, factory.ID, nil)
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, run.ID)))
+
+	event := requireUsageEventForRun(t, db, run.ID)
+	assert.Nil(t, event.WorkOrderID)
+
+	order, err := factory.CreateWorkOrder(db, "From intake", "", &r.User, nil, &run.ID)
+	require.NoError(t, err)
+
+	event = requireUsageEventForRun(t, db, run.ID)
+	require.NotNil(t, event.WorkOrderID)
+	assert.Equal(t, order.ID, *event.WorkOrderID)
+	assert.Nil(t, event.WorkOrderExecutionID)
+
+	rows, total, err := models.ListWorkOrderRunUsage(db, models.UsageReportFilter{
+		OrganizationID: r.Organization.ID,
+		FactoryID:      &factory.ID,
+	}, 50, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, rows, 1)
+	assert.Equal(t, order.ID, rows[0].WorkOrderID)
+	assert.Equal(t, uuid.Nil, rows[0].WorkOrderExecutionID)
+	assert.Equal(t, int64(1_000_000), rows[0].TotalTokens)
+}
+
 func Test__ListWorkOrderRunUsage__PaginatesAndRespectsWindow(t *testing.T) {
 	r := support.Setup(t)
 	db := database.DB(t.Context())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Usage tab named the task creator. Intake and canvas-created tasks often have no creator, so User stayed empty even when someone owned the task.

This change names each Usage row from the earliest assignee. Analysis spend with no assignee still shows an empty User.

Canceled agent runs now write LLM and compute into the ledger. If the broker is not terminal at cancel time, SuperPlane keeps polling until the broker ends. Torn result JSON still receives sidecar token usage.

Spending sums that ledger and does not skip canceled canvas runs.

Each analysis canvas run is its own Usage row. Local VM price stays an em dash. Local fleets are unbilled.

This work replaces closed PR 7358. It keeps cancel and analysis spend, then adds the assignee User column.

## Test plan

- [ ] Open workspace Usage and confirm assigned tasks show the assignee name.
- [ ] Confirm an analysis row with no assignee still shows an empty User.
- [ ] Cancel a running implement step after the agent consumes tokens.
- [ ] Confirm Usage shows model, tokens, and token price for that run.
- [ ] Confirm Spending KPI totals include that canceled run.
- [ ] Cancel a run before the broker is terminal. Confirm Usage later shows tokens.
- [ ] Run two backlog analyses on the same work order. Confirm Usage shows two rows.
- [ ] Run backlog analysis that creates a work order after it records usage.
- [ ] Confirm Usage shows a separate analysis row for that work order.
- [ ] Export the Usage CSV and confirm User matches the table.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8f5ac9f-d875-4462-b994-651b7a06bea7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8f5ac9f-d875-4462-b994-651b7a06bea7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63049013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The behavioral changes appear sound, but the explicit model-file declaration-order requirement must be satisfied before merging.

<sub>Reviews (2) · Last reviewed commit: ["fix: Merge LLM usage when result JSON is..."](https://github.com/superplanehq/superplane/commit/eb28504c83f58dde0b852ba6e6a152bf45b435a0)</sub>

<!-- /greptile_comment -->