### PR TITLE
fix(semaphore): do not fail setup on valid URLs

### DIFF
--- a/pkg/integrations/semaphore/common/client.go
+++ b/pkg/integrations/semaphore/common/client.go
@@ -6,7 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/core"
@@ -33,20 +36,16 @@ func IsNotFoundError(err error) bool {
 }
 
 func NewClientWithAPIToken(http core.HTTPContext, parameters core.IntegrationPropertyStorageReader, apiToken string) (*Client, error) {
-	url, err := parameters.GetString("organizationUrl")
+	orgURL, err := parameters.GetString("organizationUrl")
 	if err != nil {
 		return nil, fmt.Errorf("error getting organization URL: %v", err)
 	}
 
-	return &Client{
-		OrgURL:   url,
-		APIToken: string(apiToken),
-		http:     http,
-	}, nil
+	return newClient(http, orgURL, apiToken)
 }
 
 func NewClientWithStorageContexts(http core.HTTPContext, parameters core.IntegrationPropertyStorageReader, secrets core.IntegrationSecretStorageReader) (*Client, error) {
-	url, err := parameters.GetString("organizationUrl")
+	orgURL, err := parameters.GetString("organizationUrl")
 	if err != nil {
 		return nil, fmt.Errorf("error getting organization URL: %v", err)
 	}
@@ -56,11 +55,7 @@ func NewClientWithStorageContexts(http core.HTTPContext, parameters core.Integra
 		return nil, err
 	}
 
-	return &Client{
-		OrgURL:   url,
-		APIToken: string(apiToken),
-		http:     http,
-	}, nil
+	return newClient(http, orgURL, apiToken)
 }
 
 func NewClient(http core.HTTPContext, ctx core.IntegrationContext) (*Client, error) {
@@ -78,11 +73,61 @@ func NewClient(http core.HTTPContext, ctx core.IntegrationContext) (*Client, err
 		return nil, err
 	}
 
+	return newClient(http, string(orgURL), string(apiToken))
+}
+
+func newClient(http core.HTTPContext, orgURL, apiToken string) (*Client, error) {
+	parsed, err := ParseOrganizationURL(orgURL)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Client{
-		OrgURL:   string(orgURL),
-		APIToken: string(apiToken),
+		OrgURL:   parsed,
+		APIToken: apiToken,
 		http:     http,
 	}, nil
+}
+
+// ParseOrganizationURL validates a Semaphore organization URL and returns the
+// origin only (https + host + optional port). Trailing slashes, extra paths,
+// query strings, and a missing https scheme are accepted and normalized.
+func ParseOrganizationURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("organization URL is required")
+	}
+
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid organization URL")
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "https" {
+		return "", fmt.Errorf("organization URL must use https")
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return "", fmt.Errorf("organization URL must include a host")
+	}
+	if strings.ContainsAny(host, " \t") {
+		return "", fmt.Errorf("invalid organization URL")
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("organization URL must not include credentials")
+	}
+
+	if port := parsed.Port(); port != "" {
+		return scheme + "://" + net.JoinHostPort(host, port), nil
+	}
+
+	return scheme + "://" + host, nil
 }
 
 type ProjectResponse struct {

--- a/pkg/integrations/semaphore/common/client_test.go
+++ b/pkg/integrations/semaphore/common/client_test.go
@@ -1,0 +1,73 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOrganizationURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("accepts and normalizes typical organization URLs", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			name  string
+			input string
+			want  string
+		}{
+			{name: "canonical URL", input: "https://acme.semaphoreci.com", want: "https://acme.semaphoreci.com"},
+			{name: "trailing slash", input: "https://acme.semaphoreci.com/", want: "https://acme.semaphoreci.com"},
+			{name: "multiple trailing slashes", input: "https://acme.semaphoreci.com///", want: "https://acme.semaphoreci.com"},
+			{name: "surrounding whitespace", input: "  https://acme.semaphoreci.com/  ", want: "https://acme.semaphoreci.com"},
+			{name: "path copied from the address bar", input: "https://acme.semaphoreci.com/projects", want: "https://acme.semaphoreci.com"},
+			{name: "path with trailing slash", input: "https://acme.semaphoreci.com/projects/", want: "https://acme.semaphoreci.com"},
+			{name: "query string", input: "https://acme.semaphoreci.com/?ref=home", want: "https://acme.semaphoreci.com"},
+			{name: "fragment", input: "https://acme.semaphoreci.com/#org", want: "https://acme.semaphoreci.com"},
+			{name: "missing scheme", input: "acme.semaphoreci.com", want: "https://acme.semaphoreci.com"},
+			{name: "missing scheme with trailing slash", input: "acme.semaphoreci.com/", want: "https://acme.semaphoreci.com"},
+			{name: "https with port", input: "https://semaphore.internal:3000/", want: "https://semaphore.internal:3000"},
+			{name: "uppercase host", input: "https://Acme.SemaphoreCI.com/", want: "https://acme.semaphoreci.com"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				got, err := ParseOrganizationURL(tc.input)
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			})
+		}
+	})
+
+	t.Run("rejects invalid organization URLs", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			name    string
+			input   string
+			wantErr string
+		}{
+			{name: "empty", input: "", wantErr: "organization URL is required"},
+			{name: "whitespace only", input: "   ", wantErr: "organization URL is required"},
+			{name: "http scheme", input: "http://acme.semaphoreci.com", wantErr: "organization URL must use https"},
+			{name: "unsupported scheme", input: "ftp://acme.semaphoreci.com", wantErr: "organization URL must use https"},
+			{name: "missing host", input: "https://", wantErr: "organization URL must include a host"},
+			{name: "credentials", input: "https://user:pass@acme.semaphoreci.com", wantErr: "organization URL must not include credentials"},
+			{name: "spaces in host", input: "https://acme semaphoreci.com", wantErr: "invalid organization URL"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				_, err := ParseOrganizationURL(tc.input)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			})
+		}
+	})
+}

