### PR TITLE
feat(cli): list and describe workspaces

### DIFF
--- a/pkg/cli/commands/workspaces/active.go
+++ b/pkg/cli/commands/workspaces/active.go
@@ -35,7 +35,7 @@ func (c *activeCommand) setActive(ctx core.CommandContext, nameOrID string) erro
 func (c *activeCommand) printActive(ctx core.CommandContext) error {
 	active := strings.TrimSpace(ctx.Config.GetActiveWorkspace())
 	if active == "" {
-		return fmt.Errorf("no active workspace; pass a name, key, or id, or run interactively")
+		return fmt.Errorf("no active workspace; pass a key or id, or run interactively")
 	}
 	if !ctx.Renderer.IsText() {
 		return ctx.Renderer.Render(map[string]string{"id": active})

--- a/pkg/cli/commands/workspaces/describe.go
+++ b/pkg/cli/commands/workspaces/describe.go
@@ -1,0 +1,82 @@
+package workspaces
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/superplanehq/superplane/pkg/cli/core"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+func resolveDescribeWorkspace(ctx core.CommandContext, workspaceFlag *string) (string, error) {
+	flagValue := ""
+	if workspaceFlag != nil {
+		flagValue = strings.TrimSpace(*workspaceFlag)
+	}
+
+	positional := ""
+	if len(ctx.Args) == 1 {
+		positional = strings.TrimSpace(ctx.Args[0])
+	}
+
+	if flagValue != "" && positional != "" {
+		return "", fmt.Errorf("pass a workspace argument or --workspace, not both")
+	}
+
+	ref := flagValue
+	if ref == "" {
+		ref = positional
+	}
+	return ResolveWorkspaceID(ctx, ref)
+}
+
+type describeCommand struct {
+	workspace *string
+}
+
+func (c *describeCommand) Execute(ctx core.CommandContext) error {
+	workspaceRef, err := resolveDescribeWorkspace(ctx, c.workspace)
+	if err != nil {
+		return err
+	}
+
+	response, _, err := ctx.API.FactoryAPI.FactoriesDescribeFactory(ctx.Context, workspaceRef).Execute()
+	if err != nil {
+		return err
+	}
+
+	workspace := response.GetFactory()
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(workspace)
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		return renderWorkspaceDescribeText(stdout, workspace)
+	})
+}
+
+func renderWorkspaceDescribeText(stdout io.Writer, workspace openapi_client.FactoriesFactory) error {
+	writer := tabwriter.NewWriter(stdout, 0, 8, 2, ' ', 0)
+	_, _ = fmt.Fprintf(writer, "Key\t%s\n", workspace.GetKey())
+	_, _ = fmt.Fprintf(writer, "Name\t%s\n", workspace.GetName())
+	_, _ = fmt.Fprintf(writer, "ID\t%s\n", workspace.GetId())
+	_, _ = fmt.Fprintf(writer, "Lines\t%s\n", formatWorkspaceLineNames(workspace.GetLines()))
+	return writer.Flush()
+}
+
+func formatWorkspaceLineNames(lines []openapi_client.FactoriesFactoryLine) string {
+	names := make([]string, 0, len(lines))
+	for _, line := range lines {
+		name := strings.TrimSpace(line.GetName())
+		if name == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return "(none)"
+	}
+	return strings.Join(names, ", ")
+}

