### PR TITLE
fix: Show OpenRouter turn tokens in usage chart

### DIFF
--- a/pkg/components/runner/openrouter/run.js
+++ b/pkg/components/runner/openrouter/run.js
@@ -356,6 +356,8 @@ async function runPrompt(promptFile, model, helpers = {}) {
   });
   const loadSessionUsage = helpers.readSessionUsage || readSessionUsage;
   const sessionUsageBefore = loadSessionUsage(sp);
+  const sessionStepsBefore = readSessionStepUsages(sp);
+  const firstPromptTurn = telemetry.currentTurn() + 1;
 
   let failed = false;
   let exitCode = 0;
@@ -425,13 +427,18 @@ async function runPrompt(promptFile, model, helpers = {}) {
   }
 
   formatter.flush(failed);
+  const sessionSteps = newSessionStepUsages(readSessionStepUsages(sp), sessionStepsBefore);
   const recorded = preferRecordedUsage(
     usageWithCost(lastUsage, lastCost),
     subtractUsage(loadSessionUsage(sp), sessionUsageBefore),
   );
   const usage = recorded;
   lastCost = Number(recorded.total_cost_usd) || lastCost;
-  applyRecordedUsageToTelemetry(telemetry, usage);
+  if (sessionSteps.length > 0) {
+    applyRecordedStepsToTelemetry(telemetry, sessionSteps, firstPromptTurn);
+  } else {
+    applyRecordedUsageToTelemetry(telemetry, usage);
+  }
   const payload = {
     type: "result",
     result: resultTextFrom(lastResult, formatter),
@@ -720,7 +727,28 @@ function applyRecordedUsageToTelemetry(telemetry, recorded) {
   const snapshot = typeof telemetry.snapshot === "function" ? telemetry.snapshot() : null;
   const turns = snapshot && Array.isArray(snapshot.turns) ? snapshot.turns : [];
   const current = turns.length ? turns[turns.length - 1].usage : emptyUsage();
-  telemetry.updateCurrentUsage(turns.length ? mergeUsage(current, gap) : gap);
+  telemetry.mergeCurrentUsage(turns.length ? mergeUsage(current, gap) : gap);
+}
+
+function newSessionStepUsages(after, before) {
+  const priorKeys = new Set((before || []).map((step) => step.key));
+  return (after || []).filter((step) => !priorKeys.has(step.key));
+}
+
+function applyRecordedStepsToTelemetry(telemetry, steps, firstTurn) {
+  if (!telemetry || !Array.isArray(steps)) {
+    return;
+  }
+  for (const [index, step] of steps.entries()) {
+    if (!step || tokenTotal(step.usage) <= 0) {
+      continue;
+    }
+    const turn = firstTurn + index;
+    if (telemetry.replaceTurnUsage(turn, step.usage)) {
+      continue;
+    }
+    telemetry.beginTurn(step.usage, { forceNew: true });
+  }
 }
 
 function openCodeDataHome(taskDir) {
@@ -779,21 +807,32 @@ function collectJsonFiles(dir, files = []) {
   return files;
 }
 
-function readSessionUsageFromJsonParts(openCodeHome) {
+function sessionStepUsage(key, raw) {
+  const usage = usageFromStoredPart(parseStoredPart(raw));
+  if (tokenTotal(usage) <= 0 && !(Number(usage.total_cost_usd) > 0)) {
+    return null;
+  }
+  return { key, usage };
+}
+
+function readSessionStepUsagesFromJsonParts(openCodeHome) {
   const roots = [path.join(openCodeHome, "storage", "part"), path.join(openCodeHome, "storage", "session", "part")];
-  let usage = emptyUsage();
+  const steps = [];
   for (const root of roots) {
-    for (const file of collectJsonFiles(root)) {
+    for (const file of collectJsonFiles(root).sort()) {
       let parsed;
       try {
         parsed = JSON.parse(fs.readFileSync(file, "utf8"));
       } catch {
         continue;
       }
-      usage = mergeUsage(usage, usageFromStoredPart(parseStoredPart(parsed)));
+      const step = sessionStepUsage(file, parsed);
+      if (step) {
+        steps.push(step);
+      }
     }
   }
-  return usage;
+  return steps;
 }
 
 function openCodeDatabasePaths(openCodeHome) {
@@ -809,11 +848,23 @@ function openCodeDatabasePaths(openCodeHome) {
   return entries.filter((name) => /^opencode.*\.db$/.test(name)).map((name) => path.join(openCodeHome, name));
 }
 
-function sumStepFinishRows(rows) {
-  let usage = emptyUsage();
+function stepUsagesFromRows(dbPath, rows) {
+  const steps = [];
   for (const row of rows || []) {
     const data = row && Object.prototype.hasOwnProperty.call(row, "data") ? row.data : row;
-    usage = mergeUsage(usage, usageFromStoredPart(parseStoredPart(data)));
+    const id = row && row.id != null ? String(row.id) : String(steps.length);
+    const step = sessionStepUsage(`${dbPath}:${id}`, data);
+    if (step) {
+      steps.push(step);
+    }
+  }
+  return steps;
+}
+
+function sumStepUsages(steps) {
+  let usage = emptyUsage();
+  for (const step of steps || []) {
+    usage = mergeUsage(usage, step && step.usage);
   }
   return usage;
 }
@@ -834,7 +885,7 @@ function withSilencedExperimentalWarnings(fn) {
   }
 }
 
-function readSessionUsageFromSqliteNative(dbPath) {
+function readSessionStepUsagesFromSqliteNative(dbPath) {
   return withSilencedExperimentalWarnings(() => {
     let DatabaseSync;
     try {
@@ -845,23 +896,29 @@ function readSessionUsageFromSqliteNative(dbPath) {
     const db = new DatabaseSync(dbPath, { readOnly: true });
     try {
       const rows = db
-        .prepare(`SELECT data FROM part WHERE json_extract(data, '$.type') IN ('step-finish', 'step_finish')`)
+        .prepare(
+          `SELECT id, data FROM part
+           WHERE json_extract(data, '$.type') IN ('step-finish', 'step_finish')
+           ORDER BY time_created, id`,
+        )
         .all();
-      return sumStepFinishRows(rows);
+      return stepUsagesFromRows(dbPath, rows);
     } finally {
       db.close();
     }
   });
 }
 
-function readSessionUsageFromSqliteCli(dbPath) {
+function readSessionStepUsagesFromSqliteCli(dbPath) {
   const result = spawnSync(
     "sqlite3",
     [
       "-readonly",
       "-json",
       dbPath,
-      `SELECT data FROM part WHERE json_extract(data, '$.type') IN ('step-finish', 'step_finish')`,
+      `SELECT id, data FROM part
+       WHERE json_extract(data, '$.type') IN ('step-finish', 'step_finish')
+       ORDER BY time_created, id`,
     ],
     { encoding: "utf8" },
   );
@@ -872,17 +929,17 @@ function readSessionUsageFromSqliteCli(dbPath) {
   try {
     rows = JSON.parse(result.stdout);
   } catch {
-    return emptyUsage();
+    return [];
   }
-  return sumStepFinishRows(rows);
+  return stepUsagesFromRows(dbPath, rows);
 }
 
-function readSessionUsageFromSqlite(dbPath) {
+function readSessionStepUsagesFromSqlite(dbPath) {
   if (!dbPath || !fs.existsSync(dbPath)) {
-    return emptyUsage();
+    return [];
   }
   try {
-    const native = readSessionUsageFromSqliteNative(dbPath);
+    const native = readSessionStepUsagesFromSqliteNative(dbPath);
     if (native) {
       return native;
     }
@@ -890,22 +947,30 @@ function readSessionUsageFromSqlite(dbPath) {
     // Missing tables or a locked WAL file are expected. Try the sqlite3 CLI.
   }
   try {
-    return readSessionUsageFromSqliteCli(dbPath);
+    return readSessionStepUsagesFromSqliteCli(dbPath);
   } catch {
-    return emptyUsage();
+    return [];
   }
 }
 
-function readSessionUsage(taskDir) {
+function preferSessionSteps(left, right) {
+  return tokenTotal(sumStepUsages(right)) > tokenTotal(sumStepUsages(left)) ? right : left;
+}
+
+function readSessionStepUsages(taskDir) {
   if (!taskDir) {
-    return emptyUsage();
+    return [];
   }
   const openCodeHome = openCodeDataHome(taskDir);
-  let usage = emptyUsage();
+  let steps = [];
   for (const dbPath of openCodeDatabasePaths(openCodeHome)) {
-    usage = preferRecordedUsage(usage, readSessionUsageFromSqlite(dbPath));
+    steps = preferSessionSteps(steps, readSessionStepUsagesFromSqlite(dbPath));
   }
-  return preferRecordedUsage(usage, readSessionUsageFromJsonParts(openCodeHome));
+  return preferSessionSteps(steps, readSessionStepUsagesFromJsonParts(openCodeHome));
+}
+
+function readSessionUsage(taskDir) {
+  return sumStepUsages(readSessionStepUsages(taskDir));
 }
 
 function usageFromStepFinish(part) {
@@ -1023,7 +1088,7 @@ function printLiveLogLine(text) {
   if (!line) {
     return;
   }
-  writeLiveLogRecord({ type: "line", text: line });
+  println(line);
 }
 
 function printRetryOutcome(errorText, extraLine) {
@@ -1135,7 +1200,8 @@ function createOpenCodeFormatter(telemetry, onSession) {
           }
           formatToolUse(part, tools);
           break;
-        case "step_finish": {
+        case "step_finish":
+        case "step-finish": {
           const stepUsage = usageFromStepFinish(part);
           usage = mergeUsage(usage, stepUsage);
           if (part.cost != null && Number.isFinite(Number(part.cost))) {
@@ -1144,7 +1210,7 @@ function createOpenCodeFormatter(telemetry, onSession) {
           if (!roundOpen) {
             beginRound(stepUsage, { message: lastText });
           } else {
-            tracker.updateCurrentUsage(usage);
+            tracker.mergeCurrentUsage(stepUsage);
           }
           roundOpen = false;
           break;

--- a/pkg/components/runner/openrouter/run.js
+++ b/pkg/components/runner/openrouter/run.js
@@ -735,16 +735,27 @@ function newSessionStepUsages(after, before) {
   return (after || []).filter((step) => !priorKeys.has(step.key));
 }
 
+function promptTurnNumbers(telemetry, firstTurn) {
+  const snapshot = typeof telemetry.snapshot === "function" ? telemetry.snapshot() : null;
+  const turns = snapshot && Array.isArray(snapshot.turns) ? snapshot.turns : [];
+  return turns
+    .map((item) => Number(item && item.turn))
+    .filter((turn) => Number.isFinite(turn) && turn >= firstTurn);
+}
+
 function applyRecordedStepsToTelemetry(telemetry, steps, firstTurn) {
   if (!telemetry || !Array.isArray(steps)) {
     return;
   }
-  for (const [index, step] of steps.entries()) {
-    if (!step || tokenTotal(step.usage) <= 0) {
-      continue;
-    }
-    const turn = firstTurn + index;
-    if (telemetry.replaceTurnUsage(turn, step.usage)) {
+  const billed = steps.filter((step) => step && tokenTotal(step.usage) > 0);
+  if (!billed.length) {
+    return;
+  }
+  const liveTurns = promptTurnNumbers(telemetry, firstTurn);
+  const offset = Math.max(0, liveTurns.length - billed.length);
+  for (const [index, step] of billed.entries()) {
+    const turn = liveTurns[offset + index];
+    if (turn && telemetry.replaceTurnUsage(turn, step.usage)) {
       continue;
     }
     telemetry.beginTurn(step.usage, { forceNew: true });

--- a/pkg/components/runner/openrouter/run_test.go
+++ b/pkg/components/runner/openrouter/run_test.go
@@ -484,6 +484,41 @@ func TestRunPromptReadsSessionJsonWhenJsonlMissesStepFinish(t *testing.T) {
 	assertTurnRecordUsage(t, liveTurns[2], 20, 6, 0, 0, 0)
 }
 
+func TestRunPromptDoesNotCopyRetryUsageOntoFailedAttemptTurn(t *testing.T) {
+	result := runOpenRouterPrompt(t, promptHarness{
+		model: "x-ai/grok-4.6",
+		spawns: []spawnScript{
+			{
+				ExitCode: 1,
+				Stderr:   "Rate limit exceeded: new-account-rpm/x-ai/grok-4.6. Please retry shortly.",
+				Stdout: []string{
+					`{"type":"step_start","sessionID":"ses_fail","part":{"type":"step-start"}}`,
+					`{"type":"error","error":{"data":{"message":"Rate limit exceeded: new-account-rpm/x-ai/grok-4.6. Please retry shortly."}}}`,
+				},
+			},
+			{
+				ExitCode: 0,
+				Stdout: []string{
+					`{"type":"step_start","sessionID":"ses_ok","part":{"type":"step-start"}}`,
+					`{"type":"text","sessionID":"ses_ok","part":{"type":"text","text":"done"}}`,
+					`{"type":"step_finish","sessionID":"ses_ok","part":{"type":"step-finish","tokens":{"input":40,"output":12}}}`,
+				},
+				SessionParts: []string{
+					`{"type":"step-finish","cost":0.02,"tokens":{"input":40,"output":12}}`,
+				},
+			},
+		},
+	})
+	assert.Equal(t, 0, result.exitCode)
+	payload := resultPayload(t, result.resultFile)
+	assertResultUsage(t, payload, 40, 12, 0.02)
+	turns := resultTurnRecords(t, payload)
+	require.Len(t, turns, 2)
+	assertTurnRecordUsage(t, turns[0], 0, 0, 0, 0, 0)
+	assertTurnRecordUsage(t, turns[1], 40, 12, 0, 0, 0)
+	assertTurnUsageSum(t, payload, 40, 12)
+}
+
 func TestReadSessionUsageSumsStepFinishJsonParts(t *testing.T) {
 	dir := t.TempDir()
 	partDir := filepath.Join(dir, "xdg", "data", "opencode", "storage", "part", "msg_1")

--- a/pkg/components/runner/openrouter/run_test.go
+++ b/pkg/components/runner/openrouter/run_test.go
@@ -148,6 +148,22 @@ func TestFormatOpenCodeJsonLinesEmitsToolRecords(t *testing.T) {
 	assert.Contains(t, output, `"type":"turn"`)
 }
 
+func TestFormatOpenCodeJsonLinesEmitsUsageForEachFinishedStep(t *testing.T) {
+	output := runOpenCodeFormatter(t, []string{
+		`{"type":"step_start","sessionID":"ses_1","part":{"type":"step-start"}}`,
+		`{"type":"text","sessionID":"ses_1","part":{"type":"text","text":"First reply"}}`,
+		`{"type":"step_finish","sessionID":"ses_1","part":{"type":"step-finish","tokens":{"input":100,"output":20,"reasoning":3,"cache":{"read":40,"write":5}}}}`,
+		`{"type":"step_start","sessionID":"ses_1","part":{"type":"step-start"}}`,
+		`{"type":"text","sessionID":"ses_1","part":{"type":"text","text":"Second reply"}}`,
+		`{"type":"step-finish","sessionID":"ses_1","part":{"type":"step-finish","tokens":{"input":80,"output":10,"reasoning":2,"cache":{"read":30,"write":4}}}}`,
+	})
+
+	turns := latestTurnRecords(t, output)
+	require.Len(t, turns, 2)
+	assertTurnRecordUsage(t, turns[1], 100, 20, 40, 5, 3)
+	assertTurnRecordUsage(t, turns[2], 80, 10, 30, 4, 2)
+}
+
 func TestFormatOpenCodeJsonLinesMarksFailedTools(t *testing.T) {
 	output := runOpenCodeFormatter(t, []string{
 		`{"type":"tool_use","sessionID":"ses_1","part":{"callID":"call_read","tool":"read","state":{"status":"error","input":{"path":"missing.txt"},"error":"ENOENT"}}}`,
@@ -197,13 +213,13 @@ func TestRunPromptRetriesSelectedModelAfterRateLimit(t *testing.T) {
 	assert.Contains(t, result.spawns[1], "openrouter/x-ai/grok-4.6")
 	assert.NotContains(t, result.spawns[1], "anthropic/")
 	assert.Equal(t, []float64{30000}, result.sleeps)
-	requireLiveLogLine(t, result.output, "Starting OpenCode · openrouter/x-ai/grok-4.6")
-	requireLiveLogLine(t, result.output, "Calling OpenCode · openrouter/x-ai/grok-4.6 (attempt 1 of 4)")
-	requireLiveLogLine(t, result.output, "Rate limit on x-ai/grok-4.6. Waiting 30 seconds, then retrying (attempt 2 of 4).")
-	requireLiveLogLine(t, result.output, "Calling OpenCode · openrouter/x-ai/grok-4.6 (attempt 2 of 4)")
-	requireNoBareStdoutLine(t, result.output, "Starting OpenCode")
-	requireNoBareStdoutLine(t, result.output, "Calling OpenCode")
-	requireNoBareStdoutLine(t, result.output, "Waiting 30 seconds")
+	requireStdoutLine(t, result.output, "Starting OpenCode · openrouter/x-ai/grok-4.6")
+	requireStdoutLine(t, result.output, "Calling OpenCode · openrouter/x-ai/grok-4.6 (attempt 1 of 4)")
+	requireStdoutLine(t, result.output, "Rate limit on x-ai/grok-4.6. Waiting 30 seconds, then retrying (attempt 2 of 4).")
+	requireStdoutLine(t, result.output, "Calling OpenCode · openrouter/x-ai/grok-4.6 (attempt 2 of 4)")
+	requireNoTypedLiveLogLine(t, result.output, "Starting OpenCode")
+	requireNoTypedLiveLogLine(t, result.output, "Calling OpenCode")
+	requireNoTypedLiveLogLine(t, result.output, "Waiting 30 seconds")
 	assert.NotContains(t, result.spawns[1], "--session")
 	assert.Regexp(t, `✓ done · \d+ turns`, result.output)
 	payload := resultPayload(t, result.resultFile)
@@ -231,8 +247,8 @@ func TestRunPromptRetriesSelectedModelAfterTemporaryProviderError(t *testing.T) 
 	assert.Contains(t, result.spawns[1], "--session")
 	assert.Contains(t, result.spawns[1], "ses_fail")
 	assert.Equal(t, []float64{30000}, result.sleeps)
-	requireLiveLogLine(t, result.output, "Temporary error on x-ai/grok-4.6. Waiting 30 seconds, then retrying (attempt 2 of 4).")
-	requireLiveLogLine(t, result.output, "Calling OpenCode · openrouter/x-ai/grok-4.6 (attempt 2 of 4)")
+	requireStdoutLine(t, result.output, "Temporary error on x-ai/grok-4.6. Waiting 30 seconds, then retrying (attempt 2 of 4).")
+	requireStdoutLine(t, result.output, "Calling OpenCode · openrouter/x-ai/grok-4.6 (attempt 2 of 4)")
 }
 
 func TestRunPromptContinuesSessionWhenRetryableFailureMadeProgress(t *testing.T) {
@@ -275,7 +291,7 @@ func TestRunPromptRetriesNestedRateLimitOnSelectedModel(t *testing.T) {
 	require.Len(t, result.spawns, 2)
 	assert.Contains(t, result.spawns[1], "openrouter/x-ai/grok-4.6")
 	assert.Equal(t, []float64{30000}, result.sleeps)
-	requireLiveLogLine(t, result.output, "Rate limit on x-ai/grok-4.6. Waiting 30 seconds, then retrying (attempt 2 of 4).")
+	requireStdoutLine(t, result.output, "Rate limit on x-ai/grok-4.6. Waiting 30 seconds, then retrying (attempt 2 of 4).")
 }
 
 func TestRunPromptUsesProgressiveWaitWithoutRetryAfter(t *testing.T) {
@@ -297,12 +313,12 @@ func TestRunPromptUsesProgressiveWaitWithoutRetryAfter(t *testing.T) {
 	assert.Equal(t, 0, result.exitCode)
 	require.Len(t, result.spawns, 4)
 	assert.Equal(t, []float64{30000, 45000, 60000}, result.sleeps)
-	requireLiveLogLine(t, result.output, "Waiting 30 seconds, then retrying (attempt 2 of 4).")
-	requireLiveLogLine(t, result.output, "Waiting 45 seconds, then retrying (attempt 3 of 4).")
-	requireLiveLogLine(t, result.output, "Waiting 60 seconds, then retrying (attempt 4 of 4).")
-	requireLiveLogLine(t, result.output, "Calling OpenCode · openrouter/x-ai/grok-4.6 (attempt 1 of 4)")
-	requireLiveLogLine(t, result.output, "Calling OpenCode · openrouter/x-ai/grok-4.6 (attempt 4 of 4)")
-	requireNoBareStdoutLine(t, result.output, "Waiting 45 seconds")
+	requireStdoutLine(t, result.output, "Waiting 30 seconds, then retrying (attempt 2 of 4).")
+	requireStdoutLine(t, result.output, "Waiting 45 seconds, then retrying (attempt 3 of 4).")
+	requireStdoutLine(t, result.output, "Waiting 60 seconds, then retrying (attempt 4 of 4).")
+	requireStdoutLine(t, result.output, "Calling OpenCode · openrouter/x-ai/grok-4.6 (attempt 1 of 4)")
+	requireStdoutLine(t, result.output, "Calling OpenCode · openrouter/x-ai/grok-4.6 (attempt 4 of 4)")
+	requireNoTypedLiveLogLine(t, result.output, "Waiting 45 seconds")
 }
 
 func TestRunPromptHonorsRetryAfterOverProgressiveWait(t *testing.T) {
@@ -316,7 +332,7 @@ func TestRunPromptHonorsRetryAfterOverProgressiveWait(t *testing.T) {
 	assert.Equal(t, 0, result.exitCode)
 	require.Len(t, result.spawns, 2)
 	assert.Equal(t, []float64{90000}, result.sleeps)
-	requireLiveLogLine(t, result.output, "Rate limit on x-ai/grok-4.6. Waiting 90 seconds, then retrying (attempt 2 of 4).")
+	requireStdoutLine(t, result.output, "Rate limit on x-ai/grok-4.6. Waiting 90 seconds, then retrying (attempt 2 of 4).")
 	assert.NotContains(t, result.output, "Waiting 30 seconds")
 }
 
@@ -333,9 +349,9 @@ func TestRunPromptStopsAfterFourRateLimitAttempts(t *testing.T) {
 	assert.Equal(t, 1, result.exitCode)
 	require.Len(t, result.spawns, 4)
 	assert.Equal(t, []float64{30000, 45000, 60000}, result.sleeps)
-	requireLiveLogLine(t, result.output, "Calling OpenCode · openrouter/x-ai/grok-4.6 (attempt 4 of 4)")
-	requireLiveLogLine(t, result.output, "Rate limit on x-ai/grok-4.6. Stopped after 4 attempts.")
-	requireNoBareStdoutLine(t, result.output, "Stopped after 4 attempts")
+	requireStdoutLine(t, result.output, "Calling OpenCode · openrouter/x-ai/grok-4.6 (attempt 4 of 4)")
+	requireStdoutLine(t, result.output, "Rate limit on x-ai/grok-4.6. Stopped after 4 attempts.")
+	requireNoTypedLiveLogLine(t, result.output, "Stopped after 4 attempts")
 	assert.NotContains(t, result.output, "attempt 5")
 	assert.Regexp(t, `✗ failed`, result.output)
 }
@@ -451,13 +467,21 @@ func TestRunPromptReadsSessionJsonWhenJsonlMissesStepFinish(t *testing.T) {
 			},
 			SessionParts: []string{
 				`{"type":"step-finish","cost":0.02,"tokens":{"input":40,"output":12}}`,
+				`{"type":"step-finish","cost":0.01,"tokens":{"input":20,"output":6}}`,
 			},
 		}},
 	})
 	assert.Equal(t, 0, result.exitCode)
 	payload := resultPayload(t, result.resultFile)
-	assertResultUsage(t, payload, 40, 12, 0.02)
-	assertTurnUsageSum(t, payload, 40, 12)
+	assertResultUsage(t, payload, 60, 18, 0.03)
+	turns := resultTurnRecords(t, payload)
+	require.Len(t, turns, 2)
+	assertTurnRecordUsage(t, turns[0], 40, 12, 0, 0, 0)
+	assertTurnRecordUsage(t, turns[1], 20, 6, 0, 0, 0)
+	assertTurnUsageSum(t, payload, 60, 18)
+	liveTurns := latestTurnRecords(t, result.output)
+	assertTurnRecordUsage(t, liveTurns[1], 40, 12, 0, 0, 0)
+	assertTurnRecordUsage(t, liveTurns[2], 20, 6, 0, 0, 0)
 }
 
 func TestReadSessionUsageSumsStepFinishJsonParts(t *testing.T) {
@@ -489,14 +513,14 @@ try {
   process.exit(2);
 }
 const db = new DatabaseSync(process.env.OPENCODE_DB);
-db.exec("CREATE TABLE part (id TEXT PRIMARY KEY, data TEXT NOT NULL)");
-const insert = db.prepare("INSERT INTO part (id, data) VALUES (?, ?)");
-insert.run("prt_1", JSON.stringify({
+db.exec("CREATE TABLE part (id TEXT PRIMARY KEY, time_created INTEGER NOT NULL, data TEXT NOT NULL)");
+const insert = db.prepare("INSERT INTO part (id, time_created, data) VALUES (?, ?, ?)");
+insert.run("prt_1", 1, JSON.stringify({
   type: "step-finish",
   cost: 0.01,
   tokens: { input: 10, output: 8, reasoning: 1, cache: { read: 4, write: 2 } },
 }));
-insert.run("prt_2", JSON.stringify({ type: "text", text: "hi" }));
+insert.run("prt_2", 2, JSON.stringify({ type: "text", text: "hi" }));
 db.close();
 `)
 	cmd.Env = append(os.Environ(), "OPENCODE_DB="+dbPath, "NODE_NO_WARNINGS=1")
@@ -541,6 +565,11 @@ func TestRunPromptSucceedsWhenOpenCodeExitsNonZeroAfterTwoFinishedSteps(t *testi
 	require.True(t, ok)
 	assert.Equal(t, float64(15), usage["input_tokens"])
 	assert.Equal(t, float64(11), usage["output_tokens"])
+	turns := resultTurnRecords(t, payload)
+	require.Len(t, turns, 2)
+	assertTurnRecordUsage(t, turns[0], 10, 8, 0, 0, 0)
+	assertTurnRecordUsage(t, turns[1], 5, 3, 0, 0, 0)
+	assertTurnUsageSum(t, payload, 15, 11)
 	assert.Regexp(t, `✓ done`, result.output)
 }
 
@@ -649,7 +678,7 @@ func TestRunPromptFailsImmediatelyOnInvalidAPIKey(t *testing.T) {
 	assert.Empty(t, result.sleeps)
 	assert.NotContains(t, result.output, "Waiting")
 	assert.NotContains(t, result.output, "Retrying")
-	requireLiveLogLine(t, result.output, "Invalid API key")
+	requireStdoutLine(t, result.output, "Invalid API key")
 	assert.Regexp(t, `✗ failed`, result.output)
 }
 
@@ -684,9 +713,9 @@ func TestRunPromptContinuesSessionOnLaterPrompt(t *testing.T) {
 	require.NotEmpty(t, second.spawns)
 	assert.Contains(t, second.spawns[0], "--session")
 	assert.Contains(t, second.spawns[0], "ses_keep")
-	requireLiveLogLine(t, second.output, "Continuing OpenCode session on openrouter/anthropic/claude-sonnet-4-6")
-	requireLiveLogLine(t, second.output, "Calling OpenCode · openrouter/anthropic/claude-sonnet-4-6 (attempt 1 of 4)")
-	requireNoBareStdoutLine(t, second.output, "Continuing OpenCode session")
+	requireStdoutLine(t, second.output, "Continuing OpenCode session on openrouter/anthropic/claude-sonnet-4-6")
+	requireStdoutLine(t, second.output, "Calling OpenCode · openrouter/anthropic/claude-sonnet-4-6 (attempt 1 of 4)")
+	requireNoTypedLiveLogLine(t, second.output, "Continuing OpenCode session")
 }
 
 func TestRunPromptWritesOpenRouterBaseURLIntoConfig(t *testing.T) {
@@ -712,9 +741,9 @@ func TestRunPromptWritesOpenRouterBaseURLIntoConfig(t *testing.T) {
 	assert.Contains(t, result.spawns[0], "--auto")
 	assert.Equal(t, "--pure", result.spawns[0][0])
 	assert.Equal(t, "run", result.spawns[0][1])
-	requireLiveLogLine(t, result.output, "Starting OpenCode · openrouter/anthropic/claude-sonnet-4-6")
-	requireLiveLogLine(t, result.output, "Calling OpenCode · openrouter/anthropic/claude-sonnet-4-6 (attempt 1 of 4)")
-	requireNoBareStdoutLine(t, result.output, "Starting OpenCode")
+	requireStdoutLine(t, result.output, "Starting OpenCode · openrouter/anthropic/claude-sonnet-4-6")
+	requireStdoutLine(t, result.output, "Calling OpenCode · openrouter/anthropic/claude-sonnet-4-6 (attempt 1 of 4)")
+	requireNoTypedLiveLogLine(t, result.output, "Starting OpenCode")
 }
 
 func TestRunPromptDoesNotRetryWhenSuccessfulSpawnLogs429(t *testing.T) {
@@ -753,8 +782,8 @@ func TestRunPromptStopsWaitingWhenExecutionTimeoutExpires(t *testing.T) {
 	assert.Equal(t, 1, result.exitCode)
 	require.Len(t, result.spawns, 1)
 	assert.Empty(t, result.sleeps)
-	requireLiveLogLine(t, result.output, "Rate limit wait exceeded the execution timeout")
-	requireNoBareStdoutLine(t, result.output, "wait exceeded the execution timeout")
+	requireStdoutLine(t, result.output, "Rate limit wait exceeded the execution timeout")
+	requireNoTypedLiveLogLine(t, result.output, "wait exceeded the execution timeout")
 }
 
 func TestRunPromptTimeoutLineUsesTemporaryErrorLabel(t *testing.T) {
@@ -775,7 +804,7 @@ func TestRunPromptTimeoutLineUsesTemporaryErrorLabel(t *testing.T) {
 	assert.Equal(t, 1, result.exitCode)
 	require.Len(t, result.spawns, 1)
 	assert.Empty(t, result.sleeps)
-	requireLiveLogLine(t, result.output, "Temporary error wait exceeded the execution timeout")
+	requireStdoutLine(t, result.output, "Temporary error wait exceeded the execution timeout")
 	assert.NotContains(t, result.output, "Rate limit wait exceeded the execution timeout")
 }
 
@@ -793,7 +822,7 @@ func TestRunPromptDoesNotWaitWhenRetryExceedsRemainingTimeout(t *testing.T) {
 	assert.Equal(t, 1, result.exitCode)
 	require.Len(t, result.spawns, 1)
 	assert.Empty(t, result.sleeps)
-	requireLiveLogLine(t, result.output, "Rate limit wait exceeded the execution timeout")
+	requireStdoutLine(t, result.output, "Rate limit wait exceeded the execution timeout")
 }
 
 func TestWaitDeadlineMsUsesExecutionTimeoutSeconds(t *testing.T) {
@@ -1162,6 +1191,50 @@ func typedLiveLogRecords(t *testing.T, output string) []map[string]any {
 	return records
 }
 
+func latestTurnRecords(t *testing.T, output string) map[int]map[string]any {
+	t.Helper()
+	turns := map[int]map[string]any{}
+	for _, record := range typedLiveLogRecords(t, output) {
+		if record["type"] != "turn" {
+			continue
+		}
+		turn, ok := record["turn"].(float64)
+		require.True(t, ok)
+		turns[int(turn)] = record
+	}
+	return turns
+}
+
+func assertTurnRecordUsage(
+	t *testing.T,
+	record map[string]any,
+	input, output, cacheRead, cacheCreation, reasoning float64,
+) {
+	t.Helper()
+	usage, ok := record["usage"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, input, usage["input_tokens"])
+	assert.Equal(t, output, usage["output_tokens"])
+	assert.Equal(t, cacheRead, usage["cache_read_input_tokens"])
+	assert.Equal(t, cacheCreation, usage["cache_creation_input_tokens"])
+	assert.Equal(t, reasoning, usage["reasoning_tokens"])
+}
+
+func resultTurnRecords(t *testing.T, payload map[string]any) []map[string]any {
+	t.Helper()
+	telemetry, ok := payload["telemetry"].(map[string]any)
+	require.True(t, ok, "result payload must include telemetry")
+	rawTurns, ok := telemetry["turns"].([]any)
+	require.True(t, ok, "telemetry must include turns")
+	turns := make([]map[string]any, 0, len(rawTurns))
+	for _, raw := range rawTurns {
+		turn, ok := raw.(map[string]any)
+		require.True(t, ok)
+		turns = append(turns, turn)
+	}
+	return turns
+}
+
 func liveLogLineTexts(t *testing.T, output string) []string {
 	t.Helper()
 	var texts []string
@@ -1178,17 +1251,7 @@ func liveLogLineTexts(t *testing.T, output string) []string {
 	return texts
 }
 
-func requireLiveLogLine(t *testing.T, output, needle string) {
-	t.Helper()
-	for _, text := range liveLogLineTexts(t, output) {
-		if strings.Contains(text, needle) {
-			return
-		}
-	}
-	require.Failf(t, "missing typed live-log line", "wanted %q in type=line records; got %q", needle, liveLogLineTexts(t, output))
-}
-
-func requireNoBareStdoutLine(t *testing.T, output, needle string) {
+func requireStdoutLine(t *testing.T, output, needle string) {
 	t.Helper()
 	for _, line := range strings.Split(output, "\n") {
 		trimmed := strings.TrimSpace(line)
@@ -1196,7 +1259,17 @@ func requireNoBareStdoutLine(t *testing.T, output, needle string) {
 			continue
 		}
 		if strings.Contains(trimmed, needle) {
-			require.Failf(t, "found bare stdout line", "wanted %q only as a type=line live-log record; found %q", needle, trimmed)
+			return
+		}
+	}
+	require.Failf(t, "missing stdout line", "wanted %q in plain stdout; got %q", needle, output)
+}
+
+func requireNoTypedLiveLogLine(t *testing.T, output, needle string) {
+	t.Helper()
+	for _, text := range liveLogLineTexts(t, output) {
+		if strings.Contains(text, needle) {
+			require.Failf(t, "found typed live-log line", "wanted %q as plain stdout, not a type=line record; got %q", needle, liveLogLineTexts(t, output))
 		}
 	}
 }

--- a/pkg/components/runner/turn_telemetry.js
+++ b/pkg/components/runner/turn_telemetry.js
@@ -318,6 +318,21 @@ function createTurnTelemetry(options) {
       persist();
       return snapshot.turn;
     },
+    replaceTurnUsage(turn, usage) {
+      const turnNumber = asNumber(turn);
+      const snapshot = state.turns.find((item) => item.turn === turnNumber);
+      if (!snapshot) {
+        return 0;
+      }
+      const incoming = normalizeUsage(usage);
+      if (usageEquals(snapshot.usage, incoming)) {
+        return snapshot.turn;
+      }
+      snapshot.usage = incoming;
+      persist();
+      emitTurn(snapshot);
+      return snapshot.turn;
+    },
     stampToolStart(record) {
       if (state.currentTurn < 1) {
         this.beginTurn({});

--- a/pkg/components/runner/turn_telemetry_test.go
+++ b/pkg/components/runner/turn_telemetry_test.go
@@ -244,6 +244,32 @@ process.stdout.write(JSON.stringify({ records, telemetry: telemetry.snapshot() }
 	assert.Equal(t, float64(29497), payload.Telemetry.Turns[0].Usage["cache_read_input_tokens"])
 }
 
+func TestTurnTelemetryReplacesUsageForAnEarlierTurn(t *testing.T) {
+	t.Parallel()
+
+	taskDir := t.TempDir()
+	writeTurnTelemetryScript(t, taskDir)
+
+	payload := runTurnTelemetryHarness(t, taskDir, `
+const { createTurnTelemetry } = require(process.env.TURN_TELEMETRY_SCRIPT);
+const records = [];
+const telemetry = createTurnTelemetry({
+  taskDir: process.env.SUPERPLANE_TASK_DIR,
+  write: (record) => records.push(record),
+});
+telemetry.beginTurn({});
+telemetry.beginTurn({});
+telemetry.replaceTurnUsage(1, { input_tokens: 10, output_tokens: 2 });
+process.stdout.write(JSON.stringify({ records, telemetry: telemetry.snapshot() }));
+`)
+
+	require.Len(t, payload.Telemetry.Turns, 2)
+	assert.Equal(t, float64(10), payload.Telemetry.Turns[0].Usage["input_tokens"])
+	assert.Equal(t, float64(2), payload.Telemetry.Turns[0].Usage["output_tokens"])
+	lastRecord := payload.Records[len(payload.Records)-1]
+	assert.Equal(t, float64(1), lastRecord["turn"])
+}
+
 func TestTurnTelemetryAppliesBilledOutputGapToLastTurn(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Factory tasks showed token totals with empty usage-chart bars.

OpenRouter stored billed usage after each step but did not emit a live turn record. The usage chart then showed 0 tokens on every bar.

Start and wait status lines used typed JSON. The runner already wraps stdout, so those lines appeared as raw JSON.

This change emits tokenized turn records after each finished step. It also writes status lines as plain stdout.

## Test plan

- [ ] Run an OpenRouter factory task that completes more than one turn.
- [ ] Open the phase usage chart and confirm each bar has input and output tokens.
- [ ] Confirm start and wait log lines show as plain text, not JSON.
- [ ] Confirm cache-read tokens still appear as a label, not as a bar.


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63281260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge, with the previously reported retry double-counting issue resolved and no new actionable defects identified.

<sub>Reviews (2) · Last reviewed commit: ["fix: Avoid double-counting OpenRouter re..."](https://github.com/superplanehq/superplane/commit/38a5dda1002eb541796480de92d8722dcc1d97a2)</sub>

<!-- /greptile_comment -->