--- a/pkg/integrations/semaphore/integration_secrets.go
+++ b/pkg/integrations/semaphore/integration_secrets.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/semaphore/common"
 )
 
 const (
@@ -118,17 +119,24 @@ func resolveAPIToken(integrationCtx core.IntegrationContext) (string, error) {
 }
 
 func organizationURL(integrationCtx core.IntegrationContext) string {
+	var raw string
 	if !integrationCtx.LegacySetup() {
-		url, err := integrationCtx.Properties().GetString(PropertyOrganizationURL)
+		value, err := integrationCtx.Properties().GetString(PropertyOrganizationURL)
 		if err != nil {
 			return ""
 		}
-		return strings.TrimRight(strings.TrimSpace(url), "/")
+		raw = value
+	} else {
+		value, err := integrationCtx.GetConfig("organizationUrl")
+		if err != nil {
+			return ""
+		}
+		raw = string(value)
 	}
 
-	raw, err := integrationCtx.GetConfig("organizationUrl")
+	parsed, err := common.ParseOrganizationURL(raw)
 	if err != nil {
 		return ""
 	}
-	return strings.TrimRight(strings.TrimSpace(string(raw)), "/")
+	return parsed
 }

--- a/pkg/integrations/semaphore/integration_secrets_test.go
+++ b/pkg/integrations/semaphore/integration_secrets_test.go
@@ -35,6 +35,24 @@ func TestResolveSecrets(t *testing.T) {
 	assert.NotContains(t, secrets.Setup, "sem-token")
 }
 
+func TestResolveSecretsNormalizesOrganizationURL(t *testing.T) {
+	t.Parallel()
+
+	secrets, err := (&Semaphore{}).ResolveSecrets(core.IntegrationSecretContext{
+		Integration: &contexts.IntegrationContext{
+			NewSetupFlow: true,
+			CurrentSecrets: map[string]core.IntegrationSecret{
+				SecretAPIToken: {Name: SecretAPIToken, Value: []byte("sem-token")},
+			},
+			CurrentProperties: map[string]any{
+				PropertyOrganizationURL: "https://acme.semaphoreci.com/",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("https://acme.semaphoreci.com"), secrets.Values[integrationSecretSemaphoreOrganizationURL])
+}
+
 func TestResolveSecretsWithoutOrganizationURL(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/integrations/semaphore/semaphore_test.go
+++ b/pkg/integrations/semaphore/semaphore_test.go
@@ -45,6 +45,36 @@ func Test__Semaphore__Sync(t *testing.T) {
 		assert.Equal(t, "https://example.semaphoreci.com/api/v1alpha/projects", httpContext.Requests[0].URL.String())
 	})
 
+	t.Run("trailing slash on organization URL still lists projects", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("[]")),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{Projects: []string{}},
+			Configuration: map[string]any{
+				"organizationUrl": "https://example.semaphoreci.com/",
+				"apiToken":        "token-123",
+			},
+		}
+
+		err := s.Sync(core.SyncContext{
+			Configuration: integrationCtx.Configuration,
+			HTTP:          httpContext,
+			Integration:   integrationCtx,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "ready", integrationCtx.State)
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://example.semaphoreci.com/api/v1alpha/projects", httpContext.Requests[0].URL.String())
+	})
+
 	t.Run("failure listing projects -> error", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{

--- a/pkg/integrations/semaphore/setup_provider.go
+++ b/pkg/integrations/semaphore/setup_provider.go
@@ -238,20 +238,21 @@ func (s *SetupProvider) onSelectOrganizationSubmit(inputs any, ctx core.SetupSte
 		return nil, errors.New("invalid input")
 	}
 
-	organizationURL, ok := m[PropertyOrganizationURL].(string)
+	rawOrganizationURL, ok := m[PropertyOrganizationURL].(string)
 	if !ok {
 		return nil, errors.New("invalid organization URL")
 	}
 
-	if organizationURL == "" {
-		return nil, errors.New("organization URL is required")
+	organizationURL, err := common.ParseOrganizationURL(rawOrganizationURL)
+	if err != nil {
+		return nil, err
 	}
 
 	//
 	// The organization URL is not something you can change,
 	// so once it's set, you cannot change it.
 	//
-	err := ctx.Properties.Create(core.IntegrationPropertyDefinition{
+	err = ctx.Properties.Create(core.IntegrationPropertyDefinition{
 		Name:        PropertyOrganizationURL,
 		Label:       "Organization URL",
 		Description: "The URL of the Semaphore organization you are connected",

--- a/pkg/integrations/semaphore/setup_provider_test.go
+++ b/pkg/integrations/semaphore/setup_provider_test.go
@@ -166,6 +166,14 @@ func Test__Semaphore__SetupProvider__OnStepSubmit(t *testing.T) {
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "organization URL is required")
+
+		_, err = s.OnStepSubmit(core.SetupStepContext{
+			Step:       core.StepInfo{Name: SetupStepSelectOrganization, Inputs: map[string]any{"organizationUrl": "ftp://org.semaphoreci.com"}},
+			Logger:     logger,
+			Properties: &contexts.IntegrationPropertyStorage{},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "organization URL must use https")
 	})
 
 	t.Run("selectOrganization success", func(t *testing.T) {
@@ -186,6 +194,26 @@ func Test__Semaphore__SetupProvider__OnStepSubmit(t *testing.T) {
 		require.NoError(t, getErr)
 		assert.Equal(t, orgURL, stored)
 		assert.Contains(t, next.Instructions, orgURL)
+	})
+
+	t.Run("selectOrganization normalizes trailing slash and extra path", func(t *testing.T) {
+		intCtx := &contexts.IntegrationContext{}
+		props := intCtx.Properties()
+		next, err := s.OnStepSubmit(core.SetupStepContext{
+			Step: core.StepInfo{
+				Name:   SetupStepSelectOrganization,
+				Inputs: map[string]any{"organizationUrl": " https://org.semaphoreci.com/projects/ "},
+			},
+			Logger:     logger,
+			Properties: props,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, next)
+
+		stored, getErr := props.GetString("organizationUrl")
+		require.NoError(t, getErr)
+		assert.Equal(t, "https://org.semaphoreci.com", stored)
+		assert.Contains(t, next.Instructions, "https://org.semaphoreci.com/people")
 	})
 
 	t.Run("enterAPIToken validation", func(t *testing.T) {


### PR DESCRIPTION
Semaphore setup was failing when org URL had a trailing slash at the end.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63087178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR is not yet safe to merge because existing integrations with stored HTTP organization URLs will stop working, and the explicit repository style requirement must also be satisfied.

<sub>Reviews (1) · Last reviewed commit: ["fix(semaphore): do not fail setup on val..."](https://github.com/superplanehq/superplane/commit/de82284baafd37f1b73465fb1b5580bdec8f6911)</sub>

<!-- /greptile_comment -->