### PR TITLE
Feat/agent log step timestamps

### DIFF
--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.spec.tsx
@@ -36,6 +36,39 @@ describe("toolCallSummary", () => {
   });
 });
 
+describe("PhaseLogCard elapsed timestamps", () => {
+  it("shows elapsed timestamps on thought and action rows", () => {
+    const stream: SplitRunStreamLine[] = [
+      line({
+        id: "agent",
+        componentName: "Run Claude Code",
+        component: "runnerClaudeCode",
+        orderKey: 1_000,
+      }),
+      line({
+        id: "thought",
+        note: true,
+        componentName: "I will inspect the repository.",
+        componentType: "note",
+        orderKey: 2_000,
+      }),
+      line({
+        id: "action",
+        note: true,
+        noteParentId: "thought",
+        componentName: "git status",
+        componentType: "bash",
+        orderKey: 2_341_000,
+      }),
+    ];
+
+    render(<PhaseLogCard phase={PHASE} expanded stream={stream} />);
+
+    expect(screen.getByTestId("split-run-stream-elapsed-thought")).toHaveTextContent("00:01");
+    expect(screen.getByTestId("split-run-stream-elapsed-action")).toHaveTextContent("39:00");
+  });
+});
+
 describe("groupClaudeSteps", () => {
   it("keeps tools and agent notes in log order", () => {
     const write = groupClaudeSteps(PLANNING_STREAM.filter((entry) => entry.note)).find(

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
@@ -3,7 +3,7 @@ import { agentRunNewTokenCount } from "@/lib/agentRunTelemetryChart";
 
 const EMPTY_AGENT_TELEMETRY = emptyAgentRunTelemetry();
 const EMPTY_USAGE_SERIES: AgentPromptUsageSeries[] = [];
-import { formatClockDurationLabel } from "@/lib/duration";
+import { formatClockDuration, formatClockDurationLabel } from "@/lib/duration";
 import { formatCompactTokenValue } from "@/lib/formatTokenCount";
 import { cn, resolveIcon } from "@/lib/utils";
 import { ChevronRight, CircleX, Loader2, Maximize2, RotateCw } from "lucide-react";
@@ -889,6 +889,7 @@ function StreamNode({
     : mergeLiveStreamNotes(liveNotes, notes);
   const steps = compactSessionLog ? groupPlanningSessionLog(merged) : groupClaudeSteps(merged);
   const hasChildren = steps.length > 0 || isRunnerComponent(line.component);
+  const runStartedAt = line.orderKey ?? firstTimestamp(merged);
 
   return (
     <li className="min-w-0">
@@ -910,6 +911,7 @@ function StreamNode({
               step={step}
               highlightUserTalk={compactSessionLog}
               stickyHeader={!compactSessionLog}
+              runStartedAt={runStartedAt}
             />
           ))}
         </ol>
@@ -992,10 +994,12 @@ function StreamStep({
   step,
   highlightUserTalk = false,
   stickyHeader = true,
+  runStartedAt,
 }: {
   step: ClaudeStepGroup;
   highlightUserTalk?: boolean;
   stickyHeader?: boolean;
+  runStartedAt?: number;
 }) {
   const hasOutput = Boolean(step.line.detail);
   const hasBody = step.events.length > 0 || hasOutput;
@@ -1018,6 +1022,7 @@ function StreamStep({
             {step.line.componentName}
           </StreamLineTitle>
           <StepStatusMark status={step.line.status} />
+          <StreamElapsedTimestamp line={step.line} runStartedAt={runStartedAt} />
         </div>
       ) : null}
       {hasBody ? (
@@ -1025,9 +1030,20 @@ function StreamStep({
           {hasOutput ? <StreamOutput text={step.line.detail ?? ""} /> : null}
           {step.events.map((event) =>
             event.kind === "note" ? (
-              <StreamTalkNote key={event.line.id} line={event.line} highlightUserTalk={highlightUserTalk} />
+              <StreamTalkNote
+                key={event.line.id}
+                line={event.line}
+                highlightUserTalk={highlightUserTalk}
+                runStartedAt={runStartedAt}
+              />
             ) : (
-              <StreamToolGroup key={event.id} stepId={event.id} tools={event.tools} label={event.label} />
+              <StreamToolGroup
+                key={event.id}
+                stepId={event.id}
+                tools={event.tools}
+                label={event.label}
+                runStartedAt={runStartedAt}
+              />
             ),
           )}
         </>
@@ -1036,7 +1052,15 @@ function StreamStep({
   );
 }
 
-function StreamTalkNote({ line, highlightUserTalk }: { line: SplitRunStreamLine; highlightUserTalk: boolean }) {
+function StreamTalkNote({
+  line,
+  highlightUserTalk,
+  runStartedAt,
+}: {
+  line: SplitRunStreamLine;
+  highlightUserTalk: boolean;
+  runStartedAt?: number;
+}) {
   const isUserTalk = highlightUserTalk && (line.componentType === "prompt" || Boolean(line.userTalk));
   const youLabel = line.userTalk === "survey" ? CREATE_WITH_AGENT_COPY.youSurvey : CREATE_WITH_AGENT_COPY.you;
   return (
@@ -1056,11 +1080,22 @@ function StreamTalkNote({ line, highlightUserTalk }: { line: SplitRunStreamLine;
           <MarkdownContent content={line.componentName} variant="workspace" className={STREAM_NOTE_MARKDOWN} />
         </div>
       )}
+      <StreamElapsedTimestamp line={line} runStartedAt={runStartedAt} />
     </div>
   );
 }
 
-function StreamToolGroup({ stepId, tools, label }: { stepId: string; tools: SplitRunStreamLine[]; label?: string }) {
+function StreamToolGroup({
+  stepId,
+  tools,
+  label,
+  runStartedAt,
+}: {
+  stepId: string;
+  tools: SplitRunStreamLine[];
+  label?: string;
+  runStartedAt?: number;
+}) {
   const [expanded, setExpanded] = useState(false);
   const summary = label ?? toolCallSummary(tools);
 
@@ -1079,11 +1114,12 @@ function StreamToolGroup({ stepId, tools, label }: { stepId: string; tools: Spli
           <ChevronRight className={cn("size-3 transition-transform", expanded && "rotate-90")} aria-hidden />
         </span>
         <StreamLineTitle>{summary}</StreamLineTitle>
+        <StreamElapsedTimestamp line={tools[0]} runStartedAt={runStartedAt} />
       </button>
       {expanded ? (
         <ol className="min-w-0">
           {tools.map((tool) => (
-            <StreamTool key={tool.id} tool={tool} />
+            <StreamTool key={tool.id} tool={tool} runStartedAt={runStartedAt} />
           ))}
         </ol>
       ) : null}
@@ -1091,7 +1127,7 @@ function StreamToolGroup({ stepId, tools, label }: { stepId: string; tools: Spli
   );
 }
 
-function StreamTool({ tool }: { tool: SplitRunStreamLine }) {
+function StreamTool({ tool, runStartedAt }: { tool: SplitRunStreamLine; runStartedAt?: number }) {
   const [expanded, setExpanded] = useState(tool.status === "running");
   useEffect(() => {
     if (tool.status === "running") {
@@ -1107,6 +1143,7 @@ function StreamTool({ tool }: { tool: SplitRunStreamLine }) {
       ) : null}
       <StreamLineTitle wrap>{tool.componentName}</StreamLineTitle>
       <StepStatusMark status={tool.status} />
+      <StreamElapsedTimestamp line={tool} runStartedAt={runStartedAt} />
     </>
   );
 
@@ -1134,6 +1171,32 @@ function StreamTool({ tool }: { tool: SplitRunStreamLine }) {
       )}
       {expanded && hasOutput ? <StreamOutput text={tool.detail ?? ""} /> : null}
     </li>
+  );
+}
+
+function firstTimestamp(lines: SplitRunStreamLine[]): number | undefined {
+  return lines.reduce<number | undefined>((first, line) => {
+    if (line.orderKey === undefined) {
+      return first;
+    }
+    return first === undefined ? line.orderKey : Math.min(first, line.orderKey);
+  }, undefined);
+}
+
+function StreamElapsedTimestamp({ line, runStartedAt }: { line?: SplitRunStreamLine; runStartedAt?: number }) {
+  if (runStartedAt === undefined || line?.orderKey === undefined) {
+    return null;
+  }
+
+  const elapsed = formatClockDuration(Math.max(0, line.orderKey - runStartedAt));
+  return (
+    <span
+      data-testid={`split-run-stream-elapsed-${line.id}`}
+      aria-label={`Elapsed time ${elapsed}`}
+      className="ml-3 shrink-0 tabular-nums text-muted-foreground"
+    >
+      {elapsed}
+    </span>
   );
 }
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunLiveCanvas.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunLiveCanvas.ts
@@ -291,7 +291,13 @@ function streamLineForNode(
     iconSrc: presentation.iconSrc,
     component: node.component,
     executionId: execution?.id,
+    orderKey: timestampMs(execution?.createdAt),
   };
+}
+
+function timestampMs(value: string | undefined): number | undefined {
+  const parsed = Date.parse(value ?? "");
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 export function splitRunCanvasFromLive(input: {

--- a/web_src/src/pages/factories/pages/work-order-split-run/streamNotesFromLiveLog.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/streamNotesFromLiveLog.spec.ts
@@ -40,6 +40,7 @@ function promptSection(): CommandSection {
             lines: ["package workers"],
             status: "passed",
             duration_ms: 80,
+            started_at: 4_500,
           },
         ],
       },
@@ -88,16 +89,16 @@ describe("notesFromLiveLogSections", () => {
     expect(notes[1]?.componentName).toBe("You are implementing a fix.\n\nRead the ticket first.");
   });
 
-  it("tags the section, its notes, and its tools with the section start time", () => {
+  it("tags the section and its notes with the section start time", () => {
     const notes = notesFromLiveLogSections("agent", [{ ...promptSection(), started_at: 5_000 }]);
 
-    expect(notes.map((note) => note.orderKey)).toEqual([5_000, 5_000, 5_000]);
+    expect(notes.map((note) => note.orderKey)).toEqual([5_000, 5_000, 4_500]);
   });
 
-  it("leaves orderKey undefined when the section has no start time", () => {
+  it("keeps prompt lines untimed when the section has no start time", () => {
     const notes = notesFromLiveLogSections("agent", [{ ...promptSection(), started_at: null }]);
 
-    expect(notes.every((note) => note.orderKey === undefined)).toBe(true);
+    expect(notes.map((note) => note.orderKey)).toEqual([undefined, undefined, 4_500]);
   });
 
   it("falls back to parseClaudeCodeLog for old -> [Tool] lines", () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/streamNotesFromLiveLog.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/streamNotesFromLiveLog.ts
@@ -74,6 +74,7 @@ export function notesFromLiveLogSections(nodeId: string, sections: CommandSectio
         continue;
       }
       for (const tool of event.tools) {
+        const toolOrderKey = tool.started_at ?? orderKey;
         notes.push({
           id: tool.id,
           nodeId,
@@ -85,7 +86,7 @@ export function notesFromLiveLogSections(nodeId: string, sections: CommandSectio
           componentName: tool.text,
           status: streamStatus(tool.status),
           detail: tool.lines.filter((line) => line.trim() && !isRawAgentTurnLiveLogText(line)).join("\n") || undefined,
-          ...orderKeyProps(orderKey),
+          ...orderKeyProps(toolOrderKey),
         });
       }
     }

--- a/web_src/src/pages/factories/pages/work-order-split-run/streamNotesFromLiveLog.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/streamNotesFromLiveLog.ts
@@ -27,6 +27,11 @@ function orderKeyProps(orderKey: number | undefined): { orderKey?: number } {
   return orderKey === undefined ? {} : { orderKey };
 }
 
+/** A tool's own start time takes priority over its section's, when known. */
+function toolOrderKey(tool: { started_at?: number | null }, sectionOrderKey: number | undefined): number | undefined {
+  return tool.started_at ?? sectionOrderKey;
+}
+
 export function notesFromLiveLogSections(nodeId: string, sections: CommandSection[]): SplitRunStreamLine[] {
   const notes: SplitRunStreamLine[] = [];
   for (const section of sections) {
@@ -74,7 +79,6 @@ export function notesFromLiveLogSections(nodeId: string, sections: CommandSectio
         continue;
       }
       for (const tool of event.tools) {
-        const toolOrderKey = tool.started_at ?? orderKey;
         notes.push({
           id: tool.id,
           nodeId,
@@ -86,7 +90,7 @@ export function notesFromLiveLogSections(nodeId: string, sections: CommandSectio
           componentName: tool.text,
           status: streamStatus(tool.status),
           detail: tool.lines.filter((line) => line.trim() && !isRawAgentTurnLiveLogText(line)).join("\n") || undefined,
-          ...orderKeyProps(toolOrderKey),
+          ...orderKeyProps(toolOrderKey(tool, orderKey)),
         });
       }
     }

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.ts
@@ -103,6 +103,7 @@ export function startToolOnLatestSection(
   text: string,
   sourceId?: string,
   commandIndex?: number,
+  startedAtMs?: number | null,
 ): LogState {
   const sectionPos = commandSectionPosition(state, commandIndex);
   if (sectionPos < 0) {
@@ -116,7 +117,7 @@ export function startToolOnLatestSection(
     return state;
   }
   const nextSections = [...state.sections];
-  nextSections[sectionPos] = startToolOnSection(section, kind, text, sourceId);
+  nextSections[sectionPos] = startToolOnSection(section, kind, text, sourceId, startedAtMs);
   return { ...state, sections: nextSections };
 }
 
@@ -187,7 +188,13 @@ function appendLineToSection(section: CommandSection, text: string): CommandSect
   };
 }
 
-function startToolOnSection(section: CommandSection, kind: string, text: string, sourceId?: string): CommandSection {
+function startToolOnSection(
+  section: CommandSection,
+  kind: string,
+  text: string,
+  sourceId?: string,
+  startedAtMs?: number | null,
+): CommandSection {
   const tool: CommandTool = {
     id: sourceId?.trim() || `${section.index}-tool-${toolCount(section)}`,
     sourceId: sourceId?.trim() || undefined,
@@ -196,6 +203,7 @@ function startToolOnSection(section: CommandSection, kind: string, text: string,
     lines: [],
     status: "running",
     duration_ms: null,
+    started_at: startedAtMs ?? section.started_at,
   };
   const last = section.events.at(-1);
   if (last?.kind === "tools") {

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogSections.ts
@@ -101,10 +101,9 @@ export function startToolOnLatestSection(
   state: LogState,
   kind: string,
   text: string,
-  sourceId?: string,
-  commandIndex?: number,
-  startedAtMs?: number | null,
+  options?: { sourceId?: string; commandIndex?: number; startedAtMs?: number | null },
 ): LogState {
+  const { sourceId, commandIndex, startedAtMs } = options ?? {};
   const sectionPos = commandSectionPosition(state, commandIndex);
   if (sectionPos < 0) {
     return state;

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogStream.ts
@@ -35,7 +35,7 @@ export type LiveLogStreamHandlers = {
   onStreamError: (message: string) => void;
   onCmdStart?: (index: number, text: string, startedAtMs: number | null, kind?: string, preview?: string) => void;
   onCmdEnd?: (index: number, status: "passed" | "failed", durationMs: number) => void;
-  onToolStart?: (kind: string, text: string, id?: string, turn?: number) => void;
+  onToolStart?: (kind: string, text: string, id?: string, turn?: number, startedAtMs?: number | null) => void;
   onToolEnd?: (status: "passed" | "failed", durationMs: number, id?: string, turn?: number) => void;
   onTurn?: (turn: number, usage: Record<string, number>, message?: string) => void;
 };
@@ -151,6 +151,7 @@ function dispatchToolStartRecord(rec: LiveLogRecordEnvelope, handlers: LiveLogSt
     typeof rec.text === "string" ? rec.text : "",
     typeof rec.id === "string" ? rec.id : undefined,
     typeof rec.turn === "number" ? rec.turn : undefined,
+    parseStartedAtMs(rec.started_at),
   );
   return true;
 }

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/types.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/types.ts
@@ -29,6 +29,7 @@ export type CommandTool = {
   lines: string[];
   status: "running" | "passed" | "failed";
   duration_ms: number | null;
+  started_at?: number | null;
 };
 
 export type CommandSectionEvent = { kind: "note"; text: string } | { kind: "tools"; id: string; tools: CommandTool[] };

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
@@ -221,7 +221,11 @@ function startReplayedTool(
     return state;
   }
   return withClearedError(
-    startToolOnLatestSection(state, tool.kind, tool.text, tool.sourceId, tool.commandIndex, tool.startedAtMs),
+    startToolOnLatestSection(state, tool.kind, tool.text, {
+      sourceId: tool.sourceId,
+      commandIndex: tool.commandIndex,
+      startedAtMs: tool.startedAtMs,
+    }),
   );
 }
 

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
@@ -160,9 +160,13 @@ function createStreamHandlers(ctx: StreamHandlerContext): LiveLogStreamHandlers 
     },
     onCmdEnd: (index, status, durationMs) =>
       setState((prev) => withClearedError(completeCommandSection(prev, index, status, durationMs))),
-    onToolStart: (kind, text, id, turn) => {
+    onToolStart: (kind, text, id, turn, startedAtMs) => {
       setState((prev) =>
-        startReplayedTool(prev, { kind, text, sourceId: id, commandIndex: commandCursor.index }, reconnecting),
+        startReplayedTool(
+          prev,
+          { kind, text, sourceId: id, commandIndex: commandCursor.index, startedAtMs },
+          reconnecting,
+        ),
       );
       setUsage((prev) => applyPromptUsageRecord(prev, { type: "tool_start", kind, text, id, turn }));
     },
@@ -210,13 +214,15 @@ function rememberOrStartCommand(
 
 function startReplayedTool(
   state: LogState,
-  tool: { kind: string; text: string; sourceId?: string; commandIndex?: number },
+  tool: { kind: string; text: string; sourceId?: string; commandIndex?: number; startedAtMs?: number | null },
   reconnecting: boolean,
 ): LogState {
   if (shouldSkipUnindexedLiveLogReplay(reconnecting, tool.commandIndex, hasFinishedCommandSection(state))) {
     return state;
   }
-  return withClearedError(startToolOnLatestSection(state, tool.kind, tool.text, tool.sourceId, tool.commandIndex));
+  return withClearedError(
+    startToolOnLatestSection(state, tool.kind, tool.text, tool.sourceId, tool.commandIndex, tool.startedAtMs),
+  );
 }
 
 function endReplayedTool(


### PR DESCRIPTION
## What changed
Adds elapsed time (MM:SS from run start) to every thought and action row in the agent log viewer, right-aligned.

## Why
Closes #7270 — operators couldn't tell which steps in a long run were fast vs. slow (a 39-minute wait looked identical to a 1-second step).

## How
- Threads `orderKey` (derived from each event's `started_at`) down through `PhaseLogCard` so every row can compute its own elapsed time relative to the run's start.
- New `StreamElapsedTimestamp` component renders the `MM:SS` label using the existing `formatClockDuration` helper.
- Added tests covering the elapsed-time calculation on both thought and action rows.