### PR TITLE
feat: Add read-only admin Price Books page

### DIFF
--- a/pkg/models/usage_price_book.go
+++ b/pkg/models/usage_price_book.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"slices"
 	"strings"
 	"time"
 
@@ -45,18 +46,52 @@ func (UsagePriceBookRate) TableName() string {
 	return "usage_price_book_rates"
 }
 
+// ListUsagePriceBooks returns every catalog version, newest effective_at first.
+func ListUsagePriceBooks(tx *gorm.DB) ([]UsagePriceBook, error) {
+	var books []UsagePriceBook
+	err := tx.Order("effective_at DESC").Find(&books).Error
+	if err != nil {
+		return nil, err
+	}
+	return books, nil
+}
+
+// FindUsagePriceBook returns one catalog version.
+func FindUsagePriceBook(tx *gorm.DB, version string) (*UsagePriceBook, error) {
+	var book UsagePriceBook
+	err := tx.Where("version = ?", version).First(&book).Error
+	if err != nil {
+		return nil, err
+	}
+	return &book, nil
+}
+
+// ListUsagePriceBookRates returns the match rules for one catalog version.
+func ListUsagePriceBookRates(tx *gorm.DB, version string) ([]UsagePriceBookRate, error) {
+	var rows []UsagePriceBookRate
+	err := tx.Where("version = ?", version).Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	slices.SortFunc(rows, compareUsagePriceBookRates)
+	return rows, nil
+}
+
 // LoadCurrentPriceBook installs the latest database catalog into the
 // in-memory price book. Callers keep the compiled-in fallback when this
 // returns an error (empty table or missing migration).
 func LoadCurrentPriceBook(tx *gorm.DB) error {
-	var book UsagePriceBook
-	err := tx.Order("effective_at DESC").First(&book).Error
+	books, err := ListUsagePriceBooks(tx)
 	if err != nil {
 		return err
 	}
+	if len(books) == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	book := books[0]
 
-	var rows []UsagePriceBookRate
-	err = tx.Where("version = ?", book.Version).Find(&rows).Error
+	rows, err := ListUsagePriceBookRates(tx, book.Version)
 	if err != nil {
 		return err
 	}
@@ -94,4 +129,11 @@ func LoadCurrentPriceBook(tx *gorm.DB) error {
 
 	pricebook.Replace(loaded)
 	return nil
+}
+
+func compareUsagePriceBookRates(a, b UsagePriceBookRate) int {
+	if keyOrder := strings.Compare(a.MatchKey, b.MatchKey); keyOrder != 0 {
+		return keyOrder
+	}
+	return strings.Compare(a.MatchMode, b.MatchMode)
 }

--- a/pkg/models/usage_price_book_test.go
+++ b/pkg/models/usage_price_book_test.go
@@ -5,12 +5,71 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/usage/pricebook"
 	"github.com/superplanehq/superplane/test/support"
 )