--- a/pkg/cli/commands/workspaces/describe_test.go
+++ b/pkg/cli/commands/workspaces/describe_test.go
@@ -1,0 +1,103 @@
+package workspaces
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	cli "github.com/superplanehq/superplane/test/support/cli"
+)
+
+const describeFactoryPayload = `{
+  "factory": {
+    "id": "11111111-1111-1111-1111-111111111111",
+    "name": "SuperPlane",
+    "key": "SUPER",
+    "description": "Primary workspace",
+    "lines": [
+      {"id": "line-1", "name": "build", "steps": [{"type": "app"}, {"type": "app"}]},
+      {"id": "line-2", "name": "review", "steps": [{"type": "app"}]}
+    ]
+  }
+}`
+
+func newDescribeFactoryServer(t *testing.T, wantFactoryPath string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, wantFactoryPath, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(describeFactoryPayload))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestDescribeCommandUsesPositionalKey(t *testing.T) {
+	ctx, stdout := cli.NewCommandContext(t, newDescribeFactoryServer(t, "/api/v1/factories/super"), "text")
+	ctx.Args = []string{"super"}
+
+	require.NoError(t, (&describeCommand{}).Execute(ctx))
+
+	out := stdout.String()
+	require.Contains(t, out, "SUPER")
+	require.Contains(t, out, "SuperPlane")
+	require.Contains(t, out, "11111111-1111-1111-1111-111111111111")
+	require.NotContains(t, out, "Description:")
+	require.NotContains(t, out, "Primary workspace")
+	require.Contains(t, out, "build, review")
+	require.NotContains(t, out, "step")
+	require.NotContains(t, out, "Tasks")
+}
+
+func TestDescribeCommandUsesWorkspaceFlag(t *testing.T) {
+	workspace := "ship"
+	ctx, stdout := cli.NewCommandContextWithConfig(
+		t,
+		newDescribeFactoryServer(t, "/api/v1/factories/ship"),
+		"text",
+		&cli.FakeConfig{ActiveWorkspace: "11111111-1111-1111-1111-111111111111"},
+	)
+
+	require.NoError(t, (&describeCommand{workspace: &workspace}).Execute(ctx))
+	require.Contains(t, stdout.String(), "SUPER")
+}
+
+func TestDescribeCommandUsesActiveWorkspace(t *testing.T) {
+	workspaceID := "11111111-1111-1111-1111-111111111111"
+	ctx, stdout := cli.NewCommandContextWithConfig(
+		t,
+		newDescribeFactoryServer(t, "/api/v1/factories/"+workspaceID),
+		"text",
+		&cli.FakeConfig{ActiveWorkspace: workspaceID},
+	)
+
+	require.NoError(t, (&describeCommand{}).Execute(ctx))
+	require.Contains(t, stdout.String(), "SUPER")
+}
+
+func TestDescribeCommandRendersJSON(t *testing.T) {
+	ctx, stdout := cli.NewCommandContext(t, newDescribeFactoryServer(t, "/api/v1/factories/super"), "json")
+	ctx.Args = []string{"super"}
+
+	require.NoError(t, (&describeCommand{}).Execute(ctx))
+	require.Contains(t, stdout.String(), `"key": "SUPER"`)
+	require.Contains(t, stdout.String(), `"name": "build"`)
+}
+
+func TestDescribeCommandRequiresWorkspace(t *testing.T) {
+	ctx, _ := cli.NewCommandContextWithConfig(t, nil, "text", &cli.FakeConfig{})
+	err := (&describeCommand{}).Execute(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "superplane workspace active")
+}
+
+func TestDescribeCommandRejectsFlagAndArgument(t *testing.T) {
+	workspace := "ship"
+	ctx, _ := cli.NewCommandContextWithConfig(t, nil, "text", &cli.FakeConfig{})
+	ctx.Args = []string{"super"}
+	err := (&describeCommand{workspace: &workspace}).Execute(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not both")
+}

--- a/pkg/cli/commands/workspaces/list.go
+++ b/pkg/cli/commands/workspaces/list.go
@@ -1,0 +1,60 @@
+package workspaces
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/superplanehq/superplane/pkg/cli/core"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+type listCommand struct{}
+
+func (c *listCommand) Execute(ctx core.CommandContext) error {
+	response, _, err := ctx.API.FactoryAPI.FactoriesListFactories(ctx.Context).Execute()
+	if err != nil {
+		return err
+	}
+
+	workspaces := response.GetFactories()
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(workspaces)
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		return renderWorkspaceListText(stdout, workspaces, activeWorkspaceID(ctx))
+	})
+}
+
+func renderWorkspaceListText(stdout io.Writer, workspaces []openapi_client.FactoriesFactory, activeID string) error {
+	if len(workspaces) == 0 {
+		_, err := fmt.Fprintln(stdout, "No workspaces found.")
+		return err
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 8, 2, ' ', 0)
+	_, _ = fmt.Fprintln(writer, "KEY\tNAME\tACTIVE\tID")
+	for _, workspace := range workspaces {
+		active := ""
+		if activeID != "" && workspace.GetId() == activeID {
+			active = "*"
+		}
+		_, _ = fmt.Fprintf(
+			writer,
+			"%s\t%s\t%s\t%s\n",
+			workspace.GetKey(),
+			workspace.GetName(),
+			active,
+			workspace.GetId(),
+		)
+	}
+	return writer.Flush()
+}
+
+func activeWorkspaceID(ctx core.CommandContext) string {
+	if ctx.Config == nil {
+		return ""
+	}
+	return ctx.Config.GetActiveWorkspace()
+}

