### PR TITLE
feat(cli): accept slug/number in API and CLI flags

### DIFF
--- a/pkg/cli/commands/tasks/artifact_add.go
+++ b/pkg/cli/commands/tasks/artifact_add.go
@@ -26,7 +26,7 @@ func (c *artifactAddCommand) Execute(ctx core.CommandContext) error {
 	artifactType := strings.ToLower(strings.TrimSpace(stringValue(c.typ)))
 
 	if rawTaskID == "" {
-		return fmt.Errorf("--task must be a UUID or slug")
+		return fmt.Errorf("--task is required")
 	}
 
 	workspaceID, err := resolveWorkspace(ctx, c.workspace)
@@ -34,7 +34,7 @@ func (c *artifactAddCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
-	taskID, err := resolveTaskID(ctx, workspaceID, rawTaskID)
+	taskID, err := resolveTaskID(rawTaskID)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/commands/tasks/artifact_list.go
+++ b/pkg/cli/commands/tasks/artifact_list.go
@@ -17,7 +17,7 @@ func (c *artifactListCommand) Execute(ctx core.CommandContext) error {
 	rawTaskID := strings.TrimSpace(stringValue(c.taskID))
 
 	if rawTaskID == "" {
-		return fmt.Errorf("--task must be a UUID or slug")
+		return fmt.Errorf("--task is required")
 	}
 
 	workspaceID, err := resolveWorkspace(ctx, c.workspace)
@@ -25,7 +25,7 @@ func (c *artifactListCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
-	taskID, err := resolveTaskID(ctx, workspaceID, rawTaskID)
+	taskID, err := resolveTaskID(rawTaskID)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/commands/tasks/assign.go
+++ b/pkg/cli/commands/tasks/assign.go
@@ -41,7 +41,7 @@ func (c *taskAssignCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
-	taskID, err := resolveTaskID(ctx, workspaceID, rawTaskID)
+	taskID, err := resolveTaskID(rawTaskID)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func (c *taskAssignCommand) Execute(ctx core.CommandContext) error {
 		_, err := fmt.Fprintf(
 			stdout,
 			"Task assignees updated: %s\nAssignees: %s\n",
-			task.GetId(),
+			taskDisplayID(task),
 			formatAssigneeList(task.GetAssignees()),
 		)
 		return err

--- a/pkg/cli/commands/tasks/create.go
+++ b/pkg/cli/commands/tasks/create.go
@@ -65,7 +65,7 @@ func (c *taskCreateCommand) Execute(ctx core.CommandContext) error {
 		_, err := fmt.Fprintf(
 			stdout,
 			"Task created: %s (state: %s)\nTitle: %s\nAssignees: %s\n",
-			task.GetId(),
+			taskDisplayID(task),
 			formatTaskState(task.GetState()),
 			task.GetTitle(),
 			formatAssigneeList(task.GetAssignees()),

--- a/pkg/cli/commands/tasks/describe.go
+++ b/pkg/cli/commands/tasks/describe.go
@@ -28,7 +28,7 @@ func (c *taskDescribeCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
-	taskID, err := resolveTaskID(ctx, workspaceID, rawTaskID)
+	taskID, err := resolveTaskID(rawTaskID)
 	if err != nil {
 		return err
 	}
@@ -111,6 +111,8 @@ func renderTaskDescribeText(
 ) error {
 	writer := tabwriter.NewWriter(stdout, 0, 8, 2, ' ', 0)
 	writeAlignedField(writer, "ID", task.GetId())
+	writeAlignedField(writer, "Number", task.GetNumber())
+	writeAlignedField(writer, "Key", task.GetKey())
 	writeAlignedField(writer, "Title", task.GetTitle())
 	writeAlignedField(writer, "State", formatTaskState(task.GetState()))
 	writeAlignedField(writer, "Result", formatTaskResult(task.GetResult()))

--- a/pkg/cli/commands/tasks/dispatch.go
+++ b/pkg/cli/commands/tasks/dispatch.go
@@ -31,7 +31,7 @@ func (c *taskDispatchCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
-	taskID, err := resolveTaskID(ctx, workspaceID, rawTaskID)
+	taskID, err := resolveTaskID(rawTaskID)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (c *taskDispatchCommand) Execute(ctx core.CommandContext) error {
 		_, err := fmt.Fprintf(
 			stdout,
 			"Task dispatched: %s -> line %q (state: %s)\n",
-			task.GetId(),
+			taskDisplayID(task),
 			lineName,
 			formatTaskState(task.GetState()),
 		)

--- a/pkg/cli/commands/tasks/helpers.go
+++ b/pkg/cli/commands/tasks/helpers.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/cli/commands/workspaces"
 	"github.com/superplanehq/superplane/pkg/cli/core"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
 
 func resolveWorkspace(ctx core.CommandContext, workspaceFlag *string) (string, error) {
@@ -20,26 +20,20 @@ func stringValue(value *string) string {
 	return *value
 }
 
-func resolveTaskID(ctx core.CommandContext, workspaceID, raw string) (string, error) {
+func resolveTaskID(raw string) (string, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
 		return "", fmt.Errorf("--task is required")
 	}
+	return trimmed, nil
+}
 
-	if _, err := uuid.Parse(trimmed); err == nil {
-		return trimmed, nil
+func taskDisplayID(task openapi_client.FactoriesWorkOrder) string {
+	if number := strings.TrimSpace(task.GetNumber()); number != "" {
+		return number
 	}
-
-	response, _, err := ctx.API.FactoryAPI.FactoriesListWorkOrders(ctx.Context, workspaceID).Execute()
-	if err != nil {
-		return "", err
+	if key := strings.TrimSpace(task.GetKey()); key != "" {
+		return key
 	}
-
-	for _, task := range response.GetOrders() {
-		if task.GetKey() == trimmed {
-			return task.GetId(), nil
-		}
-	}
-
-	return "", fmt.Errorf("task %q not found", trimmed)
+	return task.GetId()
 }

--- a/pkg/cli/commands/tasks/helpers_test.go
+++ b/pkg/cli/commands/tasks/helpers_test.go
@@ -1,65 +1,41 @@
 package tasks
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	cli "github.com/superplanehq/superplane/test/support/cli"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
 
-const testResolveWorkspaceID = "11111111-1111-1111-1111-111111111111"
+func TestResolveTaskID(t *testing.T) {
+	t.Run("returns the trimmed identifier", func(t *testing.T) {
+		resolved, err := resolveTaskID("  1823  ")
+		require.NoError(t, err)
+		assert.Equal(t, "1823", resolved)
+	})
 
-func TestResolveTaskID_UUID(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-	}))
-	t.Cleanup(server.Close)
+	t.Run("accepts a key", func(t *testing.T) {
+		resolved, err := resolveTaskID("SUPER-1823")
+		require.NoError(t, err)
+		assert.Equal(t, "SUPER-1823", resolved)
+	})
 
-	ctx, _ := cli.NewCommandContext(t, server, "text")
-	id := "22222222-2222-2222-2222-222222222222"
-
-	resolved, err := resolveTaskID(ctx, testResolveWorkspaceID, id)
-	require.NoError(t, err)
-	assert.Equal(t, id, resolved)
+	t.Run("requires a value", func(t *testing.T) {
+		_, err := resolveTaskID("   ")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--task is required")
+	})
 }
 
-func TestResolveTaskID_Slug(t *testing.T) {
-	const listPayload = `{"orders":[{"id":"22222222-2222-2222-2222-222222222222","key":"SP-42","title":"Task One"}]}`
+func TestTaskDisplayID(t *testing.T) {
+	task := openapi_client.NewFactoriesWorkOrder()
+	task.SetId("22222222-2222-2222-2222-222222222222")
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", taskDisplayID(*task))
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/factories/"+testResolveWorkspaceID+"/orders" {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(listPayload))
-			return
-		}
-		t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-	}))
-	t.Cleanup(server.Close)
+	task.SetKey("SUPER-1823")
+	assert.Equal(t, "SUPER-1823", taskDisplayID(*task))
 
-	ctx, _ := cli.NewCommandContext(t, server, "text")
-	resolved, err := resolveTaskID(ctx, testResolveWorkspaceID, "SP-42")
-	require.NoError(t, err)
-	assert.Equal(t, "22222222-2222-2222-2222-222222222222", resolved)
-}
-
-func TestResolveTaskID_SlugNotFound(t *testing.T) {
-	const listPayload = `{"orders":[{"id":"22222222-2222-2222-2222-222222222222","key":"SP-42","title":"Task One"}]}`
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/factories/"+testResolveWorkspaceID+"/orders" {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(listPayload))
-			return
-		}
-		t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-	}))
-	t.Cleanup(server.Close)
-
-	ctx, _ := cli.NewCommandContext(t, server, "text")
-	_, err := resolveTaskID(ctx, testResolveWorkspaceID, "SP-99")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `task "SP-99" not found`)
+	task.SetNumber("1823")
+	assert.Equal(t, "1823", taskDisplayID(*task))
 }

--- a/pkg/cli/commands/tasks/list.go
+++ b/pkg/cli/commands/tasks/list.go
@@ -71,12 +71,12 @@ func (c *taskListCommand) Execute(ctx core.CommandContext) error {
 		}
 
 		writer := tabwriter.NewWriter(stdout, 0, 8, 2, ' ', 0)
-		_, _ = fmt.Fprintln(writer, "ID\tTITLE\tSTATE\tRESULT\tASSIGNEES\tEXECUTIONS\tCREATED")
+		_, _ = fmt.Fprintln(writer, "NUMBER\tTITLE\tSTATE\tRESULT\tASSIGNEES\tEXECUTIONS\tCREATED")
 		for _, task := range tasks {
 			_, _ = fmt.Fprintf(
 				writer,
 				"%s\t%s\t%s\t%s\t%s\t%d\t%s\n",
-				task.GetId(),
+				taskDisplayID(task),
 				task.GetTitle(),
 				formatTaskState(task.GetState()),
 				formatTaskResult(task.GetResult()),

--- a/pkg/cli/commands/tasks/root.go
+++ b/pkg/cli/commands/tasks/root.go
@@ -25,7 +25,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Short: "List tasks in a workspace",
 		Long: `List tasks in a workspace.
 
---workspace is a workspace name or UUID. When omitted, the active workspace
+--workspace is a workspace name, key, or UUID. When omitted, the active workspace
 from "superplane workspace active" is used.
 
 --assignees accepts user UUIDs or emails (comma-separated or repeated).
@@ -43,7 +43,7 @@ Examples:
   superplane tasks list --state all`,
 		Args: cobra.NoArgs,
 	}
-	taskListCmd.Flags().StringVar(&taskListWorkspace, "workspace", "", "workspace name or UUID (default: active workspace)")
+	taskListCmd.Flags().StringVar(&taskListWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
 	taskListCmd.Flags().StringSliceVar(&taskListAssignees, "assignees", nil, "filter by assignee user UUID or email (repeatable)")
 	taskListCmd.Flags().StringSliceVar(&taskListStates, "state", nil, "filter by task state (repeatable, e.g. open or STATE_OPEN); defaults to open when omitted; pass 'all' to include every state")
 	taskListCmd.Flags().StringSliceVar(&taskListResults, "result", nil, "filter by task result (repeatable, e.g. completed or RESULT_COMPLETED)")
@@ -67,15 +67,15 @@ Examples:
 		Long: `Show a task's title, assignees, description, comments, and
 timeline of events.
 
---workspace is a workspace name or UUID. When omitted, the active workspace
-from "superplane workspace active" is used. --task is the task UUID or slug
-(e.g. prefix-123).
+--workspace is a workspace name, key, or UUID. When omitted, the active workspace
+from "superplane workspace active" is used. --task is the task number, key, or UUID
+(for example 1823 or SUPER-1823).
 
 Example:
-  superplane tasks describe --workspace shipping --task "$TID"`,
+  superplane tasks describe --workspace super --task 1823`,
 		Args: cobra.NoArgs,
 	}
-	taskDescribeCmd.Flags().StringVar(&taskDescribeWorkspace, "workspace", "", "workspace name or UUID (default: active workspace)")
+	taskDescribeCmd.Flags().StringVar(&taskDescribeWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
 	bindTaskIDFlag(taskDescribeCmd, &taskDescribeTaskID)
 	core.Bind(taskDescribeCmd, &taskDescribeCommand{
 		workspace: &taskDescribeWorkspace,
@@ -95,7 +95,7 @@ Example:
 		Short: "Create a task",
 		Long: `Create a task in draft state.
 
---workspace is a workspace name or UUID. When omitted, the active workspace
+--workspace is a workspace name, key, or UUID. When omitted, the active workspace
 from "superplane workspace active" is used. --title is required.
 --description sets the description inline; -f/--file reads it from a
 file (or - for stdin) instead; the two are mutually exclusive.
@@ -113,7 +113,7 @@ Examples:
     --assignee bob@example.com`,
 		Args: cobra.NoArgs,
 	}
-	taskCreateCmd.Flags().StringVar(&taskCreateWorkspace, "workspace", "", "workspace name or UUID (default: active workspace)")
+	taskCreateCmd.Flags().StringVar(&taskCreateWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
 	taskCreateCmd.Flags().StringVar(&taskCreateTitle, "title", "", "task title (required)")
 	taskCreateCmd.Flags().StringVar(&taskCreateDescription, "description", "", "task description (inline)")
 	taskCreateCmd.Flags().StringVarP(&taskCreateFile, "file", "f", "", "read description from file (or - for stdin)")
@@ -137,17 +137,17 @@ Examples:
 		Short: "Dispatch a task to a workspace line",
 		Long: `Dispatch a task to a workspace line, starting its execution.
 
---workspace is a workspace name or UUID. When omitted, the active workspace
-from "superplane workspace active" is used. --task is the task UUID or slug
-(e.g. prefix-123). --line is the target workspace line's name.
+--workspace is a workspace name, key, or UUID. When omitted, the active workspace
+from "superplane workspace active" is used. --task is the task number, key, or UUID
+(for example 1823 or SUPER-1823). --line is the target workspace line's name.
 
 A draft task moves to the open state on its first dispatch.
 
 Example:
-  superplane tasks dispatch --task "$TID" --line build`,
+  superplane tasks dispatch --workspace super --task 1823 --line build`,
 		Args: cobra.NoArgs,
 	}
-	taskDispatchCmd.Flags().StringVar(&taskDispatchWorkspace, "workspace", "", "workspace name or UUID (default: active workspace)")
+	taskDispatchCmd.Flags().StringVar(&taskDispatchWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
 	bindTaskIDFlag(taskDispatchCmd, &taskDispatchTaskID)
 	taskDispatchCmd.Flags().StringVar(&taskDispatchLine, "line", "", "workspace line name (required)")
 	core.Bind(taskDispatchCmd, &taskDispatchCommand{
@@ -167,19 +167,19 @@ Example:
 		Short: "Set a task's assignees",
 		Long: `Set a task's assignees.
 
---workspace is a workspace name or UUID. When omitted, the active workspace
-from "superplane workspace active" is used. --task is the task UUID or slug
-(e.g. prefix-123).
+--workspace is a workspace name, key, or UUID. When omitted, the active workspace
+from "superplane workspace active" is used. --task is the task number, key, or UUID
+(for example 1823 or SUPER-1823).
 
 --assignee accepts a user UUID or email and is repeatable; at least one is
 required. This command replaces the entire assignee list with the ones
 given — it does not add to the existing list.
 
 Example:
-  superplane tasks assign --task "$TID" --assignee alice@example.com --assignee bob@example.com`,
+  superplane tasks assign --workspace super --task 1823 --assignee alice@example.com --assignee bob@example.com`,
 		Args: cobra.NoArgs,
 	}
-	taskAssignCmd.Flags().StringVar(&taskAssignWorkspace, "workspace", "", "workspace name or UUID (default: active workspace)")
+	taskAssignCmd.Flags().StringVar(&taskAssignWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
 	bindTaskIDFlag(taskAssignCmd, &taskAssignTaskID)
 	taskAssignCmd.Flags().StringArrayVar(&taskAssignAssignees, "assignee", nil, "assignee user UUID or email (repeatable, required); replaces the full assignee list")
 	core.Bind(taskAssignCmd, &taskAssignCommand{
@@ -210,41 +210,41 @@ Example:
 		Short: "Attach an artifact to a task",
 		Long: `Attach a typed artifact to a task.
 
---workspace is a workspace name or UUID. When omitted, the active workspace
-from "superplane workspace active" is used. --task is the task UUID or slug.
+--workspace is a workspace name, key, or UUID. When omitted, the active workspace
+from "superplane workspace active" is used. --task is the task number, key, or UUID.
 --type is one of: markdown, branch, link.
 
 Examples:
-  superplane tasks artifacts list --workspace shipping --task "$TID"
+  superplane tasks artifacts list --workspace super --task 1823
 
   # Uses the active workspace
   superplane tasks artifacts add \
-    --task "$TID" \
+    --task 1823 \
     --type markdown \
     --title "PLAN.md" \
     -f ./PLAN.md
 
   superplane tasks artifacts add \
-    --workspace shipping \
-    --task "$TID" \
+    --workspace super \
+    --task 1823 \
     --type markdown \
     --title "PLAN.md" \
     -f ./PLAN.md
 
   superplane tasks artifacts add \
-    --task "$TID" \
+    --task 1823 \
     --type branch \
     --name feature/login
 
   superplane tasks artifacts add \
-    --task "$TID" \
+    --task 1823 \
     --type link \
     --url https://preview.example.com/pr-42 \
     --title Preview`,
 		Args: cobra.NoArgs,
 	}
-	artifactAddCmd.Flags().StringVar(&artifactAddWorkspace, "workspace", "", "workspace name or UUID (default: active workspace)")
-	artifactAddCmd.Flags().StringVar(&artifactAddTaskID, "task", "", "task UUID or slug (e.g. prefix-123)")
+	artifactAddCmd.Flags().StringVar(&artifactAddWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
+	artifactAddCmd.Flags().StringVar(&artifactAddTaskID, "task", "", "task number, key, or UUID (for example 1823 or SUPER-1823)")
 	artifactAddCmd.Flags().StringVar(&artifactAddTypeName, "type", "", "artifact type: markdown, branch, or link")
 	artifactAddCmd.Flags().StringVar(&artifactAddTitle, "title", "", "artifact title")
 	artifactAddCmd.Flags().StringVar(&artifactAddBody, "body", "", "markdown body (inline)")
@@ -273,15 +273,15 @@ Examples:
 		Short: "List artifacts on a task",
 		Long: `List artifacts on a task.
 
---workspace is a workspace name or UUID. When omitted, the active workspace
+--workspace is a workspace name, key, or UUID. When omitted, the active workspace
 from "superplane workspace active" is used.
 
 Example:
-  superplane tasks artifacts list --workspace shipping --task "$TID"`,
+  superplane tasks artifacts list --workspace super --task 1823`,
 		Args: cobra.NoArgs,
 	}
-	artifactListCmd.Flags().StringVar(&artifactListWorkspace, "workspace", "", "workspace name or UUID (default: active workspace)")
-	artifactListCmd.Flags().StringVar(&artifactListTaskID, "task", "", "task UUID or slug (e.g. prefix-123)")
+	artifactListCmd.Flags().StringVar(&artifactListWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
+	artifactListCmd.Flags().StringVar(&artifactListTaskID, "task", "", "task number, key, or UUID (for example 1823 or SUPER-1823)")
 	_ = artifactListCmd.MarkFlagRequired("task")
 	core.Bind(artifactListCmd, &artifactListCommand{
 		workspace: &artifactListWorkspace,
@@ -302,5 +302,5 @@ Example:
 }
 
 func bindTaskIDFlag(cmd *cobra.Command, dest *string) {
-	cmd.Flags().StringVar(dest, "task", "", "task UUID or slug (e.g. prefix-123)")
+	cmd.Flags().StringVar(dest, "task", "", "task number, key, or UUID (for example 1823 or SUPER-1823)")
 }

--- a/pkg/cli/commands/tasks/root.go
+++ b/pkg/cli/commands/tasks/root.go
@@ -25,7 +25,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Short: "List tasks in a workspace",
 		Long: `List tasks in a workspace.
 
---workspace is a workspace name, key, or UUID. When omitted, the active workspace
+--workspace is a workspace key or UUID. When omitted, the active workspace
 from "superplane workspace active" is used.
 
 --assignees accepts user UUIDs or emails (comma-separated or repeated).
@@ -37,13 +37,13 @@ By default, only open tasks are shown. Pass --state all to see
 draft, open, and closed tasks.
 
 Examples:
-  superplane tasks list --workspace shipping --state open
+  superplane tasks list --workspace super --state open
   superplane tasks list --assignees alice@example.com --result failed
   superplane tasks list --unassigned
   superplane tasks list --state all`,
 		Args: cobra.NoArgs,
 	}
-	taskListCmd.Flags().StringVar(&taskListWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
+	taskListCmd.Flags().StringVar(&taskListWorkspace, "workspace", "", "workspace key or UUID (default: active workspace)")
 	taskListCmd.Flags().StringSliceVar(&taskListAssignees, "assignees", nil, "filter by assignee user UUID or email (repeatable)")
 	taskListCmd.Flags().StringSliceVar(&taskListStates, "state", nil, "filter by task state (repeatable, e.g. open or STATE_OPEN); defaults to open when omitted; pass 'all' to include every state")
 	taskListCmd.Flags().StringSliceVar(&taskListResults, "result", nil, "filter by task result (repeatable, e.g. completed or RESULT_COMPLETED)")
@@ -67,7 +67,7 @@ Examples:
 		Long: `Show a task's title, assignees, description, comments, and
 timeline of events.
 
---workspace is a workspace name, key, or UUID. When omitted, the active workspace
+--workspace is a workspace key or UUID. When omitted, the active workspace
 from "superplane workspace active" is used. --task is the task number, key, or UUID
 (for example 1823 or SUPER-1823).
 
@@ -75,7 +75,7 @@ Example:
   superplane tasks describe --workspace super --task 1823`,
 		Args: cobra.NoArgs,
 	}
-	taskDescribeCmd.Flags().StringVar(&taskDescribeWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
+	taskDescribeCmd.Flags().StringVar(&taskDescribeWorkspace, "workspace", "", "workspace key or UUID (default: active workspace)")
 	bindTaskIDFlag(taskDescribeCmd, &taskDescribeTaskID)
 	core.Bind(taskDescribeCmd, &taskDescribeCommand{
 		workspace: &taskDescribeWorkspace,
@@ -95,7 +95,7 @@ Example:
 		Short: "Create a task",
 		Long: `Create a task in draft state.
 
---workspace is a workspace name, key, or UUID. When omitted, the active workspace
+--workspace is a workspace key or UUID. When omitted, the active workspace
 from "superplane workspace active" is used. --title is required.
 --description sets the description inline; -f/--file reads it from a
 file (or - for stdin) instead; the two are mutually exclusive.
@@ -113,7 +113,7 @@ Examples:
     --assignee bob@example.com`,
 		Args: cobra.NoArgs,
 	}
-	taskCreateCmd.Flags().StringVar(&taskCreateWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
+	taskCreateCmd.Flags().StringVar(&taskCreateWorkspace, "workspace", "", "workspace key or UUID (default: active workspace)")
 	taskCreateCmd.Flags().StringVar(&taskCreateTitle, "title", "", "task title (required)")
 	taskCreateCmd.Flags().StringVar(&taskCreateDescription, "description", "", "task description (inline)")
 	taskCreateCmd.Flags().StringVarP(&taskCreateFile, "file", "f", "", "read description from file (or - for stdin)")
@@ -137,7 +137,7 @@ Examples:
 		Short: "Dispatch a task to a workspace line",
 		Long: `Dispatch a task to a workspace line, starting its execution.
 
---workspace is a workspace name, key, or UUID. When omitted, the active workspace
+--workspace is a workspace key or UUID. When omitted, the active workspace
 from "superplane workspace active" is used. --task is the task number, key, or UUID
 (for example 1823 or SUPER-1823). --line is the target workspace line's name.
 
@@ -147,7 +147,7 @@ Example:
   superplane tasks dispatch --workspace super --task 1823 --line build`,
 		Args: cobra.NoArgs,
 	}
-	taskDispatchCmd.Flags().StringVar(&taskDispatchWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
+	taskDispatchCmd.Flags().StringVar(&taskDispatchWorkspace, "workspace", "", "workspace key or UUID (default: active workspace)")
 	bindTaskIDFlag(taskDispatchCmd, &taskDispatchTaskID)
 	taskDispatchCmd.Flags().StringVar(&taskDispatchLine, "line", "", "workspace line name (required)")
 	core.Bind(taskDispatchCmd, &taskDispatchCommand{
@@ -167,7 +167,7 @@ Example:
 		Short: "Set a task's assignees",
 		Long: `Set a task's assignees.
 
---workspace is a workspace name, key, or UUID. When omitted, the active workspace
+--workspace is a workspace key or UUID. When omitted, the active workspace
 from "superplane workspace active" is used. --task is the task number, key, or UUID
 (for example 1823 or SUPER-1823).
 
@@ -179,7 +179,7 @@ Example:
   superplane tasks assign --workspace super --task 1823 --assignee alice@example.com --assignee bob@example.com`,
 		Args: cobra.NoArgs,
 	}
-	taskAssignCmd.Flags().StringVar(&taskAssignWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
+	taskAssignCmd.Flags().StringVar(&taskAssignWorkspace, "workspace", "", "workspace key or UUID (default: active workspace)")
 	bindTaskIDFlag(taskAssignCmd, &taskAssignTaskID)
 	taskAssignCmd.Flags().StringArrayVar(&taskAssignAssignees, "assignee", nil, "assignee user UUID or email (repeatable, required); replaces the full assignee list")
 	core.Bind(taskAssignCmd, &taskAssignCommand{
@@ -210,7 +210,7 @@ Example:
 		Short: "Attach an artifact to a task",
 		Long: `Attach a typed artifact to a task.
 
---workspace is a workspace name, key, or UUID. When omitted, the active workspace
+--workspace is a workspace key or UUID. When omitted, the active workspace
 from "superplane workspace active" is used. --task is the task number, key, or UUID.
 --type is one of: markdown, branch, link.
 
@@ -243,7 +243,7 @@ Examples:
     --title Preview`,
 		Args: cobra.NoArgs,
 	}
-	artifactAddCmd.Flags().StringVar(&artifactAddWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
+	artifactAddCmd.Flags().StringVar(&artifactAddWorkspace, "workspace", "", "workspace key or UUID (default: active workspace)")
 	artifactAddCmd.Flags().StringVar(&artifactAddTaskID, "task", "", "task number, key, or UUID (for example 1823 or SUPER-1823)")
 	artifactAddCmd.Flags().StringVar(&artifactAddTypeName, "type", "", "artifact type: markdown, branch, or link")
 	artifactAddCmd.Flags().StringVar(&artifactAddTitle, "title", "", "artifact title")
@@ -273,14 +273,14 @@ Examples:
 		Short: "List artifacts on a task",
 		Long: `List artifacts on a task.
 
---workspace is a workspace name, key, or UUID. When omitted, the active workspace
+--workspace is a workspace key or UUID. When omitted, the active workspace
 from "superplane workspace active" is used.
 
 Example:
   superplane tasks artifacts list --workspace super --task 1823`,
 		Args: cobra.NoArgs,
 	}
-	artifactListCmd.Flags().StringVar(&artifactListWorkspace, "workspace", "", "workspace name, key, or UUID (default: active workspace)")
+	artifactListCmd.Flags().StringVar(&artifactListWorkspace, "workspace", "", "workspace key or UUID (default: active workspace)")
 	artifactListCmd.Flags().StringVar(&artifactListTaskID, "task", "", "task number, key, or UUID (for example 1823 or SUPER-1823)")
 	_ = artifactListCmd.MarkFlagRequired("task")
 	core.Bind(artifactListCmd, &artifactListCommand{

--- a/pkg/cli/commands/workspaces/active.go
+++ b/pkg/cli/commands/workspaces/active.go
@@ -35,7 +35,7 @@ func (c *activeCommand) setActive(ctx core.CommandContext, nameOrID string) erro
 func (c *activeCommand) printActive(ctx core.CommandContext) error {
 	active := strings.TrimSpace(ctx.Config.GetActiveWorkspace())
 	if active == "" {
-		return fmt.Errorf("no active workspace; pass a name or id, or run interactively")
+		return fmt.Errorf("no active workspace; pass a name, key, or id, or run interactively")
 	}
 	if !ctx.Renderer.IsText() {
 		return ctx.Renderer.Render(map[string]string{"id": active})

--- a/pkg/cli/commands/workspaces/resolve.go
+++ b/pkg/cli/commands/workspaces/resolve.go
@@ -29,7 +29,7 @@ func errWorkspaceRequired() error {
 func FindWorkspaceID(ctx core.CommandContext, nameOrID string) (string, error) {
 	trimmed := strings.TrimSpace(nameOrID)
 	if trimmed == "" {
-		return "", fmt.Errorf("workspace name, key, or id is required")
+		return "", fmt.Errorf("workspace key or id is required")
 	}
 	if _, err := uuid.Parse(trimmed); err == nil {
 		return trimmed, nil

--- a/pkg/cli/commands/workspaces/resolve.go
+++ b/pkg/cli/commands/workspaces/resolve.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/cli/core"
-	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
 
 func ResolveWorkspaceID(ctx core.CommandContext, workspaceFlag string) (string, error) {
@@ -20,7 +19,7 @@ func ResolveWorkspaceID(ctx core.CommandContext, workspaceFlag string) (string, 
 	if trimmed == "" {
 		return "", errWorkspaceRequired()
 	}
-	return FindWorkspaceID(ctx, trimmed)
+	return trimmed, nil
 }
 
 func errWorkspaceRequired() error {
@@ -30,33 +29,23 @@ func errWorkspaceRequired() error {
 func FindWorkspaceID(ctx core.CommandContext, nameOrID string) (string, error) {
 	trimmed := strings.TrimSpace(nameOrID)
 	if trimmed == "" {
-		return "", fmt.Errorf("workspace name or id is required")
+		return "", fmt.Errorf("workspace name, key, or id is required")
 	}
 	if _, err := uuid.Parse(trimmed); err == nil {
 		return trimmed, nil
 	}
 
-	response, _, err := ctx.API.FactoryAPI.FactoriesListFactories(ctx.Context).Execute()
+	response, _, err := ctx.API.FactoryAPI.FactoriesDescribeFactory(ctx.Context, trimmed).Execute()
 	if err != nil {
 		return "", err
 	}
-
-	var matches []openapi_client.FactoriesFactory
-	for _, ws := range response.GetFactories() {
-		if ws.GetName() == trimmed {
-			matches = append(matches, ws)
-		}
+	if response == nil || !response.HasFactory() {
+		return "", fmt.Errorf("workspace %q is missing an id", trimmed)
 	}
-
-	if len(matches) == 0 {
-		return "", fmt.Errorf("workspace %q not found", trimmed)
-	}
-	if len(matches) > 1 {
-		return "", fmt.Errorf("multiple workspaces named %q found", trimmed)
-	}
-	if !matches[0].HasId() {
+	factory := response.GetFactory()
+	if !factory.HasId() {
 		return "", fmt.Errorf("workspace %q is missing an id", trimmed)
 	}
 
-	return matches[0].GetId(), nil
+	return factory.GetId(), nil
 }

--- a/pkg/cli/commands/workspaces/resolve_test.go
+++ b/pkg/cli/commands/workspaces/resolve_test.go
@@ -46,13 +46,6 @@ func TestFindWorkspaceID(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, workspaceID, got)
 	})
-
-	t.Run("resolves workspace name through the API", func(t *testing.T) {
-		ctx, _ := cli.NewCommandContext(t, newDescribeServer(t, "/api/v1/factories/SuperPlane"), "text")
-		got, err := FindWorkspaceID(ctx, "SuperPlane")
-		require.NoError(t, err)
-		assert.Equal(t, workspaceID, got)
-	})
 }
 
 func TestResolveWorkspaceID(t *testing.T) {

--- a/pkg/cli/commands/workspaces/resolve_test.go
+++ b/pkg/cli/commands/workspaces/resolve_test.go
@@ -1,7 +1,6 @@
 package workspaces
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,25 +10,61 @@ import (
 	cli "github.com/superplanehq/superplane/test/support/cli"
 )
 
+func TestFindWorkspaceID(t *testing.T) {
+	workspaceID := "11111111-1111-1111-1111-111111111111"
+	const describePayload = `{"factory":{"id":"11111111-1111-1111-1111-111111111111","name":"SuperPlane","key":"SUPER"}}`
+
+	newDescribeServer := func(t *testing.T, wantPath string) *httptest.Server {
+		t.Helper()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet && r.URL.Path == wantPath {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(describePayload))
+				return
+			}
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}))
+		t.Cleanup(server.Close)
+		return server
+	}
+
+	t.Run("returns UUID unchanged", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}))
+		t.Cleanup(server.Close)
+
+		ctx, _ := cli.NewCommandContext(t, server, "text")
+		got, err := FindWorkspaceID(ctx, workspaceID)
+		require.NoError(t, err)
+		assert.Equal(t, workspaceID, got)
+	})
+
+	t.Run("resolves workspace key through the API", func(t *testing.T) {
+		ctx, _ := cli.NewCommandContext(t, newDescribeServer(t, "/api/v1/factories/super"), "text")
+		got, err := FindWorkspaceID(ctx, "super")
+		require.NoError(t, err)
+		assert.Equal(t, workspaceID, got)
+	})
+
+	t.Run("resolves workspace name through the API", func(t *testing.T) {
+		ctx, _ := cli.NewCommandContext(t, newDescribeServer(t, "/api/v1/factories/SuperPlane"), "text")
+		got, err := FindWorkspaceID(ctx, "SuperPlane")
+		require.NoError(t, err)
+		assert.Equal(t, workspaceID, got)
+	})
+}
+
 func TestResolveWorkspaceID(t *testing.T) {
 	workspaceID := "11111111-1111-1111-1111-111111111111"
 
 	t.Run("uses explicit workspace flag", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(fmt.Sprintf(
-				`{"factories":[{"id":%q,"name":"shipping"}]}`,
-				workspaceID,
-			)))
-		}))
-		t.Cleanup(server.Close)
-
-		ctx, _ := cli.NewCommandContextWithConfig(t, server, "text", &cli.FakeConfig{
+		ctx, _ := cli.NewCommandContextWithConfig(t, nil, "text", &cli.FakeConfig{
 			ActiveWorkspace: "ignored",
 		})
-		got, err := ResolveWorkspaceID(ctx, "shipping")
+		got, err := ResolveWorkspaceID(ctx, "super")
 		require.NoError(t, err)
-		assert.Equal(t, workspaceID, got)
+		assert.Equal(t, "super", got)
 	})
 
 	t.Run("falls back to active workspace", func(t *testing.T) {

--- a/pkg/cli/commands/workspaces/root.go
+++ b/pkg/cli/commands/workspaces/root.go
@@ -17,7 +17,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Short: "Set or show the active workspace",
 		Long: `Set the active workspace used when --workspace is omitted.
 
-Pass a workspace name, key, or UUID, or run with no args in an interactive terminal
+Pass a workspace key or UUID, or run with no args in an interactive terminal
 to pick from a list. Non-interactive with no args prints the active workspace id.`,
 		Args: cobra.MaximumNArgs(1),
 	}

--- a/pkg/cli/commands/workspaces/root.go
+++ b/pkg/cli/commands/workspaces/root.go
@@ -17,7 +17,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Short: "Set or show the active workspace",
 		Long: `Set the active workspace used when --workspace is omitted.
 
-Pass a workspace name or UUID, or run with no args in an interactive terminal
+Pass a workspace name, key, or UUID, or run with no args in an interactive terminal
 to pick from a list. Non-interactive with no args prints the active workspace id.`,
 		Args: cobra.MaximumNArgs(1),
 	}

--- a/pkg/grpc/actions/factories/add_work_order_comment.go
+++ b/pkg/grpc/actions/factories/add_work_order_comment.go
@@ -27,16 +27,6 @@ func AddWorkOrderComment(
 		return nil, factoryErrorToStatus(err, "failed to add work order comment")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to add work order comment")
-	}
-
-	orderID, err := parseOrderID(req.GetOrderId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to add work order comment")
-	}
-
 	body := strings.TrimSpace(req.GetBody())
 	if body == "" {
 		return nil, factoryErrorToStatus(invalidArgument("body is required"), "failed to add work order comment")
@@ -57,8 +47,20 @@ func AddWorkOrderComment(
 		UserID: &userIDStr,
 	}
 
-	var comment *models.FactoryWorkOrderComment
 	db := database.DB(ctx)
+	resolvedFactory, err := findFactory(db, orgID, req.GetFactoryId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to add work order comment")
+	}
+	factoryID := resolvedFactory.ID
+
+	resolvedOrder, err := findWorkOrder(db, resolvedFactory, req.GetOrderId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to add work order comment")
+	}
+	orderID := resolvedOrder.ID
+
+	var comment *models.FactoryWorkOrderComment
 	err = db.Transaction(func(tx *gorm.DB) error {
 		factoryModel, err := models.FindFactory(tx, orgID, factoryID)
 		if err != nil {

--- a/pkg/grpc/actions/factories/close_work_order.go
+++ b/pkg/grpc/actions/factories/close_work_order.go
@@ -30,32 +30,23 @@ func CloseWorkOrder(ctx context.Context, organizationID string, req *pb.CloseWor
 		return nil, factoryErrorToStatus(invalidArgument("invalid user id"), "failed to create work order")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to close work order")
-	}
-
-	orderID, err := parseOrderID(req.GetOrderId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to close work order")
-	}
-
 	result, err := closeWorkOrderResult(req.GetResult())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to close work order")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to close work order")
 	}
 
 	logger := logging.ForFactory(*factory)
-	order, err := factory.FindWorkOrder(db, orderID)
+	order, err := findWorkOrder(db, factory, req.GetOrderId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to close work order")
 	}
+	orderID := order.ID
 
 	logger = logging.WithWorkOrder(logger, *order)
 	fromState := order.State

--- a/pkg/grpc/actions/factories/create_factory_intake.go
+++ b/pkg/grpc/actions/factories/create_factory_intake.go
@@ -72,21 +72,17 @@ func CreateFactoryIntake(
 		return nil, factoryErrorToStatus(err, "failed to create factory intake")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to create factory intake")
-	}
-
 	source, err := parseFactoryIntakeSource(req.GetSource())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create factory intake")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create factory intake")
 	}
+	factoryID := factory.ID
 
 	name := strings.TrimSpace(req.GetName())
 	if name == "" {

--- a/pkg/grpc/actions/factories/create_factory_line.go
+++ b/pkg/grpc/actions/factories/create_factory_line.go
@@ -5,17 +5,11 @@ import (
 	"strings"
 
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 )
 
 func CreateFactoryLine(ctx context.Context, organizationID string, req *pb.CreateFactoryLineRequest) (*pb.CreateFactoryLineResponse, error) {
 	orgID, err := parseOrganizationID(organizationID)
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to create factory line")
-	}
-
-	factoryID, err := parseFactoryID(req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create factory line")
 	}
@@ -26,10 +20,11 @@ func CreateFactoryLine(ctx context.Context, organizationID string, req *pb.Creat
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create factory line")
 	}
+	factoryID := factory.ID
 
 	steps, err := parseLineSteps(db, orgID, factoryID, req.GetSteps())
 	if err != nil {

--- a/pkg/grpc/actions/factories/create_factory_pr_feedback_handler.go
+++ b/pkg/grpc/actions/factories/create_factory_pr_feedback_handler.go
@@ -26,16 +26,12 @@ func CreateFactoryPRFeedbackHandler(
 		return nil, factoryErrorToStatus(err, "failed to create factory PR feedback handler")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to create factory PR feedback handler")
-	}
-
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create factory PR feedback handler")
 	}
+	factoryID := factory.ID
 
 	repository := strings.TrimSpace(req.GetSettings().GetSubject().GetRepository())
 	if repository == "" {

--- a/pkg/grpc/actions/factories/create_factory_pull_request.go
+++ b/pkg/grpc/actions/factories/create_factory_pull_request.go
@@ -21,23 +21,13 @@ func CreateFactoryPullRequest(
 		return nil, factoryErrorToStatus(err, "failed to create factory pull request")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to create factory pull request")
-	}
-
-	orderID, err := parseOrderID(req.GetWorkOrderId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to create factory pull request")
-	}
-
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create factory pull request")
 	}
 
-	order, err := factory.FindWorkOrder(db, orderID)
+	order, err := findWorkOrder(db, factory, req.GetWorkOrderId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create factory pull request")
 	}

--- a/pkg/grpc/actions/factories/create_work_order.go
+++ b/pkg/grpc/actions/factories/create_work_order.go
@@ -25,11 +25,6 @@ func CreateWorkOrder(ctx context.Context, organizationID string, req *pb.CreateW
 		return nil, factoryErrorToStatus(err, "failed to create work order")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to create work order")
-	}
-
 	title := strings.TrimSpace(req.GetTitle())
 	if title == "" {
 		return nil, factoryErrorToStatus(invalidArgument("title is required"), "failed to create work order")
@@ -46,7 +41,7 @@ func CreateWorkOrder(ctx context.Context, organizationID string, req *pb.CreateW
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create work order")
 	}

--- a/pkg/grpc/actions/factories/create_work_order_artifact.go
+++ b/pkg/grpc/actions/factories/create_work_order_artifact.go
@@ -24,16 +24,6 @@ func CreateWorkOrderArtifact(
 		return nil, factoryErrorToStatus(err, "failed to create work order artifact")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to create work order artifact")
-	}
-
-	orderID, err := parseOrderID(req.GetOrderId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to create work order artifact")
-	}
-
 	artifactType, ok := artifactTypeFromProto(req.GetType())
 	if !ok {
 		return nil, factoryErrorToStatus(invalidArgument("artifact type is required"), "failed to create work order artifact")
@@ -54,15 +44,17 @@ func CreateWorkOrderArtifact(
 	}
 
 	db := database.DB(ctx)
-	factoryModel, err := models.FindFactory(db, orgID, factoryID)
+	factoryModel, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create work order artifact")
 	}
+	factoryID := factoryModel.ID
 
-	order, err := factoryModel.FindWorkOrder(db, orderID)
+	order, err := findWorkOrder(db, factoryModel, req.GetOrderId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create work order artifact")
 	}
+	orderID := order.ID
 
 	artifact, err := order.CreateArtifact(db, models.FactoryWorkOrderArtifactParams{
 		Type:      artifactType,

--- a/pkg/grpc/actions/factories/delete_factory.go
+++ b/pkg/grpc/actions/factories/delete_factory.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 	"gorm.io/gorm"
 )
@@ -15,13 +14,8 @@ func DeleteFactory(ctx context.Context, organizationID, factoryID string) (*pb.D
 		return nil, factoryErrorToStatus(err, "failed to delete factory")
 	}
 
-	id, err := parseFactoryID(factoryID)
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to delete factory")
-	}
-
 	err = database.DB(ctx).Transaction(func(tx *gorm.DB) error {
-		factory, err := models.FindFactory(tx, orgID, id)
+		factory, err := findFactory(tx, orgID, factoryID)
 		if err != nil {
 			return err
 		}

--- a/pkg/grpc/actions/factories/delete_factory_intake.go
+++ b/pkg/grpc/actions/factories/delete_factory_intake.go
@@ -16,18 +16,13 @@ func DeleteFactoryIntake(ctx context.Context, organizationID string, req *pb.Del
 		return nil, factoryErrorToStatus(err, "failed to delete factory intake")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to delete factory intake")
-	}
-
 	intakeID, err := parseIntakeID(req.GetIntakeId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to delete factory intake")
 	}
 
 	err = database.DB(ctx).Transaction(func(tx *gorm.DB) error {
-		factory, err := models.FindFactory(tx, orgID, factoryID)
+		factory, err := findFactory(tx, orgID, req.GetFactoryId())
 		if err != nil {
 			return err
 		}

--- a/pkg/grpc/actions/factories/delete_factory_pr_feedback_handler.go
+++ b/pkg/grpc/actions/factories/delete_factory_pr_feedback_handler.go
@@ -20,18 +20,13 @@ func DeleteFactoryPRFeedbackHandler(
 		return nil, factoryErrorToStatus(err, "failed to delete factory PR feedback handler")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to delete factory PR feedback handler")
-	}
-
 	handlerID, err := parsePRFeedbackHandlerID(req.GetHandlerId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to delete factory PR feedback handler")
 	}
 
 	err = database.DB(ctx).Transaction(func(tx *gorm.DB) error {
-		factory, err := models.FindFactory(tx, orgID, factoryID)
+		factory, err := findFactory(tx, orgID, req.GetFactoryId())
 		if err != nil {
 			return err
 		}

--- a/pkg/grpc/actions/factories/describe_factory.go
+++ b/pkg/grpc/actions/factories/describe_factory.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 )
 
@@ -14,13 +13,8 @@ func DescribeFactory(ctx context.Context, organizationID, factoryID string) (*pb
 		return nil, factoryErrorToStatus(err, "failed to describe factory")
 	}
 
-	id, err := parseFactoryID(factoryID)
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to describe factory")
-	}
-
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, id)
+	factory, err := findFactory(db, orgID, factoryID)
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to describe factory")
 	}

--- a/pkg/grpc/actions/factories/describe_factory_pull_request.go
+++ b/pkg/grpc/actions/factories/describe_factory_pull_request.go
@@ -18,18 +18,13 @@ func DescribeFactoryPullRequest(
 		return nil, factoryErrorToStatus(err, "failed to describe factory pull request")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to describe factory pull request")
-	}
-
 	prID, err := parsePullRequestID(req.GetPrId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to describe factory pull request")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to describe factory pull request")
 	}

--- a/pkg/grpc/actions/factories/describe_factory_test.go
+++ b/pkg/grpc/actions/factories/describe_factory_test.go
@@ -7,14 +7,17 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"gorm.io/gorm"
+
 	"github.com/superplanehq/superplane/pkg/database"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 	"github.com/superplanehq/superplane/test/support"
-	"gorm.io/gorm"
 )
 
-func Test__DescribeFactory_AcceptsKeyAndName(t *testing.T) {
+func Test__DescribeFactory_AcceptsKey(t *testing.T) {
 	r := support.Setup(t)
 	ctx := t.Context()
 	db := database.DB(ctx)
@@ -28,10 +31,10 @@ func Test__DescribeFactory_AcceptsKeyAndName(t *testing.T) {
 		assert.Equal(t, factoryModel.ID.String(), resp.Factory.GetId())
 	})
 
-	t.Run("describes by workspace name", func(t *testing.T) {
-		resp, err := DescribeFactory(ctx, r.Organization.ID.String(), "superplane")
-		require.NoError(t, err)
-		assert.Equal(t, factoryModel.ID.String(), resp.Factory.GetId())
+	t.Run("rejects a workspace name", func(t *testing.T) {
+		_, err := DescribeFactory(ctx, r.Organization.ID.String(), "SuperPlane")
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, grpcerrors.Code(err))
 	})
 }
 

--- a/pkg/grpc/actions/factories/describe_factory_test.go
+++ b/pkg/grpc/actions/factories/describe_factory_test.go
@@ -14,6 +14,27 @@ import (
 	"gorm.io/gorm"
 )
 
+func Test__DescribeFactory_AcceptsKeyAndName(t *testing.T) {
+	r := support.Setup(t)
+	ctx := t.Context()
+	db := database.DB(ctx)
+
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, "SuperPlane", "", "SUPER")
+	require.NoError(t, err)
+
+	t.Run("describes by workspace key", func(t *testing.T) {
+		resp, err := DescribeFactory(ctx, r.Organization.ID.String(), "super")
+		require.NoError(t, err)
+		assert.Equal(t, factoryModel.ID.String(), resp.Factory.GetId())
+	})
+
+	t.Run("describes by workspace name", func(t *testing.T) {
+		resp, err := DescribeFactory(ctx, r.Organization.ID.String(), "superplane")
+		require.NoError(t, err)
+		assert.Equal(t, factoryModel.ID.String(), resp.Factory.GetId())
+	})
+}
+
 func Test__DescribeFactory_AttachesLineMetrics(t *testing.T) {
 	r := support.Setup(t)
 	ctx := t.Context()

--- a/pkg/grpc/actions/factories/describe_factory_usage.go
+++ b/pkg/grpc/actions/factories/describe_factory_usage.go
@@ -25,19 +25,15 @@ func DescribeFactoryUsage(
 		return nil, factoryErrorToStatus(err, "failed to describe factory usage")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to describe factory usage")
-	}
-
 	period := clampUsagePeriodDays(int(req.GetPeriodDays()))
 	since := time.Now().AddDate(0, 0, -period)
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to describe factory usage")
 	}
+	factoryID := factory.ID
 
 	totals, byModel, err := models.SummarizeUsage(db, models.UsageReportFilter{
 		OrganizationID: orgID,

--- a/pkg/grpc/actions/factories/describe_factory_velocity.go
+++ b/pkg/grpc/actions/factories/describe_factory_velocity.go
@@ -39,17 +39,14 @@ func DescribeFactoryVelocity(
 		return nil, factoryErrorToStatus(err, "failed to describe factory velocity")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to describe factory velocity")
-	}
-
 	period := clampPeriodDays(int(req.GetPeriodDays()))
 
 	db := database.DB(ctx)
-	if _, err := models.FindFactory(db, orgID, factoryID); err != nil {
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
+	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to describe factory velocity")
 	}
+	factoryID := factory.ID
 
 	now := time.Now().In(time.Local)
 	buckets := buildDayBuckets(now, period)

--- a/pkg/grpc/actions/factories/describe_work_order.go
+++ b/pkg/grpc/actions/factories/describe_work_order.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 )
 
@@ -14,23 +13,13 @@ func DescribeWorkOrder(ctx context.Context, organizationID string, req *pb.Descr
 		return nil, factoryErrorToStatus(err, "failed to describe work order")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to describe work order")
-	}
-
-	orderID, err := parseOrderID(req.GetOrderId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to describe work order")
-	}
-
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to describe work order")
 	}
 
-	order, err := factory.FindWorkOrder(db, orderID)
+	order, err := findWorkOrder(db, factory, req.GetOrderId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to describe work order")
 	}

--- a/pkg/grpc/actions/factories/describe_work_order_test.go
+++ b/pkg/grpc/actions/factories/describe_work_order_test.go
@@ -1,0 +1,42 @@
+package factories
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func Test__DescribeWorkOrder_AcceptsNumberAndKey(t *testing.T) {
+	r := support.Setup(t)
+	ctx := t.Context()
+	db := database.DB(ctx)
+
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, "Numbers", "", "NUM")
+	require.NoError(t, err)
+	order, err := factoryModel.CreateWorkOrder(db, "one", "", &r.User, nil, nil)
+	require.NoError(t, err)
+
+	t.Run("describes by task number", func(t *testing.T) {
+		resp, err := DescribeWorkOrder(ctx, r.Organization.ID.String(), &pb.DescribeWorkOrderRequest{
+			FactoryId: "num",
+			OrderId:   "1",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, order.ID.String(), resp.Order.GetId())
+		assert.Equal(t, int64(1), resp.Order.GetNumber())
+	})
+
+	t.Run("describes by task key", func(t *testing.T) {
+		resp, err := DescribeWorkOrder(ctx, r.Organization.ID.String(), &pb.DescribeWorkOrderRequest{
+			FactoryId: factoryModel.ID.String(),
+			OrderId:   "num-1",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, order.ID.String(), resp.Order.GetId())
+	})
+}

--- a/pkg/grpc/actions/factories/dispatch_work_order.go
+++ b/pkg/grpc/actions/factories/dispatch_work_order.go
@@ -24,15 +24,18 @@ func DispatchWorkOrder(ctx context.Context, organizationID string, req *pb.Dispa
 		return nil, factoryErrorToStatus(err, "failed to dispatch work order")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
+	db := database.DB(ctx)
+	resolvedFactory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to dispatch work order")
 	}
+	factoryID := resolvedFactory.ID
 
-	orderID, err := parseOrderID(req.GetOrderId())
+	resolvedOrder, err := findWorkOrder(db, resolvedFactory, req.GetOrderId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to dispatch work order")
 	}
+	orderID := resolvedOrder.ID
 
 	lineName := strings.TrimSpace(req.GetLineName())
 	if lineName == "" {
@@ -54,7 +57,6 @@ func DispatchWorkOrder(ctx context.Context, organizationID string, req *pb.Dispa
 	var logger *log.Entry
 	var fromState string
 
-	db := database.DB(ctx)
 	err = db.Transaction(func(tx *gorm.DB) error {
 		f, err := models.FindFactory(tx, orgID, factoryID)
 		if err != nil {

--- a/pkg/grpc/actions/factories/export_factory_work_order_run_usage.go
+++ b/pkg/grpc/actions/factories/export_factory_work_order_run_usage.go
@@ -35,16 +35,12 @@ func ExportFactoryWorkOrderRunUsage(
 		return nil, factoryErrorToStatus(err, "failed to export factory work order run usage")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to export factory work order run usage")
-	}
-
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to export factory work order run usage")
 	}
+	factoryID := factory.ID
 
 	rows, err := models.ListAllWorkOrderRunUsage(db, models.UsageReportFilter{
 		OrganizationID: orgID,

--- a/pkg/grpc/actions/factories/factory_llm_models.go
+++ b/pkg/grpc/actions/factories/factory_llm_models.go
@@ -18,13 +18,11 @@ func ListFactoryLLMModels(
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list factory models")
 	}
-	factoryID, err := parseFactoryID(req.GetFactoryId())
+	factory, err := findFactory(database.DB(ctx), orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list factory models")
 	}
-	if _, err := models.FindFactory(database.DB(ctx), orgID, factoryID); err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list factory models")
-	}
+	factoryID := factory.ID
 
 	parent, err := models.ResolveSelectableLLMModels(database.DB(ctx), orgID, nil, req.GetProvider(), req.GetFundingSource())
 	if err != nil {
@@ -58,10 +56,11 @@ func UpdateFactoryLLMModels(
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory models")
 	}
-	factoryID, err := parseFactoryID(req.GetFactoryId())
+	factory, err := findFactory(database.DB(ctx), orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory models")
 	}
+	factoryID := factory.ID
 
 	saved, err := models.UpsertFactoryLLMModelAllowlist(
 		database.DB(ctx),

--- a/pkg/grpc/actions/factories/helpers.go
+++ b/pkg/grpc/actions/factories/helpers.go
@@ -2,6 +2,7 @@ package factories
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -18,15 +19,6 @@ func parseOrganizationID(organizationID string) (uuid.UUID, error) {
 	return orgID, nil
 }
 
-func parseFactoryID(factoryID string) (uuid.UUID, error) {
-	id, err := uuid.Parse(factoryID)
-	if err != nil {
-		return uuid.Nil, invalidArgument("invalid factory id")
-	}
-
-	return id, nil
-}
-
 func parseOrderID(orderID string) (uuid.UUID, error) {
 	id, err := uuid.Parse(orderID)
 	if err != nil {
@@ -34,6 +26,20 @@ func parseOrderID(orderID string) (uuid.UUID, error) {
 	}
 
 	return id, nil
+}
+
+func findFactory(tx *gorm.DB, organizationID uuid.UUID, ref string) (*models.Factory, error) {
+	if strings.TrimSpace(ref) == "" {
+		return nil, invalidArgument("invalid factory id")
+	}
+	return models.FindFactoryByRef(tx, organizationID, ref)
+}
+
+func findWorkOrder(tx *gorm.DB, factory *models.Factory, ref string) (*models.FactoryWorkOrder, error) {
+	if strings.TrimSpace(ref) == "" {
+		return nil, invalidArgument("invalid work order id")
+	}
+	return factory.FindWorkOrderByRef(tx, ref)
 }
 
 func parsePullRequestID(prID string) (uuid.UUID, error) {

--- a/pkg/grpc/actions/factories/helpers.go
+++ b/pkg/grpc/actions/factories/helpers.go
@@ -28,6 +28,8 @@ func parseOrderID(orderID string) (uuid.UUID, error) {
 	return id, nil
 }
 
+// findFactory resolves a factory path id for describe, update, and delete.
+// Accept UUID or workspace key only. See models.FindFactoryByRef.
 func findFactory(tx *gorm.DB, organizationID uuid.UUID, ref string) (*models.Factory, error) {
 	if strings.TrimSpace(ref) == "" {
 		return nil, invalidArgument("invalid factory id")

--- a/pkg/grpc/actions/factories/import_factory_intake_item.go
+++ b/pkg/grpc/actions/factories/import_factory_intake_item.go
@@ -31,11 +31,6 @@ func ImportFactoryIntakeItem(
 		return nil, factoryErrorToStatus(err, "failed to import factory intake item")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to import factory intake item")
-	}
-
 	intakeID, err := parseIntakeID(req.GetIntakeId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to import factory intake item")
@@ -56,7 +51,7 @@ func ImportFactoryIntakeItem(
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to import factory intake item")
 	}

--- a/pkg/grpc/actions/factories/line_runner_models.go
+++ b/pkg/grpc/actions/factories/line_runner_models.go
@@ -27,12 +27,13 @@ func ListFactoryLineRunnerModels(
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list line runner models")
 	}
-	factoryID, err := parseFactoryID(req.GetFactoryId())
+	db := database.DB(ctx)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list line runner models")
 	}
 
-	ids, err := listLineRunnerModels(database.DB(ctx), orgID, factoryID, req.GetLineName())
+	ids, err := listLineRunnerModels(db, orgID, factory.ID, req.GetLineName())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list line runner models")
 	}

--- a/pkg/grpc/actions/factories/list_factory_apps.go
+++ b/pkg/grpc/actions/factories/list_factory_apps.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 )
 
@@ -14,13 +13,8 @@ func ListFactoryApps(ctx context.Context, organizationID string, req *pb.ListFac
 		return nil, factoryErrorToStatus(err, "failed to list factory apps")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list factory apps")
-	}
-
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list factory apps")
 	}

--- a/pkg/grpc/actions/factories/list_factory_intake_runs.go
+++ b/pkg/grpc/actions/factories/list_factory_intake_runs.go
@@ -29,18 +29,13 @@ func ListFactoryIntakeRuns(
 		return nil, factoryErrorToStatus(err, "failed to list factory intake runs")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list factory intake runs")
-	}
-
 	intakeID, err := parseIntakeID(req.GetIntakeId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list factory intake runs")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list factory intake runs")
 	}

--- a/pkg/grpc/actions/factories/list_factory_intakes.go
+++ b/pkg/grpc/actions/factories/list_factory_intakes.go
@@ -16,13 +16,8 @@ func ListFactoryIntakes(ctx context.Context, organizationID string, req *pb.List
 		return nil, factoryErrorToStatus(err, "failed to list factory intakes")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list factory intakes")
-	}
-
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list factory intakes")
 	}

--- a/pkg/grpc/actions/factories/list_factory_pr_feedback_handlers.go
+++ b/pkg/grpc/actions/factories/list_factory_pr_feedback_handlers.go
@@ -20,13 +20,8 @@ func ListFactoryPRFeedbackHandlers(
 		return nil, factoryErrorToStatus(err, "failed to list factory PR feedback handlers")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list factory PR feedback handlers")
-	}
-
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list factory PR feedback handlers")
 	}

--- a/pkg/grpc/actions/factories/list_factory_pull_requests.go
+++ b/pkg/grpc/actions/factories/list_factory_pull_requests.go
@@ -19,18 +19,13 @@ func ListFactoryPullRequests(
 		return nil, factoryErrorToStatus(err, "failed to list factory pull requests")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list factory pull requests")
-	}
-
 	filter, err := listFactoryPullRequestFilter(req)
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list factory pull requests")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list factory pull requests")
 	}

--- a/pkg/grpc/actions/factories/list_factory_work_order_run_usage.go
+++ b/pkg/grpc/actions/factories/list_factory_work_order_run_usage.go
@@ -28,21 +28,17 @@ func ListFactoryWorkOrderRunUsage(
 		return nil, factoryErrorToStatus(err, "failed to list factory work order run usage")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list factory work order run usage")
-	}
-
 	since, until, err := resolveWorkOrderRunUsageWindow(req)
 	if err != nil {
 		return nil, grpcerrors.InvalidArgument(err, err.Error())
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list factory work order run usage")
 	}
+	factoryID := factory.ID
 
 	rows, total, err := models.ListWorkOrderRunUsage(db, models.UsageReportFilter{
 		OrganizationID: orgID,

--- a/pkg/grpc/actions/factories/list_work_order_artifacts.go
+++ b/pkg/grpc/actions/factories/list_work_order_artifacts.go
@@ -21,23 +21,13 @@ func ListWorkOrderArtifacts(
 		return nil, factoryErrorToStatus(err, "failed to list work order artifacts")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list work order artifacts")
-	}
-
-	orderID, err := parseOrderID(req.GetOrderId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list work order artifacts")
-	}
-
 	db := database.DB(ctx)
-	factoryModel, err := models.FindFactory(db, orgID, factoryID)
+	factoryModel, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list work order artifacts")
 	}
 
-	order, err := factoryModel.FindWorkOrder(db, orderID)
+	order, err := findWorkOrder(db, factoryModel, req.GetOrderId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list work order artifacts")
 	}

--- a/pkg/grpc/actions/factories/list_work_order_checks.go
+++ b/pkg/grpc/actions/factories/list_work_order_checks.go
@@ -19,23 +19,13 @@ func ListWorkOrderChecks(
 		return nil, factoryErrorToStatus(err, "failed to list work order checks")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list work order checks")
-	}
-
-	orderID, err := parseOrderID(req.GetOrderId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list work order checks")
-	}
-
 	db := database.DB(ctx)
-	factoryModel, err := models.FindFactory(db, orgID, factoryID)
+	factoryModel, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list work order checks")
 	}
 
-	order, err := factoryModel.FindWorkOrder(db, orderID)
+	order, err := findWorkOrder(db, factoryModel, req.GetOrderId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list work order checks")
 	}

--- a/pkg/grpc/actions/factories/list_work_order_events.go
+++ b/pkg/grpc/actions/factories/list_work_order_events.go
@@ -23,26 +23,16 @@ func ListWorkOrderEvents(ctx context.Context, organizationID string, req *pb.Lis
 		return nil, factoryErrorToStatus(err, "failed to list work order events")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list work order events")
-	}
-
-	orderID, err := parseOrderID(req.GetOrderId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list work order events")
-	}
-
 	limit := getWorkOrderEventsLimit(req.GetLimit())
 	before := getWorkOrderEventsBefore(req.GetBefore())
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list work order events")
 	}
 
-	order, err := factory.FindWorkOrder(db, orderID)
+	order, err := findWorkOrder(db, factory, req.GetOrderId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list work order events")
 	}

--- a/pkg/grpc/actions/factories/list_work_orders.go
+++ b/pkg/grpc/actions/factories/list_work_orders.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 )
 
@@ -14,13 +13,8 @@ func ListWorkOrders(ctx context.Context, organizationID string, req *pb.ListWork
 		return nil, factoryErrorToStatus(err, "failed to list work orders")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to list work orders")
-	}
-
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list work orders")
 	}

--- a/pkg/grpc/actions/factories/materialize_factory_app.go
+++ b/pkg/grpc/actions/factories/materialize_factory_app.go
@@ -19,19 +19,17 @@ func MaterializeFactoryAppTemplate(
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to materialize factory app template")
 	}
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to materialize factory app template")
-	}
 	appID, err := parseFactoryAppID(req.GetAppId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to materialize factory app template")
 	}
 
 	db := database.DB(ctx)
-	if _, err := models.FindFactory(db, orgID, factoryID); err != nil {
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
+	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to materialize factory app template")
 	}
+	factoryID := factory.ID
 	canvas, _, err := findFactoryAppForDefaults(db, orgID, factoryID, appID)
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to materialize factory app template")
@@ -61,20 +59,17 @@ func MaterializeFactoryAppDefaults(
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to materialize factory app defaults")
 	}
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to materialize factory app defaults")
-	}
 	appID, err := parseFactoryAppID(req.GetAppId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to materialize factory app defaults")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to materialize factory app defaults")
 	}
+	factoryID := factory.ID
 	canvas, version, err := findFactoryAppForDefaults(db, orgID, factoryID, appID)
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to materialize factory app defaults")

--- a/pkg/grpc/actions/factories/planning_session.go
+++ b/pkg/grpc/actions/factories/planning_session.go
@@ -332,10 +332,6 @@ func planningSessionActor(ctx context.Context, organizationID, factoryID string)
 	if err != nil {
 		return uuid.Nil, uuid.Nil, uuid.Nil, factoryErrorToStatus(err, "failed to load planning session")
 	}
-	parsedFactoryID, err := parseFactoryID(factoryID)
-	if err != nil {
-		return uuid.Nil, uuid.Nil, uuid.Nil, factoryErrorToStatus(err, "failed to load planning session")
-	}
 	userIDStr, ok := authentication.GetUserIdFromMetadata(ctx)
 	if !ok {
 		return uuid.Nil, uuid.Nil, uuid.Nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
@@ -344,7 +340,11 @@ func planningSessionActor(ctx context.Context, organizationID, factoryID string)
 	if err != nil {
 		return uuid.Nil, uuid.Nil, uuid.Nil, factoryErrorToStatus(invalidArgument("invalid user id"), "failed to load planning session")
 	}
-	return orgID, parsedFactoryID, userID, nil
+	factory, err := findFactory(database.DB(ctx), orgID, factoryID)
+	if err != nil {
+		return uuid.Nil, uuid.Nil, uuid.Nil, factoryErrorToStatus(err, "failed to load planning session")
+	}
+	return orgID, factory.ID, userID, nil
 }
 
 func parseSessionID(sessionID string) (uuid.UUID, error) {

--- a/pkg/grpc/actions/factories/search_factory_intake_items.go
+++ b/pkg/grpc/actions/factories/search_factory_intake_items.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 )
 
@@ -19,18 +18,13 @@ func SearchFactoryIntakeItems(
 		return nil, factoryErrorToStatus(err, "failed to search factory intake items")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to search factory intake items")
-	}
-
 	intakeID, err := parseIntakeID(req.GetIntakeId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to search factory intake items")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to search factory intake items")
 	}

--- a/pkg/grpc/actions/factories/sync_factory_velocity.go
+++ b/pkg/grpc/actions/factories/sync_factory_velocity.go
@@ -30,15 +30,11 @@ func SyncFactoryVelocity(
 		return nil, factoryErrorToStatus(err, "failed to sync factory velocity")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
+	factory, err := findFactory(database.DB(ctx), orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to sync factory velocity")
 	}
-
-	factory, err := models.FindFactory(database.DB(ctx), orgID, factoryID)
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to sync factory velocity")
-	}
+	factoryID := factory.ID
 
 	// A workspace with no repository has nothing to read, and the UI explains
 	// that instead of showing progress that never finishes.

--- a/pkg/grpc/actions/factories/update_factory.go
+++ b/pkg/grpc/actions/factories/update_factory.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 )
 
@@ -14,13 +13,8 @@ func UpdateFactory(ctx context.Context, organizationID string, req *pb.UpdateFac
 		return nil, factoryErrorToStatus(err, "failed to update factory")
 	}
 
-	id, err := parseFactoryID(req.GetId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update factory")
-	}
-
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, id)
+	factory, err := findFactory(db, orgID, req.GetId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory")
 	}

--- a/pkg/grpc/actions/factories/update_factory_intake.go
+++ b/pkg/grpc/actions/factories/update_factory_intake.go
@@ -28,18 +28,13 @@ func UpdateFactoryIntake(
 		return nil, factoryErrorToStatus(err, "failed to update factory intake")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update factory intake")
-	}
-
 	intakeID, err := parseIntakeID(req.GetIntakeId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory intake")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory intake")
 	}

--- a/pkg/grpc/actions/factories/update_factory_line.go
+++ b/pkg/grpc/actions/factories/update_factory_line.go
@@ -15,21 +15,17 @@ func UpdateFactoryLine(ctx context.Context, organizationID string, req *pb.Updat
 		return nil, factoryErrorToStatus(err, "failed to update factory line")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update factory line")
-	}
-
 	lineID, err := parseLineID(req.GetLineId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory line")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory line")
 	}
+	factoryID := factory.ID
 
 	line, err := factory.FindLine(db, lineID)
 	if err != nil {

--- a/pkg/grpc/actions/factories/update_factory_onboarding.go
+++ b/pkg/grpc/actions/factories/update_factory_onboarding.go
@@ -21,13 +21,8 @@ func UpdateFactoryOnboarding(
 		return nil, factoryErrorToStatus(err, "failed to update factory onboarding")
 	}
 
-	id, err := parseFactoryID(req.GetId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update factory onboarding")
-	}
-
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, id)
+	factory, err := findFactory(db, orgID, req.GetId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory onboarding")
 	}

--- a/pkg/grpc/actions/factories/update_factory_pr_feedback_handler.go
+++ b/pkg/grpc/actions/factories/update_factory_pr_feedback_handler.go
@@ -28,18 +28,13 @@ func UpdateFactoryPRFeedbackHandler(
 		return nil, factoryErrorToStatus(err, "failed to update factory PR feedback handler")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update factory PR feedback handler")
-	}
-
 	handlerID, err := parsePRFeedbackHandlerID(req.GetHandlerId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory PR feedback handler")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory PR feedback handler")
 	}

--- a/pkg/grpc/actions/factories/update_factory_pull_request.go
+++ b/pkg/grpc/actions/factories/update_factory_pull_request.go
@@ -21,18 +21,13 @@ func UpdateFactoryPullRequest(
 		return nil, factoryErrorToStatus(err, "failed to update factory pull request")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update factory pull request")
-	}
-
 	prID, err := parsePullRequestID(req.GetPrId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory pull request")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := findFactory(db, orgID, req.GetFactoryId())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory pull request")
 	}

--- a/pkg/grpc/actions/factories/update_factory_repository.go
+++ b/pkg/grpc/actions/factories/update_factory_repository.go
@@ -39,10 +39,6 @@ func UpdateFactoryRepository(
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory repository")
 	}
-	factoryID, err := parseFactoryID(req.GetId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update factory repository")
-	}
 	repository := strings.TrimSpace(req.GetRepository())
 	defaultBranch := strings.TrimSpace(req.GetDefaultBranch())
 	if repository == "" {
@@ -62,9 +58,12 @@ func UpdateFactoryRepository(
 	}
 
 	db := database.DB(ctx)
-	var factory *models.Factory
+	factory, err := findFactory(db, orgID, req.GetId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory repository")
+	}
 	err = db.Transaction(func(tx *gorm.DB) error {
-		loaded, err := models.FindFactory(tx, orgID, factoryID)
+		loaded, err := models.FindFactory(tx, orgID, factory.ID)
 		if err != nil {
 			return err
 		}

--- a/pkg/grpc/actions/factories/update_work_order.go
+++ b/pkg/grpc/actions/factories/update_work_order.go
@@ -32,22 +32,23 @@ func UpdateWorkOrder(
 		return nil, factoryErrorToStatus(err, "failed to update work order")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update work order")
-	}
-
-	orderID, err := parseOrderID(req.GetOrderId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update work order")
-	}
-
 	title, description, err := workOrderContentFromRequest(req)
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update work order")
 	}
 
 	db := database.DB(ctx)
+	resolvedFactory, err := findFactory(db, orgID, req.GetFactoryId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update work order")
+	}
+	factoryID := resolvedFactory.ID
+
+	resolvedOrder, err := findWorkOrder(db, resolvedFactory, req.GetOrderId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update work order")
+	}
+	orderID := resolvedOrder.ID
 	var bound storedfiles.BindResult
 	err = db.Transaction(func(tx *gorm.DB) error {
 		factory, err := models.FindFactory(tx, orgID, factoryID)

--- a/pkg/grpc/actions/factories/update_work_order_assignees.go
+++ b/pkg/grpc/actions/factories/update_work_order_assignees.go
@@ -35,17 +35,19 @@ func UpdateWorkOrderAssignees(
 		return nil, factoryErrorToStatus(invalidArgument("invalid user id"), "failed to update work order assignees")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update work order assignees")
-	}
-
-	orderID, err := parseOrderID(req.GetOrderId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update work order assignees")
-	}
-
 	tx := database.DB(ctx)
+	resolvedFactory, err := findFactory(tx, orgID, req.GetFactoryId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update work order assignees")
+	}
+	factoryID := resolvedFactory.ID
+
+	resolvedOrder, err := findWorkOrder(tx, resolvedFactory, req.GetOrderId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update work order assignees")
+	}
+	orderID := resolvedOrder.ID
+
 	assigneeIDs, err := parseAssigneeIDs(tx, orgID, req.GetAssigneeIds())
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update work order assignees")

--- a/pkg/grpc/actions/factories/update_work_order_status.go
+++ b/pkg/grpc/actions/factories/update_work_order_status.go
@@ -25,16 +25,6 @@ func UpdateWorkOrderStatus(
 		return nil, factoryErrorToStatus(err, "failed to update work order status")
 	}
 
-	factoryID, err := parseFactoryID(req.GetFactoryId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update work order status")
-	}
-
-	orderID, err := parseOrderID(req.GetOrderId())
-	if err != nil {
-		return nil, factoryErrorToStatus(err, "failed to update work order status")
-	}
-
 	toState, ok := workOrderStateFromProto(req.GetState())
 	if !ok {
 		return nil, factoryErrorToStatus(invalidArgument("state is required"), "failed to update work order status")
@@ -59,6 +49,18 @@ func UpdateWorkOrderStatus(
 	}
 
 	db := database.DB(ctx)
+	resolvedFactory, err := findFactory(db, orgID, req.GetFactoryId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update work order status")
+	}
+	factoryID := resolvedFactory.ID
+
+	resolvedOrder, err := findWorkOrder(db, resolvedFactory, req.GetOrderId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update work order status")
+	}
+	orderID := resolvedOrder.ID
+
 	var order *models.FactoryWorkOrder
 	var fromState string
 	var changed bool

--- a/pkg/grpc/actions/files/files.go
+++ b/pkg/grpc/actions/files/files.go
@@ -3,6 +3,7 @@ package files
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,13 +19,13 @@ import (
 )
 
 func CreateFactoryFile(ctx context.Context, organizationID string, req *pb.CreateFactoryFileRequest) (*pb.CreateFactoryFileResponse, error) {
-	orgID, factoryID, createdByID, err := parseWriteContext(ctx, organizationID, req.GetFactoryId())
+	createdByID, err := parseCreatedBy(ctx)
 	if err != nil {
 		return nil, fileErrorToStatus(err, "failed to create workspace file")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := resolveFactory(db, organizationID, req.GetFactoryId())
 	if err != nil {
 		return nil, fileErrorToStatus(err, "failed to create workspace file")
 	}
@@ -45,17 +46,13 @@ func CreateFactoryFile(ctx context.Context, organizationID string, req *pb.Creat
 }
 
 func ListFactoryFiles(ctx context.Context, organizationID string, req *pb.ListFactoryFilesRequest) (*pb.ListFactoryFilesResponse, error) {
-	orgID, factoryID, err := parseFactoryIDs(organizationID, req.GetFactoryId())
+	db := database.DB(ctx)
+	factory, err := resolveFactory(db, organizationID, req.GetFactoryId())
 	if err != nil {
 		return nil, fileErrorToStatus(err, "failed to list workspace files")
 	}
 
-	db := database.DB(ctx)
-	if _, err := models.FindFactory(db, orgID, factoryID); err != nil {
-		return nil, fileErrorToStatus(err, "failed to list workspace files")
-	}
-
-	records, err := models.ListReadyWorkspaceFiles(db, factoryID)
+	records, err := models.ListReadyWorkspaceFiles(db, factory.ID)
 	if err != nil {
 		return nil, fileErrorToStatus(err, "failed to list workspace files")
 	}
@@ -68,21 +65,18 @@ func ListFactoryFiles(ctx context.Context, organizationID string, req *pb.ListFa
 }
 
 func CreateWorkOrderFile(ctx context.Context, organizationID string, req *pb.CreateWorkOrderFileRequest) (*pb.CreateWorkOrderFileResponse, error) {
-	orgID, factoryID, createdByID, err := parseWriteContext(ctx, organizationID, req.GetFactoryId())
-	if err != nil {
-		return nil, fileErrorToStatus(err, "failed to create task file")
-	}
-	orderID, err := parseID(req.GetOrderId(), "order id")
+	createdByID, err := parseCreatedBy(ctx)
 	if err != nil {
 		return nil, fileErrorToStatus(err, "failed to create task file")
 	}
 
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := resolveFactory(db, organizationID, req.GetFactoryId())
 	if err != nil {
 		return nil, fileErrorToStatus(err, "failed to create task file")
 	}
-	if _, err := factory.FindWorkOrder(db, orderID); err != nil {
+	order, err := resolveWorkOrder(db, factory, req.GetOrderId())
+	if err != nil {
 		return nil, fileErrorToStatus(err, "failed to create task file")
 	}
 
@@ -90,7 +84,7 @@ func CreateWorkOrderFile(ctx context.Context, organizationID string, req *pb.Cre
 		Scope:          blob.ScopeTask,
 		OrganizationID: factory.OrganizationID,
 		FactoryID:      factory.ID,
-		WorkOrderID:    orderID,
+		WorkOrderID:    order.ID,
 		Filename:       req.GetFilename(),
 		ContentType:    req.GetContentType(),
 		CreatedByID:    createdByID,
@@ -103,25 +97,17 @@ func CreateWorkOrderFile(ctx context.Context, organizationID string, req *pb.Cre
 }
 
 func ListWorkOrderFiles(ctx context.Context, organizationID string, req *pb.ListWorkOrderFilesRequest) (*pb.ListWorkOrderFilesResponse, error) {
-	orgID, factoryID, err := parseFactoryIDs(organizationID, req.GetFactoryId())
-	if err != nil {
-		return nil, fileErrorToStatus(err, "failed to list task files")
-	}
-	orderID, err := parseID(req.GetOrderId(), "order id")
-	if err != nil {
-		return nil, fileErrorToStatus(err, "failed to list task files")
-	}
-
 	db := database.DB(ctx)
-	factory, err := models.FindFactory(db, orgID, factoryID)
+	factory, err := resolveFactory(db, organizationID, req.GetFactoryId())
 	if err != nil {
 		return nil, fileErrorToStatus(err, "failed to list task files")
 	}
-	if _, err := factory.FindWorkOrder(db, orderID); err != nil {
+	order, err := resolveWorkOrder(db, factory, req.GetOrderId())
+	if err != nil {
 		return nil, fileErrorToStatus(err, "failed to list task files")
 	}
 
-	records, err := models.ListReadyTaskFiles(db, orderID)
+	records, err := models.ListReadyTaskFiles(db, order.ID)
 	if err != nil {
 		return nil, fileErrorToStatus(err, "failed to list task files")
 	}
@@ -164,32 +150,34 @@ func serializeFile(file *models.File, downloadURL, uploadURL string) *pb.File {
 	return serialized
 }
 
-func parseWriteContext(ctx context.Context, organizationID, factoryID string) (uuid.UUID, uuid.UUID, uuid.UUID, error) {
-	orgID, factoryUUID, err := parseFactoryIDs(organizationID, factoryID)
-	if err != nil {
-		return uuid.Nil, uuid.Nil, uuid.Nil, err
-	}
+func parseCreatedBy(ctx context.Context) (uuid.UUID, error) {
 	userID, ok := authentication.GetUserIdFromMetadata(ctx)
 	if !ok {
-		return uuid.Nil, uuid.Nil, uuid.Nil, errUnauthenticated
+		return uuid.Nil, errUnauthenticated
 	}
 	createdByID, err := uuid.Parse(userID)
 	if err != nil {
-		return uuid.Nil, uuid.Nil, uuid.Nil, invalidArgument("invalid user id")
+		return uuid.Nil, invalidArgument("invalid user id")
 	}
-	return orgID, factoryUUID, createdByID, nil
+	return createdByID, nil
 }
 
-func parseFactoryIDs(organizationID, factoryID string) (uuid.UUID, uuid.UUID, error) {
+func resolveFactory(db *gorm.DB, organizationID, factoryRef string) (*models.Factory, error) {
 	orgID, err := parseID(organizationID, "organization id")
 	if err != nil {
-		return uuid.Nil, uuid.Nil, err
+		return nil, err
 	}
-	factoryUUID, err := parseID(factoryID, "factory id")
-	if err != nil {
-		return uuid.Nil, uuid.Nil, err
+	if strings.TrimSpace(factoryRef) == "" {
+		return nil, invalidArgument("invalid factory id")
 	}
-	return orgID, factoryUUID, nil
+	return models.FindFactoryByRef(db, orgID, factoryRef)
+}
+
+func resolveWorkOrder(db *gorm.DB, factory *models.Factory, orderRef string) (*models.FactoryWorkOrder, error) {
+	if strings.TrimSpace(orderRef) == "" {
+		return nil, invalidArgument("invalid order id")
+	}
+	return factory.FindWorkOrderByRef(db, orderRef)
 }
 
 func parseID(value, name string) (uuid.UUID, error) {

--- a/pkg/models/factory.go
+++ b/pkg/models/factory.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -227,6 +228,51 @@ func FindFactoryByKey(tx *gorm.DB, organizationID uuid.UUID, key string) (*Facto
 	var factory Factory
 	err := tx.
 		Where("organization_id = ? AND key = ?", organizationID, normalized).
+		First(&factory).
+		Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrFactoryNotFound
+		}
+		return nil, err
+	}
+
+	return &factory, nil
+}
+
+// FindFactoryByRef resolves ref to a factory. ref is tried as a UUID first,
+// then as a workspace key, then as a workspace name. Callers that receive a
+// factory identifier from a client path or flag go through this helper so
+// UUID, key, and name URLs keep working against the same UUID-keyed data.
+func FindFactoryByRef(tx *gorm.DB, organizationID uuid.UUID, ref string) (*Factory, error) {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return nil, ErrFactoryNotFound
+	}
+	if id, err := uuid.Parse(trimmed); err == nil {
+		return FindFactory(tx, organizationID, id)
+	}
+
+	normalizedKey := NormalizeFactoryKey(trimmed)
+	if ValidateFactoryKey(normalizedKey) == nil {
+		factory, err := FindFactoryByKey(tx, organizationID, normalizedKey)
+		if err == nil || !errors.Is(err, ErrFactoryNotFound) {
+			return factory, err
+		}
+	}
+
+	return FindFactoryByName(tx, organizationID, trimmed)
+}
+
+func FindFactoryByName(tx *gorm.DB, organizationID uuid.UUID, name string) (*Factory, error) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return nil, ErrFactoryNotFound
+	}
+
+	var factory Factory
+	err := tx.
+		Where("organization_id = ? AND LOWER(name) = LOWER(?)", organizationID, trimmed).
 		First(&factory).
 		Error
 	if err != nil {
@@ -706,12 +752,50 @@ func (f *Factory) ListWorkOrdersByArtifactKeys(tx *gorm.DB, keys []string) (map[
 }
 
 func (f *Factory) FindWorkOrder(tx *gorm.DB, orderID uuid.UUID) (*FactoryWorkOrder, error) {
+	return f.findWorkOrder(tx, "id = ?", orderID)
+}
+
+func (f *Factory) FindWorkOrderByNumber(tx *gorm.DB, number int64) (*FactoryWorkOrder, error) {
+	return f.findWorkOrder(tx, "number = ?", number)
+}
+
+// FindWorkOrderByRef resolves ref to a work order in this factory. ref is
+// tried as a UUID first, then as the factory-scoped sequence number, then
+// as the display key (for example `SP-42`).
+func (f *Factory) FindWorkOrderByRef(tx *gorm.DB, ref string) (*FactoryWorkOrder, error) {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return nil, ErrFactoryWorkOrderNotFound
+	}
+	if id, err := uuid.Parse(trimmed); err == nil {
+		return f.FindWorkOrder(tx, id)
+	}
+	if number, err := strconv.ParseInt(trimmed, 10, 64); err == nil && number > 0 {
+		return f.FindWorkOrderByNumber(tx, number)
+	}
+	return f.findWorkOrderByKey(tx, trimmed)
+}
+
+func (f *Factory) findWorkOrderByKey(tx *gorm.DB, key string) (*FactoryWorkOrder, error) {
+	prefix := f.Key + "-"
+	if !strings.HasPrefix(strings.ToUpper(key), strings.ToUpper(prefix)) {
+		return nil, ErrFactoryWorkOrderNotFound
+	}
+	number, err := strconv.ParseInt(key[len(prefix):], 10, 64)
+	if err != nil || number <= 0 {
+		return nil, ErrFactoryWorkOrderNotFound
+	}
+	return f.FindWorkOrderByNumber(tx, number)
+}
+
+func (f *Factory) findWorkOrder(tx *gorm.DB, cond string, arg any) (*FactoryWorkOrder, error) {
 	var order FactoryWorkOrder
 	err := tx.
 		Preload("CreatedBy").
 		Preload("Assignees").
 		Preload("Assignees.User").
-		Where("organization_id = ? AND factory_id = ? AND id = ?", f.OrganizationID, f.ID, orderID).
+		Where("organization_id = ? AND factory_id = ?", f.OrganizationID, f.ID).
+		Where(cond, arg).
 		First(&order).
 		Error
 	if err != nil {

--- a/pkg/models/factory.go
+++ b/pkg/models/factory.go
@@ -110,6 +110,13 @@ func MapFactoryNameUniqueConstraintError(err error) error {
 	return MapFactoryConstraintError(err)
 }
 
+// WorkOrderKey returns the display identifier used for a work order that
+// belongs to this factory. Format matches `<KEY>-<number>` (for example
+// `SP-42`).
+func (f *Factory) WorkOrderKey(number int64) string {
+	return fmt.Sprintf("%s-%d", f.Key, number)
+}
+
 func CreateFactory(tx *gorm.DB, organizationID uuid.UUID, name, description, key string) (*Factory, error) {
 	normalizedKey := NormalizeFactoryKey(key)
 	if normalizedKey == "" {
@@ -240,9 +247,11 @@ func FindFactoryByKey(tx *gorm.DB, organizationID uuid.UUID, key string) (*Facto
 	return &factory, nil
 }
 
-// FindFactoryByRef resolves ref to a factory. ref is tried as a UUID first,
-// then as a workspace key. Workspace names are not accepted: they can
-// contain spaces and do not belong in `/factories/{id}` paths.
+// FindFactoryByRef resolves ref to a factory. ref is a UUID or a workspace
+// key. Workspace names are not accepted.
+//
+// Names can contain spaces, so they do not belong in `/factories/{id}`.
+// Names are also not unique in an organization.
 func FindFactoryByRef(tx *gorm.DB, organizationID uuid.UUID, ref string) (*Factory, error) {
 	trimmed := strings.TrimSpace(ref)
 	if trimmed == "" {
@@ -746,38 +755,6 @@ func (f *Factory) FindWorkOrderByRef(tx *gorm.DB, ref string) (*FactoryWorkOrder
 	return f.findWorkOrderByKey(tx, trimmed)
 }
 
-func (f *Factory) findWorkOrderByKey(tx *gorm.DB, key string) (*FactoryWorkOrder, error) {
-	prefix := f.Key + "-"
-	if !strings.HasPrefix(strings.ToUpper(key), strings.ToUpper(prefix)) {
-		return nil, ErrFactoryWorkOrderNotFound
-	}
-	number, err := strconv.ParseInt(key[len(prefix):], 10, 64)
-	if err != nil || number <= 0 {
-		return nil, ErrFactoryWorkOrderNotFound
-	}
-	return f.FindWorkOrderByNumber(tx, number)
-}
-
-func (f *Factory) findWorkOrder(tx *gorm.DB, cond string, arg any) (*FactoryWorkOrder, error) {
-	var order FactoryWorkOrder
-	err := tx.
-		Preload("CreatedBy").
-		Preload("Assignees").
-		Preload("Assignees.User").
-		Where("organization_id = ? AND factory_id = ?", f.OrganizationID, f.ID).
-		Where(cond, arg).
-		First(&order).
-		Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrFactoryWorkOrderNotFound
-		}
-		return nil, err
-	}
-
-	return &order, nil
-}
-
 type ListFactoryWorkOrdersFilters struct {
 	AssigneeIDs []uuid.UUID
 	States      []string
@@ -843,6 +820,38 @@ func (f *Factory) ListWorkOrders(tx *gorm.DB, filters ListFactoryWorkOrdersFilte
 	return orders, nil
 }
 
+func (f *Factory) findWorkOrderByKey(tx *gorm.DB, key string) (*FactoryWorkOrder, error) {
+	prefix := f.Key + "-"
+	if !strings.HasPrefix(strings.ToUpper(key), strings.ToUpper(prefix)) {
+		return nil, ErrFactoryWorkOrderNotFound
+	}
+	number, err := strconv.ParseInt(key[len(prefix):], 10, 64)
+	if err != nil || number <= 0 {
+		return nil, ErrFactoryWorkOrderNotFound
+	}
+	return f.FindWorkOrderByNumber(tx, number)
+}
+
+func (f *Factory) findWorkOrder(tx *gorm.DB, cond string, arg any) (*FactoryWorkOrder, error) {
+	var order FactoryWorkOrder
+	err := tx.
+		Preload("CreatedBy").
+		Preload("Assignees").
+		Preload("Assignees.User").
+		Where("organization_id = ? AND factory_id = ?", f.OrganizationID, f.ID).
+		Where(cond, arg).
+		First(&order).
+		Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrFactoryWorkOrderNotFound
+		}
+		return nil, err
+	}
+
+	return &order, nil
+}
+
 // allocateNextWorkOrderNumber atomically increments the factory's counter
 // and returns the value that the new work order should use. The UPDATE ...
 // RETURNING pattern serializes concurrent inserts inside Postgres without
@@ -866,11 +875,4 @@ func (f *Factory) allocateNextWorkOrderNumber(tx *gorm.DB) (int64, error) {
 
 	f.NextWorkOrderNumber = allocated + 1
 	return allocated, nil
-}
-
-// WorkOrderKey returns the display identifier used for a work order that
-// belongs to this factory. Format matches `<KEY>-<number>` (for example
-// `SP-42`).
-func (f *Factory) WorkOrderKey(number int64) string {
-	return fmt.Sprintf("%s-%d", f.Key, number)
 }

--- a/pkg/models/factory.go
+++ b/pkg/models/factory.go
@@ -241,9 +241,8 @@ func FindFactoryByKey(tx *gorm.DB, organizationID uuid.UUID, key string) (*Facto
 }
 
 // FindFactoryByRef resolves ref to a factory. ref is tried as a UUID first,
-// then as a workspace key, then as a workspace name. Callers that receive a
-// factory identifier from a client path or flag go through this helper so
-// UUID, key, and name URLs keep working against the same UUID-keyed data.
+// then as a workspace key. Workspace names are not accepted: they can
+// contain spaces and do not belong in `/factories/{id}` paths.
 func FindFactoryByRef(tx *gorm.DB, organizationID uuid.UUID, ref string) (*Factory, error) {
 	trimmed := strings.TrimSpace(ref)
 	if trimmed == "" {
@@ -253,36 +252,7 @@ func FindFactoryByRef(tx *gorm.DB, organizationID uuid.UUID, ref string) (*Facto
 		return FindFactory(tx, organizationID, id)
 	}
 
-	normalizedKey := NormalizeFactoryKey(trimmed)
-	if ValidateFactoryKey(normalizedKey) == nil {
-		factory, err := FindFactoryByKey(tx, organizationID, normalizedKey)
-		if err == nil || !errors.Is(err, ErrFactoryNotFound) {
-			return factory, err
-		}
-	}
-
-	return FindFactoryByName(tx, organizationID, trimmed)
-}
-
-func FindFactoryByName(tx *gorm.DB, organizationID uuid.UUID, name string) (*Factory, error) {
-	trimmed := strings.TrimSpace(name)
-	if trimmed == "" {
-		return nil, ErrFactoryNotFound
-	}
-
-	var factory Factory
-	err := tx.
-		Where("organization_id = ? AND LOWER(name) = LOWER(?)", organizationID, trimmed).
-		First(&factory).
-		Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrFactoryNotFound
-		}
-		return nil, err
-	}
-
-	return &factory, nil
+	return FindFactoryByKey(tx, organizationID, trimmed)
 }
 
 func ListFactories(tx *gorm.DB, organizationID uuid.UUID) ([]Factory, error) {

--- a/pkg/models/factory_key_test.go
+++ b/pkg/models/factory_key_test.go
@@ -85,6 +85,70 @@ func TestCreateFactory_RejectsDuplicateKey(t *testing.T) {
 	assert.ErrorIs(t, err, models.ErrFactoryKeyAlreadyExists)
 }
 
+func TestFindFactoryByRef(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+
+	factory, err := models.CreateFactory(db, r.Organization.ID, "SuperPlane", "", "SUPER")
+	require.NoError(t, err)
+
+	t.Run("finds by UUID", func(t *testing.T) {
+		found, err := models.FindFactoryByRef(db, r.Organization.ID, factory.ID.String())
+		require.NoError(t, err)
+		assert.Equal(t, factory.ID, found.ID)
+	})
+
+	t.Run("finds by key case-insensitively", func(t *testing.T) {
+		found, err := models.FindFactoryByRef(db, r.Organization.ID, "super")
+		require.NoError(t, err)
+		assert.Equal(t, factory.ID, found.ID)
+	})
+
+	t.Run("finds by name case-insensitively", func(t *testing.T) {
+		found, err := models.FindFactoryByRef(db, r.Organization.ID, "superplane")
+		require.NoError(t, err)
+		assert.Equal(t, factory.ID, found.ID)
+	})
+
+	t.Run("returns not found for unknown ref", func(t *testing.T) {
+		_, err := models.FindFactoryByRef(db, r.Organization.ID, "missing")
+		assert.ErrorIs(t, err, models.ErrFactoryNotFound)
+	})
+}
+
+func TestFindWorkOrderByRef(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+
+	factory, err := models.CreateFactory(db, r.Organization.ID, "Numbers", "", "NUM")
+	require.NoError(t, err)
+	order, err := factory.CreateWorkOrder(db, "one", "", &r.User, nil, nil)
+	require.NoError(t, err)
+
+	t.Run("finds by UUID", func(t *testing.T) {
+		found, err := factory.FindWorkOrderByRef(db, order.ID.String())
+		require.NoError(t, err)
+		assert.Equal(t, order.ID, found.ID)
+	})
+
+	t.Run("finds by number", func(t *testing.T) {
+		found, err := factory.FindWorkOrderByRef(db, "1")
+		require.NoError(t, err)
+		assert.Equal(t, order.ID, found.ID)
+	})
+
+	t.Run("finds by key case-insensitively", func(t *testing.T) {
+		found, err := factory.FindWorkOrderByRef(db, "num-1")
+		require.NoError(t, err)
+		assert.Equal(t, order.ID, found.ID)
+	})
+
+	t.Run("returns not found for unknown ref", func(t *testing.T) {
+		_, err := factory.FindWorkOrderByRef(db, "99")
+		assert.ErrorIs(t, err, models.ErrFactoryWorkOrderNotFound)
+	})
+}
+
 func TestCreateWorkOrder_AllocatesSequentialNumbers(t *testing.T) {
 	r := support.Setup(t)
 	db := database.DB(t.Context())

--- a/pkg/models/factory_key_test.go
+++ b/pkg/models/factory_key_test.go
@@ -104,14 +104,13 @@ func TestFindFactoryByRef(t *testing.T) {
 		assert.Equal(t, factory.ID, found.ID)
 	})
 
-	t.Run("finds by name case-insensitively", func(t *testing.T) {
-		found, err := models.FindFactoryByRef(db, r.Organization.ID, "superplane")
-		require.NoError(t, err)
-		assert.Equal(t, factory.ID, found.ID)
+	t.Run("rejects a workspace name", func(t *testing.T) {
+		_, err := models.FindFactoryByRef(db, r.Organization.ID, "SuperPlane")
+		assert.ErrorIs(t, err, models.ErrFactoryKeyInvalid)
 	})
 
-	t.Run("returns not found for unknown ref", func(t *testing.T) {
-		_, err := models.FindFactoryByRef(db, r.Organization.ID, "missing")
+	t.Run("returns not found for unknown key", func(t *testing.T) {
+		_, err := models.FindFactoryByRef(db, r.Organization.ID, "ZZZZ")
 		assert.ErrorIs(t, err, models.ErrFactoryNotFound)
 	})
 }

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -57,7 +57,7 @@ service Factories {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Describe factory";
-      description: "Returns a factory by its ID";
+      description: "Returns a factory by ID, workspace key, or name";
       tags: "Factory";
     };
   }
@@ -395,7 +395,7 @@ service Factories {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Describe factory work order";
-      description: "Returns a work order by its ID";
+      description: "Returns a work order by ID, number, or key";
       tags: "Factory";
     };
   }
@@ -725,6 +725,7 @@ message CreateFactoryResponse {
 }
 
 message DescribeFactoryRequest {
+  // Factory UUID, workspace key, or workspace name.
   string id = 1;
 }
 
@@ -1582,7 +1583,9 @@ message WorkOrderExecutionStep {
 }
 
 message DescribeWorkOrderRequest {
+  // Factory UUID, workspace key, or workspace name.
   string factory_id = 1;
+  // Work order UUID, sequence number, or display key (for example `SP-42`).
   string order_id = 2;
 }
 

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -57,7 +57,7 @@ service Factories {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Describe factory";
-      description: "Returns a factory by ID, workspace key, or name";
+      description: "Returns a factory by ID or workspace key";
       tags: "Factory";
     };
   }
@@ -725,7 +725,7 @@ message CreateFactoryResponse {
 }
 
 message DescribeFactoryRequest {
-  // Factory UUID, workspace key, or workspace name.
+  // Factory UUID or workspace key.
   string id = 1;
 }
 
@@ -1583,7 +1583,7 @@ message WorkOrderExecutionStep {
 }
 
 message DescribeWorkOrderRequest {
-  // Factory UUID, workspace key, or workspace name.
+  // Factory UUID or workspace key.
   string factory_id = 1;
   // Work order UUID, sequence number, or display key (for example `SP-42`).
   string order_id = 2;

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -57,7 +57,7 @@ service Factories {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Describe factory";
-      description: "Returns a factory by ID or workspace key";
+      description: "Returns a factory by ID or workspace key. Workspace names are not accepted: they are not unique and can contain spaces.";
       tags: "Factory";
     };
   }
@@ -725,7 +725,8 @@ message CreateFactoryResponse {
 }
 
 message DescribeFactoryRequest {
-  // Factory UUID or workspace key.
+  // Factory UUID or workspace key. Workspace names are not accepted:
+  // they are not unique and can contain spaces.
   string id = 1;
 }
 
@@ -1583,7 +1584,8 @@ message WorkOrderExecutionStep {
 }
 
 message DescribeWorkOrderRequest {
-  // Factory UUID or workspace key.
+  // Factory UUID or workspace key. Workspace names are not accepted:
+  // they are not unique and can contain spaces.
   string factory_id = 1;
   // Work order UUID, sequence number, or display key (for example `SP-42`).
   string order_id = 2;


### PR DESCRIPTION
Task and workspace CLI commands required UUIDs. Users already use the workspace
key and the task number in the product URL.

This change lets factory and work-order APIs accept those identifiers in the
path. A workspace path can be a UUID, or a workspace key,
A work-order path can be a UUID, a task number, or a display key such as
`SUPER-1823`.

The CLI sends the flag values to the API. It does not list all workspaces or
tasks to resolve them. List and describe output show the task number so a user
can copy it into later commands.

### Scope

- **API:** Factory and work-order path parameters resolve through
  `FindFactoryByRef` and `FindWorkOrderByRef`. File endpoints for workspaces
  and tasks use the same lookup. UUID paths stay valid.
- **CLI:** `--workspace` accepts a name, key, or UUID. `--task` accepts a
  number, key, or UUID. `workspace active` still stores a UUID.






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63229584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR is not safe to merge because the unresolved workspace-name compatibility issue still breaks a stated CLI input form.

<sub>Reviews (3) · Last reviewed commit: ["address comments"](https://github.com/superplanehq/superplane/commit/7c92d868b042471711a765031a87117dd0ff1d4c)</sub>

<!-- /greptile_comment -->