+
+func Test__ListUsagePriceBooks__OrdersByEffectiveAtDesc(t *testing.T) {
+	_ = support.Setup(t)
+	db := database.DB(t.Context())
+
+	books, err := models.ListUsagePriceBooks(db)
+	require.NoError(t, err)
+	require.NotEmpty(t, books)
+	assert.Equal(t, "2026-09-09.1", books[0].Version)
+
+	for i := 1; i < len(books); i++ {
+		assert.False(t, books[i].EffectiveAt.After(books[i-1].EffectiveAt))
+	}
+}
+
+func Test__FindUsagePriceBook(t *testing.T) {
+	_ = support.Setup(t)
+	db := database.DB(t.Context())
+
+	book, err := models.FindUsagePriceBook(db, "2026-09-09.1")
+	require.NoError(t, err)
+	assert.Equal(t, "2026-09-09.1", book.Version)
+
+	_, err = models.FindUsagePriceBook(db, "does-not-exist")
+	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+func Test__ListUsagePriceBookRates(t *testing.T) {
+	_ = support.Setup(t)
+	db := database.DB(t.Context())
+
+	rows, err := models.ListUsagePriceBookRates(db, "2026-09-09.1")
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+
+	hasModel := false
+	hasCompute := false
+	for i, row := range rows {
+		assert.Equal(t, "2026-09-09.1", row.Version)
+		if row.UsageKind == models.UsageKindModel {
+			hasModel = true
+		}
+		if row.UsageKind == models.UsageKindCompute {
+			hasCompute = true
+		}
+		if i == 0 {
+			continue
+		}
+		previous := rows[i-1]
+		if previous.MatchKey == row.MatchKey {
+			assert.LessOrEqual(t, previous.MatchMode, row.MatchMode)
+			continue
+		}
+		assert.Less(t, previous.MatchKey, row.MatchKey)
+	}
+	assert.True(t, hasModel)
+	assert.True(t, hasCompute)
+}
 
 func Test__LoadCurrentPriceBook__MatchesHardcodedRates(t *testing.T) {
 	_ = support.Setup(t)

--- a/pkg/public/admin_price_books.go
+++ b/pkg/public/admin_price_books.go
@@ -1,0 +1,149 @@
+package public
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"gorm.io/gorm"
+)
+
+type adminPriceBookVersion struct {
+	Version     string `json:"version"`
+	EffectiveAt string `json:"effective_at"`
+	CreatedAt   string `json:"created_at"`
+}
+
+type adminPriceBookModelRate struct {
+	MatchKey                  string `json:"match_key"`
+	MatchMode                 string `json:"match_mode"`
+	InputCentsPerMillion      int64  `json:"input_cents_per_million"`
+	OutputCentsPerMillion     int64  `json:"output_cents_per_million"`
+	CacheReadCentsPerMillion  int64  `json:"cache_read_cents_per_million"`
+	CacheWriteCentsPerMillion int64  `json:"cache_write_cents_per_million"`
+	ReasoningCentsPerMillion  int64  `json:"reasoning_cents_per_million"`
+}
+
+type adminPriceBookVMRate struct {
+	MatchKey        string `json:"match_key"`
+	MatchMode       string `json:"match_mode"`
+	MicrosPerSecond int64  `json:"micros_per_second"`
+}
+
+type adminPriceBooksResponse struct {
+	CurrentVersion string                    `json:"current_version"`
+	Version        string                    `json:"version"`
+	EffectiveAt    string                    `json:"effective_at"`
+	CreatedAt      string                    `json:"created_at"`
+	Versions       []adminPriceBookVersion   `json:"versions"`
+	Models         []adminPriceBookModelRate `json:"models"`
+	VMs            []adminPriceBookVMRate    `json:"vms"`
+}
+
+func (s *Server) adminGetPriceBooks(w http.ResponseWriter, r *http.Request) {
+	tx := database.DB(r.Context())
+	books, err := models.ListUsagePriceBooks(tx)
+	if err != nil {
+		log.Errorf("admin: failed to list price books: %v", err)
+		http.Error(w, "Failed to load price books", http.StatusInternalServerError)
+		return
+	}
+
+	requestedVersion := strings.TrimSpace(r.URL.Query().Get("version"))
+	if len(books) == 0 {
+		if requestedVersion != "" {
+			http.Error(w, "Price book not found", http.StatusNotFound)
+			return
+		}
+
+		respondJSON(w, emptyAdminPriceBooksResponse())
+		return
+	}
+
+	current := books[0]
+	selected := current
+	if requestedVersion != "" {
+		found, err := models.FindUsagePriceBook(tx, requestedVersion)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				http.Error(w, "Price book not found", http.StatusNotFound)
+				return
+			}
+
+			log.Errorf("admin: failed to load price book %s: %v", requestedVersion, err)
+			http.Error(w, "Failed to load price books", http.StatusInternalServerError)
+			return
+		}
+		selected = *found
+	}
+
+	rows, err := models.ListUsagePriceBookRates(tx, selected.Version)
+	if err != nil {
+		log.Errorf("admin: failed to list price book rates for %s: %v", selected.Version, err)
+		http.Error(w, "Failed to load price books", http.StatusInternalServerError)
+		return
+	}
+
+	respondJSON(w, buildAdminPriceBooksResponse(current.Version, selected, books, rows))
+}
+
+func emptyAdminPriceBooksResponse() adminPriceBooksResponse {
+	return adminPriceBooksResponse{
+		Versions: []adminPriceBookVersion{},
+		Models:   []adminPriceBookModelRate{},
+		VMs:      []adminPriceBookVMRate{},
+	}
+}
+
+func buildAdminPriceBooksResponse(
+	currentVersion string,
+	selected models.UsagePriceBook,
+	books []models.UsagePriceBook,
+	rows []models.UsagePriceBookRate,
+) adminPriceBooksResponse {
+	versions := make([]adminPriceBookVersion, 0, len(books))
+	for _, book := range books {
+		versions = append(versions, adminPriceBookVersion{
+			Version:     book.Version,
+			EffectiveAt: book.EffectiveAt.Format(time.RFC3339),
+			CreatedAt:   book.CreatedAt.Format(time.RFC3339),
+		})
+	}
+
+	modelRates := make([]adminPriceBookModelRate, 0)
+	vmRates := make([]adminPriceBookVMRate, 0)
+	for _, row := range rows {
+		switch strings.TrimSpace(row.UsageKind) {
+		case models.UsageKindModel:
+			modelRates = append(modelRates, adminPriceBookModelRate{
+				MatchKey:                  row.MatchKey,
+				MatchMode:                 row.MatchMode,
+				InputCentsPerMillion:      row.InputCentsPerMillion,
+				OutputCentsPerMillion:     row.OutputCentsPerMillion,
+				CacheReadCentsPerMillion:  row.CacheReadCentsPerMillion,
+				CacheWriteCentsPerMillion: row.CacheWriteCentsPerMillion,
+				ReasoningCentsPerMillion:  row.ReasoningCentsPerMillion,
+			})
+		case models.UsageKindCompute:
+			vmRates = append(vmRates, adminPriceBookVMRate{
+				MatchKey:        row.MatchKey,
+				MatchMode:       row.MatchMode,
+				MicrosPerSecond: row.MicrosPerSecond,
+			})
+		}
+	}
+
+	return adminPriceBooksResponse{
+		CurrentVersion: currentVersion,
+		Version:        selected.Version,
+		EffectiveAt:    selected.EffectiveAt.Format(time.RFC3339),
+		CreatedAt:      selected.CreatedAt.Format(time.RFC3339),
+		Versions:       versions,
+		Models:         modelRates,
+		VMs:            vmRates,
+	}
+}