--- a/pkg/cli/commands/workspaces/list_test.go
+++ b/pkg/cli/commands/workspaces/list_test.go
@@ -1,0 +1,78 @@
+package workspaces
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	cli "github.com/superplanehq/superplane/test/support/cli"
+)
+
+const listFactoriesPayload = `{
+  "factories": [
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "name": "SuperPlane",
+      "key": "SUPER",
+      "description": "Primary workspace"
+    },
+    {
+      "id": "22222222-2222-2222-2222-222222222222",
+      "name": "Shipping",
+      "key": "SHIP"
+    }
+  ]
+}`
+
+func newListFactoriesServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/factories", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listFactoriesPayload))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestListCommandRendersText(t *testing.T) {
+	ctx, stdout := cli.NewCommandContextWithConfig(t, newListFactoriesServer(t), "text", &cli.FakeConfig{
+		ActiveWorkspace: "11111111-1111-1111-1111-111111111111",
+	})
+
+	require.NoError(t, (&listCommand{}).Execute(ctx))
+
+	out := stdout.String()
+	require.Contains(t, out, "KEY")
+	require.Contains(t, out, "NAME")
+	require.Contains(t, out, "ID")
+	require.Contains(t, out, "SUPER")
+	require.Contains(t, out, "SuperPlane")
+	require.Contains(t, out, "SHIP")
+	require.Contains(t, out, "*")
+}
+
+func TestListCommandRendersJSON(t *testing.T) {
+	ctx, stdout := cli.NewCommandContext(t, newListFactoriesServer(t), "json")
+
+	require.NoError(t, (&listCommand{}).Execute(ctx))
+
+	out := stdout.String()
+	require.Contains(t, out, `"key": "SUPER"`)
+	require.Contains(t, out, `"name": "Shipping"`)
+}
+
+func TestListCommandShowsEmptyState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/factories", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"factories":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, stdout := cli.NewCommandContext(t, server, "text")
+	require.NoError(t, (&listCommand{}).Execute(ctx))
+	require.Contains(t, stdout.String(), "No workspaces found.")
+}

--- a/pkg/cli/commands/workspaces/root.go
+++ b/pkg/cli/commands/workspaces/root.go
@@ -12,6 +12,39 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Aliases: []string{"workspaces"},
 	}
 
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List workspaces",
+		Long: `List workspaces in the current organization.
+
+The KEY column is the workspace key used by --workspace and other commands.
+
+Example:
+  superplane workspaces list`,
+		Args: cobra.NoArgs,
+	}
+	core.Bind(listCmd, &listCommand{}, options)
+
+	var describeWorkspace string
+	describeCmd := &cobra.Command{
+		Use:   "describe [workspace]",
+		Short: "Show workspace details",
+		Long: `Show a workspace key, name, id, and lines.
+
+Pass a workspace key or UUID as an argument or with --workspace.
+When both are omitted, the active workspace from
+"superplane workspace active" is used.
+
+Examples:
+  superplane workspaces describe super
+  superplane workspaces describe --workspace super`,
+		Args: cobra.MaximumNArgs(1),
+	}
+	describeCmd.Flags().StringVar(&describeWorkspace, "workspace", "", "workspace key or UUID (default: active workspace)")
+	core.Bind(describeCmd, &describeCommand{
+		workspace: &describeWorkspace,
+	}, options)
+
 	activeCmd := &cobra.Command{
 		Use:   "active [workspace]",
 		Short: "Set or show the active workspace",
@@ -23,6 +56,8 @@ to pick from a list. Non-interactive with no args prints the active workspace id
 	}
 	core.Bind(activeCmd, &activeCommand{}, options)
 
+	root.AddCommand(listCmd)
+	root.AddCommand(describeCmd)
 	root.AddCommand(activeCmd)
 
 	return root

--- a/pkg/cli/commands/workspaces/root_test.go
+++ b/pkg/cli/commands/workspaces/root_test.go
@@ -11,6 +11,17 @@ import (
 func TestNewCommand_Hierarchy(t *testing.T) {
 	root := NewCommand(core.BindOptions{})
 
+	listCmd, _, err := root.Find([]string{"list"})
+	require.NoError(t, err)
+	require.NotNil(t, listCmd)
+	assert.Contains(t, listCmd.Use, "list")
+
+	describeCmd, _, err := root.Find([]string{"describe"})
+	require.NoError(t, err)
+	require.NotNil(t, describeCmd)
+	assert.Contains(t, describeCmd.Use, "describe")
+	require.NotNil(t, describeCmd.Flags().Lookup("workspace"))
+
 	activeCmd, _, err := root.Find([]string{"active"})
 	require.NoError(t, err)
 	require.NotNil(t, activeCmd)


### PR DESCRIPTION
<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63252952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge, with a non-blocking test-strengthening opportunity for the active-workspace marker.

<sub>Reviews (1) · Last reviewed commit: ["feat(cli): list and describe workspaces"](https://github.com/superplanehq/superplane/commit/bfb4a478b9e65f4f5d70447d902b67f45f050da0)</sub>

<!-- /greptile_comment -->