--- a/pkg/public/admin_price_books_test.go
+++ b/pkg/public/admin_price_books_test.go
@@ -1,0 +1,123 @@
+package public
+
+import (
+	"encoding/json"
+	"net/http"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/jwt"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+func TestAdminGetPriceBooks(t *testing.T) {
+	server, _, token := setupAdminTestServer(t)
+
+	t.Run("non-admin gets 404", func(t *testing.T) {
+		account, err := models.CreateAccount("Regular User", "regular-price-books@example.com")
+		require.NoError(t, err)
+		signer := jwt.NewSigner("test-client-secret")
+		regularToken, err := authentication.GenerateAccountToken(signer, account.ID.String(), time.Now(), time.Hour)
+		require.NoError(t, err)
+
+		response := execRequest(server, requestParams{
+			method:     "GET",
+			path:       "/admin/api/price-books",
+			authCookie: regularToken,
+		})
+		assert.Equal(t, http.StatusNotFound, response.Code)
+	})
+
+	t.Run("admin loads the current price book", func(t *testing.T) {
+		response := execRequest(server, requestParams{
+			method:     "GET",
+			path:       "/admin/api/price-books",
+			authCookie: token,
+		})
+		assert.Equal(t, http.StatusOK, response.Code)
+
+		var body adminPriceBooksResponse
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+		assert.Equal(t, "2026-09-09.1", body.CurrentVersion)
+		assert.Equal(t, "2026-09-09.1", body.Version)
+		require.GreaterOrEqual(t, len(body.Versions), 2)
+		assert.Equal(t, "2026-09-09.1", body.Versions[0].Version)
+		require.NotEmpty(t, body.Models)
+		require.NotEmpty(t, body.VMs)
+
+		assert.True(t, containsModelRate(body.Models, "claude-sonnet"))
+		assert.True(t, containsVMRate(body.VMs, "e1-large-amd64", 70))
+		assert.True(t, modelRatesAreSorted(body.Models))
+		assert.True(t, vmRatesAreSorted(body.VMs))
+	})
+
+	t.Run("admin loads an explicit older version", func(t *testing.T) {
+		response := execRequest(server, requestParams{
+			method:     "GET",
+			path:       "/admin/api/price-books?version=2026-08-31.1",
+			authCookie: token,
+		})
+		assert.Equal(t, http.StatusOK, response.Code)
+
+		var body adminPriceBooksResponse
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+		assert.Equal(t, "2026-09-09.1", body.CurrentVersion)
+		assert.Equal(t, "2026-08-31.1", body.Version)
+		require.NotEmpty(t, body.Models)
+		require.NotEmpty(t, body.VMs)
+		assert.True(t, containsModelRate(body.Models, "claude-sonnet"))
+		assert.True(t, containsVMRate(body.VMs, "e1-large-amd64", 0))
+		assert.False(t, containsModelRate(body.Models, "gemini-2.5-pro"))
+	})
+
+	t.Run("unknown version returns 404", func(t *testing.T) {
+		response := execRequest(server, requestParams{
+			method:     "GET",
+			path:       "/admin/api/price-books?version=does-not-exist",
+			authCookie: token,
+		})
+		assert.Equal(t, http.StatusNotFound, response.Code)
+	})
+}
+
+func containsModelRate(rates []adminPriceBookModelRate, matchKey string) bool {
+	return slices.ContainsFunc(rates, func(rate adminPriceBookModelRate) bool {
+		return rate.MatchKey == matchKey
+	})
+}
+
+func containsVMRate(rates []adminPriceBookVMRate, matchKey string, microsPerSecond int64) bool {
+	return slices.ContainsFunc(rates, func(rate adminPriceBookVMRate) bool {
+		return rate.MatchKey == matchKey && rate.MicrosPerSecond == microsPerSecond
+	})
+}
+
+func modelRatesAreSorted(rates []adminPriceBookModelRate) bool {
+	for i := 1; i < len(rates); i++ {
+		previous := rates[i-1]
+		current := rates[i]
+		if previous.MatchKey == current.MatchKey {
+			if previous.MatchMode > current.MatchMode {
+				return false
+			}
+			continue
+		}
+		if previous.MatchKey > current.MatchKey {
+			return false
+		}
+	}
+	return true
+}
+
+func vmRatesAreSorted(rates []adminPriceBookVMRate) bool {
+	for i := 1; i < len(rates); i++ {
+		if rates[i-1].MatchKey > rates[i].MatchKey {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -735,6 +735,7 @@ func (s *Server) InitRouter(additionalMiddlewares ...mux.MiddlewareFunc) {
 	adminRoute.HandleFunc("/organizations/{orgId}/billing-plan", s.adminGetOrganizationBillingPlan).Methods("GET")
 	adminRoute.HandleFunc("/organizations/{orgId}/billing-plan", s.adminSetOrganizationBillingPlan).Methods("PUT")
 	adminRoute.HandleFunc("/runner/tasks", s.adminListRunnerTasks).Methods("GET")
+	adminRoute.HandleFunc("/price-books", s.adminGetPriceBooks).Methods("GET")
 	adminRoute.HandleFunc("/impersonate/start", s.startImpersonation).Methods("POST")
 	adminRoute.HandleFunc("/impersonate/end", s.endImpersonation).Methods("POST")
 	adminRoute.HandleFunc("/impersonate/status", s.impersonationStatus).Methods("GET")

--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -77,7 +77,7 @@ import OrganizationDetailAdmin from "./pages/admin/OrganizationDetail";
 import AccountsListAdmin from "./pages/admin/AccountsList";
 import InstallationSettingsAdmin from "./pages/admin/InstallationSettings";
 import RunnerTasksAdmin from "./pages/admin/RunnerTasks";
-import PriceBooksAdmin from "./pages/admin/PriceBooks";
+import { PriceBooks as PriceBooksAdmin } from "./pages/admin/PriceBooks";
 import ImpersonationBanner from "./components/ImpersonationBanner";
 import { usePageObservability } from "./hooks/usePageObservability";
 

--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -77,6 +77,7 @@ import OrganizationDetailAdmin from "./pages/admin/OrganizationDetail";
 import AccountsListAdmin from "./pages/admin/AccountsList";
 import InstallationSettingsAdmin from "./pages/admin/InstallationSettings";
 import RunnerTasksAdmin from "./pages/admin/RunnerTasks";
+import PriceBooksAdmin from "./pages/admin/PriceBooks";
 import ImpersonationBanner from "./components/ImpersonationBanner";
 import { usePageObservability } from "./hooks/usePageObservability";
 
@@ -229,6 +230,7 @@ function AppRouter() {
                 <Route index element={<OrganizationsListAdmin />} />
                 <Route path="accounts" element={<AccountsListAdmin />} />
                 <Route path="settings" element={<InstallationSettingsAdmin />} />
+                <Route path="price-books" element={<PriceBooksAdmin />} />
                 <Route path="runner-tasks" element={<RunnerTasksAdmin />} />
                 <Route path="organizations/:orgId" element={<OrganizationDetailAdmin />} />
               </Route>

--- a/web_src/src/components/GlobalCommandPalette/constants.ts
+++ b/web_src/src/components/GlobalCommandPalette/constants.ts
@@ -1,4 +1,5 @@
 import {
+  BookOpen,
   Building2,
   CircleUser,
   Gauge,
@@ -126,6 +127,13 @@ export const ADMIN_LINKS: Array<{
     description: "Installation network and SMTP settings",
     href: "/admin/settings",
     icon: Network,
+  },
+  {
+    id: "price-books",
+    label: "Price Books",
+    description: "Review model and VM rates for this installation",
+    href: "/admin/price-books",
+    icon: BookOpen,
   },
   {
     id: "runner-tasks",

--- a/web_src/src/lib/pageObservability.spec.ts
+++ b/web_src/src/lib/pageObservability.spec.ts
@@ -24,6 +24,7 @@ describe("resolvePageObservability", () => {
   it("maps admin routes", () => {
     expect(resolvePageObservability("/admin")).toEqual({ pageKey: "adminOrganizations", attributes: {} });
     expect(resolvePageObservability("/admin/accounts")).toEqual({ pageKey: "adminAccounts", attributes: {} });
+    expect(resolvePageObservability("/admin/price-books")).toEqual({ pageKey: "adminPriceBooks", attributes: {} });
     expect(resolvePageObservability("/admin/organizations/org-1")).toEqual({
       pageKey: "adminOrganizationDetail",
       attributes: { organization_id: "org-1" },

--- a/web_src/src/lib/pageObservability.ts
+++ b/web_src/src/lib/pageObservability.ts
@@ -47,6 +47,10 @@ export function resolvePageObservability(pathname: string): PageObservabilityCon
       return { pageKey: "adminSettings", attributes: {} };
     }
 
+    if (second === "price-books") {
+      return { pageKey: "adminPriceBooks", attributes: {} };
+    }
+
     if (second === "runner-tasks") {
       return { pageKey: "adminRunnerTasks", attributes: {} };
     }

--- a/web_src/src/pages/admin/AdminLayout.tsx
+++ b/web_src/src/pages/admin/AdminLayout.tsx
@@ -1,7 +1,7 @@
 import SuperplaneLogo from "@/assets/superplane.svg";
 import { Text } from "@/components/Text/text";
 import { useAccount } from "@/contexts/useAccount";
-import { ArrowLeft, Building, Network, Shield, Terminal, Users } from "lucide-react";
+import { ArrowLeft, BookOpen, Building, Network, Shield, Terminal, Users } from "lucide-react";
 import React from "react";
 import { Link, Navigate, NavLink, Outlet } from "react-router";
 
@@ -60,6 +60,10 @@ const AdminLayout: React.FC = () => {
               <NavLink to="/admin/settings" className={navLinkClass}>
                 <Network size={14} />
                 Settings
+              </NavLink>
+              <NavLink to="/admin/price-books" className={navLinkClass}>
+                <BookOpen size={14} />
+                Price Books
               </NavLink>
               <NavLink to="/admin/runner-tasks" className={navLinkClass}>
                 <Terminal size={14} />

--- a/web_src/src/pages/admin/PriceBooks.spec.tsx
+++ b/web_src/src/pages/admin/PriceBooks.spec.tsx
@@ -1,0 +1,133 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+
+import { showErrorToast } from "@/lib/toast";
+
+import { PriceBooks } from "./PriceBooks";
+
+vi.mock("@/lib/toast", () => ({
+  showErrorToast: vi.fn(),
+  showSuccessToast: vi.fn(),
+}));
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+const versions = [
+  { version: "2026-09-09.1", effective_at: "2026-09-09T00:00:00Z", created_at: "2026-09-09T00:00:00Z" },
+  { version: "2026-09-01.1", effective_at: "2026-09-01T00:00:00Z", created_at: "2026-09-01T00:00:00Z" },
+  { version: "2026-08-31.1", effective_at: "2026-08-31T00:00:00Z", created_at: "2026-08-31T00:00:00Z" },
+];
+
+const catalogFor = (version: string, matchKey: string) => ({
+  current_version: "2026-09-09.1",
+  version,
+  effective_at: `${version.slice(0, 10)}T00:00:00Z`,
+  created_at: `${version.slice(0, 10)}T00:00:00Z`,
+  versions,
+  models: [
+    {
+      match_key: matchKey,
+      match_mode: "prefix",
+      input_cents_per_million: 300,
+      output_cents_per_million: 1500,
+      cache_read_cents_per_million: 30,
+      cache_write_cents_per_million: 375,
+      reasoning_cents_per_million: 0,
+    },
+  ],
+  vms: [
+    {
+      match_key: "e1-large-amd64",
+      match_mode: "exact",
+      micros_per_second: 70,
+    },
+  ],
+});
+
+const currentCatalog = catalogFor("2026-09-09.1", "claude-sonnet");
+const olderCatalog = catalogFor("2026-08-31.1", "older-model");
+const middleCatalog = catalogFor("2026-09-01.1", "middle-model");
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={["/admin/price-books"]}>
+      <PriceBooks />
+    </MemoryRouter>,
+  );
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.mocked(showErrorToast).mockClear();
+});
+
+describe("PriceBooks", () => {
+  it("loads the current catalog", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(currentCatalog)),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText("claude-sonnet")).toBeInTheDocument();
+    expect(screen.getByTestId("admin-price-book-version")).toHaveTextContent("2026-09-09.1 (current)");
+    expect(screen.getByText("$3.00")).toBeInTheDocument();
+  });
+
+  it("keeps the latest selected version when an earlier request finishes last", async () => {
+    let resolveOlder: ((response: Response) => void) | undefined;
+    const olderRequest = new Promise<Response>((resolve) => {
+      resolveOlder = resolve;
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("version=2026-08-31.1")) {
+          return olderRequest;
+        }
+        if (url.includes("version=2026-09-01.1")) {
+          return jsonResponse(middleCatalog);
+        }
+        return jsonResponse(currentCatalog);
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+    expect(await screen.findByText("claude-sonnet")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "2026-08-31.1" }));
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "2026-09-01.1" }));
+
+    expect(await screen.findByText("middle-model")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveOlder?.(jsonResponse(olderCatalog));
+      await olderRequest;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("middle-model")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("older-model")).not.toBeInTheDocument();
+    expect(screen.queryByText("claude-sonnet")).not.toBeInTheDocument();
+    expect(showErrorToast).not.toHaveBeenCalled();
+  });
+});

--- a/web_src/src/pages/admin/PriceBooks.tsx
+++ b/web_src/src/pages/admin/PriceBooks.tsx
@@ -9,38 +9,12 @@ import { BookOpen } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { formatDate } from "./formatDate";
 import { formatCentsPerMillionUsd, formatMatchMode, formatMicrosPerSecondUsdPerMinute } from "./priceBookFormat";
-
-type PriceBookVersion = {
-  version: string;
-  effective_at: string;
-  created_at: string;
-};
-
-type PriceBookModelRate = {
-  match_key: string;
-  match_mode: string;
-  input_cents_per_million: number;
-  output_cents_per_million: number;
-  cache_read_cents_per_million: number;
-  cache_write_cents_per_million: number;
-  reasoning_cents_per_million: number;
-};
-
-type PriceBookVMRate = {
-  match_key: string;
-  match_mode: string;
-  micros_per_second: number;
-};
-
-type PriceBooksResponse = {
-  current_version: string;
-  version: string;
-  effective_at: string;
-  created_at: string;
-  versions: PriceBookVersion[];
-  models: PriceBookModelRate[];
-  vms: PriceBookVMRate[];
-};
+import {
+  fetchPriceBooks,
+  type PriceBookModelRate,
+  type PriceBooksResponse,
+  type PriceBookVMRate,
+} from "./priceBooksApi";
 
 type PriceBooksTab = "models" | "vms";
 
@@ -237,14 +211,7 @@ export function PriceBooks() {
     const generation = ++loadGeneration.current;
 
     try {
-      const path = version ? `/admin/api/price-books?version=${encodeURIComponent(version)}` : "/admin/api/price-books";
-      const response = await fetch(path, { credentials: "include", signal: controller.signal });
-      if (!response.ok) {
-        const text = await response.text();
-        throw new Error(text.trim() || "Failed to load price books");
-      }
-
-      const payload: PriceBooksResponse = await response.json();
+      const payload = await fetchPriceBooks(version, controller.signal);
       if (generation !== loadGeneration.current) {
         return;
       }

--- a/web_src/src/pages/admin/PriceBooks.tsx
+++ b/web_src/src/pages/admin/PriceBooks.tsx
@@ -6,7 +6,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { showErrorToast } from "@/lib/toast";
 import { BookOpen } from "lucide-react";
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { formatDate } from "./formatDate";
 import { formatCentsPerMillionUsd, formatMatchMode, formatMicrosPerSecondUsdPerMinute } from "./priceBookFormat";
 
@@ -67,7 +67,7 @@ function PriceBooksHeader() {
   );
 }
 
-function PriceBooksMessage({ message, action }: { message: string; action?: React.ReactNode }) {
+function PriceBooksMessage({ message, action }: { message: string; action?: ReactNode }) {
   return (
     <div className="space-y-6">
       <PriceBooksHeader />
@@ -216,11 +216,13 @@ function PriceBooksCatalog({
   );
 }
 
-const PriceBooks: React.FC = () => {
+export function PriceBooks() {
   const [data, setData] = useState<PriceBooksResponse | null>(null);
   const [tab, setTab] = useState<PriceBooksTab>("models");
   const [loading, setLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
+  const loadAbort = useRef<AbortController | null>(null);
+  const loadGeneration = useRef(0);
 
   const loadPriceBooks = useCallback(async (version?: string) => {
     const isFirstLoad = version === undefined;
@@ -229,25 +231,38 @@ const PriceBooks: React.FC = () => {
       setLoadFailed(false);
     }
 
+    loadAbort.current?.abort();
+    const controller = new AbortController();
+    loadAbort.current = controller;
+    const generation = ++loadGeneration.current;
+
     try {
       const path = version ? `/admin/api/price-books?version=${encodeURIComponent(version)}` : "/admin/api/price-books";
-      const response = await fetch(path, { credentials: "include" });
+      const response = await fetch(path, { credentials: "include", signal: controller.signal });
       if (!response.ok) {
         const text = await response.text();
         throw new Error(text.trim() || "Failed to load price books");
       }
 
       const payload: PriceBooksResponse = await response.json();
+      if (generation !== loadGeneration.current) {
+        return;
+      }
+
       setData(payload);
       setLoadFailed(false);
     } catch (error) {
+      if (generation !== loadGeneration.current || controller.signal.aborted) {
+        return;
+      }
+
       showErrorToast(error instanceof Error ? error.message : "Failed to load price books");
       if (isFirstLoad) {
         setLoadFailed(true);
         setData(null);
       }
     } finally {
-      if (isFirstLoad) {
+      if (isFirstLoad && generation === loadGeneration.current) {
         setLoading(false);
       }
     }
@@ -255,6 +270,9 @@ const PriceBooks: React.FC = () => {
 
   useEffect(() => {
     void loadPriceBooks();
+    return () => {
+      loadAbort.current?.abort();
+    };
   }, [loadPriceBooks]);
 
   useReportPageReady(!loading);
@@ -293,6 +311,4 @@ const PriceBooks: React.FC = () => {
       onVersionChange={(version) => void loadPriceBooks(version)}
     />
   );
-};
-
-export default PriceBooks;
+}

--- a/web_src/src/pages/admin/PriceBooks.tsx
+++ b/web_src/src/pages/admin/PriceBooks.tsx
@@ -1,0 +1,298 @@
+import { Text } from "@/components/Text/text";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
+import { showErrorToast } from "@/lib/toast";
+import { BookOpen } from "lucide-react";
+import React, { useCallback, useEffect, useState } from "react";
+import { formatDate } from "./formatDate";
+import { formatCentsPerMillionUsd, formatMatchMode, formatMicrosPerSecondUsdPerMinute } from "./priceBookFormat";
+
+type PriceBookVersion = {
+  version: string;
+  effective_at: string;
+  created_at: string;
+};
+
+type PriceBookModelRate = {
+  match_key: string;
+  match_mode: string;
+  input_cents_per_million: number;
+  output_cents_per_million: number;
+  cache_read_cents_per_million: number;
+  cache_write_cents_per_million: number;
+  reasoning_cents_per_million: number;
+};
+
+type PriceBookVMRate = {
+  match_key: string;
+  match_mode: string;
+  micros_per_second: number;
+};
+
+type PriceBooksResponse = {
+  current_version: string;
+  version: string;
+  effective_at: string;
+  created_at: string;
+  versions: PriceBookVersion[];
+  models: PriceBookModelRate[];
+  vms: PriceBookVMRate[];
+};
+
+type PriceBooksTab = "models" | "vms";
+
+function isPriceBooksTab(value: string): value is PriceBooksTab {
+  return value === "models" || value === "vms";
+}
+
+const tableWrapClass =
+  "bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden dark:bg-gray-900 dark:outline-gray-700/70";
+const headerCellClass = "text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400";
+const numericHeaderCellClass = `${headerCellClass} text-right`;
+const bodyCellClass = "px-4 py-2.5 text-gray-700 dark:text-gray-300";
+const numericCellClass = `${bodyCellClass} text-right tabular-nums`;
+const rowClass = "border-b border-slate-50 last:border-0 dark:border-gray-800/70";
+
+function PriceBooksHeader() {
+  return (
+    <div>
+      <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Price Books</h1>
+      <Text className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        Rates that SuperPlane uses to price hosted models and runner VMs.
+      </Text>
+    </div>
+  );
+}
+
+function PriceBooksMessage({ message, action }: { message: string; action?: React.ReactNode }) {
+  return (
+    <div className="space-y-6">
+      <PriceBooksHeader />
+      <div className={`${tableWrapClass} p-8 text-center`}>
+        <BookOpen size={24} className="mx-auto text-gray-400 dark:text-gray-500" />
+        <Text className="mt-3 text-sm text-gray-600 dark:text-gray-400">{message}</Text>
+        {action}
+      </div>
+    </div>
+  );
+}
+
+function EmptyRatesMessage({ message }: { message: string }) {
+  return (
+    <div className={`${tableWrapClass} p-8 text-center`}>
+      <BookOpen size={24} className="mx-auto text-gray-400 dark:text-gray-500" />
+      <Text className="mt-3 text-sm text-gray-600 dark:text-gray-400">{message}</Text>
+    </div>
+  );
+}
+
+function ModelsTable({ rates }: { rates: PriceBookModelRate[] }) {
+  if (rates.length === 0) {
+    return <EmptyRatesMessage message="This version has no model rates." />;
+  }
+
+  return (
+    <div className={tableWrapClass}>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-100 dark:border-gray-700/70">
+            <th className={headerCellClass}>Match</th>
+            <th className={headerCellClass}>Mode</th>
+            <th className={numericHeaderCellClass}>Input</th>
+            <th className={numericHeaderCellClass}>Output</th>
+            <th className={numericHeaderCellClass}>Cache read</th>
+            <th className={numericHeaderCellClass}>Cache write</th>
+            <th className={numericHeaderCellClass}>Reasoning</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rates.map((rate) => (
+            <tr key={`${rate.match_key}:${rate.match_mode}`} className={rowClass}>
+              <td className={`${bodyCellClass} font-mono text-xs`}>{rate.match_key}</td>
+              <td className={bodyCellClass}>{formatMatchMode(rate.match_mode)}</td>
+              <td className={numericCellClass}>{formatCentsPerMillionUsd(rate.input_cents_per_million)}</td>
+              <td className={numericCellClass}>{formatCentsPerMillionUsd(rate.output_cents_per_million)}</td>
+              <td className={numericCellClass}>{formatCentsPerMillionUsd(rate.cache_read_cents_per_million)}</td>
+              <td className={numericCellClass}>{formatCentsPerMillionUsd(rate.cache_write_cents_per_million)}</td>
+              <td className={numericCellClass}>{formatCentsPerMillionUsd(rate.reasoning_cents_per_million)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function VMsTable({ rates }: { rates: PriceBookVMRate[] }) {
+  if (rates.length === 0) {
+    return <EmptyRatesMessage message="This version has no VM rates." />;
+  }
+
+  return (
+    <div className={tableWrapClass}>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-100 dark:border-gray-700/70">
+            <th className={headerCellClass}>Machine type</th>
+            <th className={numericHeaderCellClass}>Micros per second</th>
+            <th className={numericHeaderCellClass}>Rate</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rates.map((rate) => (
+            <tr key={`${rate.match_key}:${rate.match_mode}`} className={rowClass}>
+              <td className={`${bodyCellClass} font-mono text-xs`}>{rate.match_key}</td>
+              <td className={`${numericCellClass} font-mono text-xs`}>{rate.micros_per_second}</td>
+              <td className={numericCellClass}>{formatMicrosPerSecondUsdPerMinute(rate.micros_per_second)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function PriceBooksCatalog({
+  data,
+  tab,
+  onTabChange,
+  onVersionChange,
+}: {
+  data: PriceBooksResponse;
+  tab: PriceBooksTab;
+  onTabChange: (tab: PriceBooksTab) => void;
+  onVersionChange: (version: string) => void;
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <PriceBooksHeader />
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="admin-price-book-version">Version</Label>
+          <Select value={data.version} onValueChange={onVersionChange}>
+            <SelectTrigger id="admin-price-book-version" data-testid="admin-price-book-version">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {data.versions.map((book) => (
+                <SelectItem key={book.version} value={book.version}>
+                  {book.version === data.current_version ? `${book.version} (current)` : book.version}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Text className="text-xs text-gray-500 dark:text-gray-400">Effective {formatDate(data.effective_at)}</Text>
+        </div>
+      </div>
+
+      <Tabs
+        value={tab}
+        onValueChange={(nextTab) => {
+          if (isPriceBooksTab(nextTab)) {
+            onTabChange(nextTab);
+          }
+        }}
+      >
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <TabsList>
+            <TabsTrigger value="models">Models</TabsTrigger>
+            <TabsTrigger value="vms">VMs</TabsTrigger>
+          </TabsList>
+          <Text className="text-xs text-gray-500 dark:text-gray-400">
+            {tab === "models" ? "USD per 1 million tokens" : "USD per minute of machine time"}
+          </Text>
+        </div>
+        <TabsContent value="models" className="mt-3">
+          <ModelsTable rates={data.models} />
+        </TabsContent>
+        <TabsContent value="vms" className="mt-3">
+          <VMsTable rates={data.vms} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+const PriceBooks: React.FC = () => {
+  const [data, setData] = useState<PriceBooksResponse | null>(null);
+  const [tab, setTab] = useState<PriceBooksTab>("models");
+  const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  const loadPriceBooks = useCallback(async (version?: string) => {
+    const isFirstLoad = version === undefined;
+    if (isFirstLoad) {
+      setLoading(true);
+      setLoadFailed(false);
+    }
+
+    try {
+      const path = version ? `/admin/api/price-books?version=${encodeURIComponent(version)}` : "/admin/api/price-books";
+      const response = await fetch(path, { credentials: "include" });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text.trim() || "Failed to load price books");
+      }
+
+      const payload: PriceBooksResponse = await response.json();
+      setData(payload);
+      setLoadFailed(false);
+    } catch (error) {
+      showErrorToast(error instanceof Error ? error.message : "Failed to load price books");
+      if (isFirstLoad) {
+        setLoadFailed(true);
+        setData(null);
+      }
+    } finally {
+      if (isFirstLoad) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadPriceBooks();
+  }, [loadPriceBooks]);
+
+  useReportPageReady(!loading);
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center space-y-4 py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-b border-gray-500 dark:border-gray-400"></div>
+        <Text className="text-gray-500 dark:text-gray-400">Loading price books...</Text>
+      </div>
+    );
+  }
+
+  if (loadFailed || !data) {
+    return (
+      <PriceBooksMessage
+        message="We could not load price books."
+        action={
+          <Button className="mt-4" variant="outline" size="sm" onClick={() => void loadPriceBooks()}>
+            Try again
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (data.versions.length === 0) {
+    return <PriceBooksMessage message="No price books in this installation." />;
+  }
+
+  return (
+    <PriceBooksCatalog
+      data={data}
+      tab={tab}
+      onTabChange={setTab}
+      onVersionChange={(version) => void loadPriceBooks(version)}
+    />
+  );
+};
+
+export default PriceBooks;

--- a/web_src/src/pages/admin/priceBookFormat.spec.ts
+++ b/web_src/src/pages/admin/priceBookFormat.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCentsPerMillionUsd, formatMatchMode, formatMicrosPerSecondUsdPerMinute } from "./priceBookFormat";
+
+describe("formatCentsPerMillionUsd", () => {
+  it("formats cents per million tokens as USD", () => {
+    expect(formatCentsPerMillionUsd(300)).toBe("$3.00");
+    expect(formatCentsPerMillionUsd(8)).toBe("$0.08");
+    expect(formatCentsPerMillionUsd(0)).toBe("$0.00");
+  });
+});
+
+describe("formatMicrosPerSecondUsdPerMinute", () => {
+  it("formats stored VM rates as USD per minute", () => {
+    expect(formatMicrosPerSecondUsdPerMinute(70)).toBe("$0.0042 / min");
+    expect(formatMicrosPerSecondUsdPerMinute(3)).toBe("$0.00018 / min");
+    expect(formatMicrosPerSecondUsdPerMinute(0)).toBe("$0.00 / min");
+  });
+});
+
+describe("formatMatchMode", () => {
+  it("labels known match modes", () => {
+    expect(formatMatchMode("prefix")).toBe("Prefix");
+    expect(formatMatchMode("family")).toBe("Family");
+    expect(formatMatchMode("exact")).toBe("Exact");
+  });
+});

--- a/web_src/src/pages/admin/priceBookFormat.ts
+++ b/web_src/src/pages/admin/priceBookFormat.ts
@@ -1,0 +1,26 @@
+export function formatCentsPerMillionUsd(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function formatMicrosPerSecondUsdPerMinute(microsPerSecond: number): string {
+  const dollarsPerMinute = (microsPerSecond * 60) / 1_000_000;
+  if (dollarsPerMinute === 0) {
+    return "$0.00 / min";
+  }
+
+  const formatted = dollarsPerMinute.toFixed(6).replace(/\.?0+$/, "");
+  return `$${formatted} / min`;
+}
+
+export function formatMatchMode(mode: string): string {
+  switch (mode) {
+    case "prefix":
+      return "Prefix";
+    case "family":
+      return "Family";
+    case "exact":
+      return "Exact";
+    default:
+      return mode;
+  }
+}

--- a/web_src/src/pages/admin/priceBooksApi.ts
+++ b/web_src/src/pages/admin/priceBooksApi.ts
@@ -1,0 +1,42 @@
+export type PriceBookVersion = {
+  version: string;
+  effective_at: string;
+  created_at: string;
+};
+
+export type PriceBookModelRate = {
+  match_key: string;
+  match_mode: string;
+  input_cents_per_million: number;
+  output_cents_per_million: number;
+  cache_read_cents_per_million: number;
+  cache_write_cents_per_million: number;
+  reasoning_cents_per_million: number;
+};
+
+export type PriceBookVMRate = {
+  match_key: string;
+  match_mode: string;
+  micros_per_second: number;
+};
+
+export type PriceBooksResponse = {
+  current_version: string;
+  version: string;
+  effective_at: string;
+  created_at: string;
+  versions: PriceBookVersion[];
+  models: PriceBookModelRate[];
+  vms: PriceBookVMRate[];
+};
+
+export async function fetchPriceBooks(version?: string, signal?: AbortSignal): Promise<PriceBooksResponse> {
+  const path = version ? `/admin/api/price-books?version=${encodeURIComponent(version)}` : "/admin/api/price-books";
+  const response = await fetch(path, { credentials: "include", signal });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text.trim() || "Failed to load price books");
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary

Installation admins cannot inspect the versioned model and VM rate catalog today. SuperPlane stores those rates in Postgres, but no admin UI or list API exists.

This change adds a read-only Price Books page in Installation Admin. Admins can switch versions and view Models and VMs in separate tabs.

Closes #7386

## Test plan

- [ ] Log in as an installation admin.
- [ ] Open `/admin/price-books`.
- [ ] Confirm the current version loads with model rates.
- [ ] Switch to the VMs tab and confirm machine rates.
- [ ] Select an older version and confirm the rates change.
- [ ] Confirm a non-admin cannot open the page.
- [ ] Confirm `GET /admin/api/price-books` returns 404 for a non-admin.


Made with [Cursor](https://cursor.com)





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63072204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge; no outstanding correctness, security, or repository-rule issues were identified.

<sub>Reviews (3) · Last reviewed commit: ["fix: Extract Price Books fetch helper"](https://github.com/superplanehq/superplane/commit/2a7111ca310b7c8eec48126a0e45eb08ab5084ec)</sub>

<!-- /greptile_comment -->