### PR TITLE
chore: use happy-dom instead of jsdom

### DIFF
--- a/web_src/package-lock.json
+++ b/web_src/package-lock.json
@@ -119,6 +119,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "eslint-plugin-storybook": "^10.5.7",
         "globals": "^16.0.0",
+        "happy-dom": "^20.14.5",
         "jsdom": "^30.0.1",
         "knip": "^6.35.0",
         "msw": "^2.14.6",
@@ -6587,6 +6588,23 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.69.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
@@ -7595,6 +7613,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/bundle-name": {
@@ -10396,6 +10427,48 @@
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.14.5",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.14.5.tgz",
+      "integrity": "sha512-x/RzkpWO40bTjIoT30iQtt64FLLmH/iRcUCN2X//bLx7H3ifkdfPXyqsro/OYtqzIAhiLMMA7mmiOR9C3NOKjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",

--- a/web_src/package.json
+++ b/web_src/package.json
@@ -137,6 +137,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-storybook": "^10.5.7",
     "globals": "^16.0.0",
+    "happy-dom": "^20.14.5",
     "jsdom": "^30.0.1",
     "knip": "^6.35.0",
     "msw": "^2.14.6",

--- a/web_src/src/lib/integrationSetupReturn.spec.ts
+++ b/web_src/src/lib/integrationSetupReturn.spec.ts
@@ -13,10 +13,12 @@ import {
 
 function setupReturnCookie(): string | undefined {
   const prefix = `${INTEGRATION_SETUP_RETURN_COOKIE}=`;
-  return document.cookie
+  const value = document.cookie
     .split("; ")
     .find((part) => part.startsWith(prefix))
     ?.slice(prefix.length);
+  // happy-dom keeps Max-Age=0 cookies as an empty value instead of dropping them.
+  return value === "" ? undefined : value;
 }
 
 describe("integration setup return", () => {

--- a/web_src/src/pages/__fixtures__/createOrgWorkspaceFixtureFetch.spec.ts
+++ b/web_src/src/pages/__fixtures__/createOrgWorkspaceFixtureFetch.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createOrgWorkspaceFixtureFetch } from "./createOrgWorkspaceFixtureFetch";
+import { createOrgWorkspaceFixtureFetch, fixtureFetchBaseHref } from "./createOrgWorkspaceFixtureFetch";
 
 describe("createOrgWorkspaceFixtureFetch", () => {
   it("prefers canvas-app integration definitions when appFixture is supplied", async () => {
@@ -49,6 +49,11 @@ describe("createOrgWorkspaceFixtureFetch", () => {
       "openai",
       "openrouter",
     ]);
+  });
+
+  it("uses localhost when location is a blob download URL", () => {
+    expect(fixtureFetchBaseHref("blob:mock-usage-csv")).toBe("http://localhost");
+    expect(fixtureFetchBaseHref("http://localhost:3000/org-1")).toBe("http://localhost:3000/org-1");
   });
 
   it("starts with the organization connections the story seeds", async () => {

--- a/web_src/src/pages/__fixtures__/createOrgWorkspaceFixtureFetch.ts
+++ b/web_src/src/pages/__fixtures__/createOrgWorkspaceFixtureFetch.ts
@@ -38,6 +38,14 @@ function requestUrl(input: RequestInfo | URL): string {
   return input.url;
 }
 
+/** Download clicks in happy-dom can leave location on a blob: URL. */
+export function fixtureFetchBaseHref(href = globalThis.location?.href): string {
+  if (href && (href.startsWith("http://") || href.startsWith("https://"))) {
+    return href;
+  }
+  return "http://localhost";
+}
+
 /**
  * Serves both homepage and canvas-app fixtures from one `fetch` override so
  * Storybook can navigate between HomePage and AppPage without hitting the network.
@@ -66,7 +74,7 @@ export function createOrgWorkspaceFixtureFetch(
   const accountState = createStorybookAccountState(homeFixture.organizationId);
 
   const impl = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    const url = new URL(requestUrl(input), globalThis.location?.href ?? "http://localhost");
+    const url = new URL(requestUrl(input), fixtureFetchBaseHref());
     const method = requestMethod(input, init);
     const body = await readRequestJson(input, init);
     const agentRoute = matchStorybookAgentMessageRoute({

--- a/web_src/src/pages/app/console/htmlSanitize.spec.ts
+++ b/web_src/src/pages/app/console/htmlSanitize.spec.ts
@@ -1,11 +1,14 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
 import { sanitizeHtml } from "./htmlSanitize";
 
 /**
- * The sanitizer runs in jsdom under vitest. Each test exercises one specific
- * threat or allow-list rule documented in `htmlSanitize.ts`. Failures here
- * indicate a regression in the widget's security policy.
+ * The sanitizer runs in jsdom. happy-dom's NodeIterator skips siblings after a
+ * removal, so mixed forbidden-tag payloads are not a reliable check there.
+ * Each test exercises one specific threat or allow-list rule documented in
+ * `htmlSanitize.ts`. Failures here indicate a regression in the widget's
+ * security policy.
  */
 const ROOT_ID = "html-root";
 

--- a/web_src/src/pages/factories/WorkOrderDescriptionEditor.spec.tsx
+++ b/web_src/src/pages/factories/WorkOrderDescriptionEditor.spec.tsx
@@ -277,6 +277,9 @@ describe("WorkOrderDescriptionEditor", () => {
     fireEvent.paste(input, {
       clipboardData: { getData: () => "" },
     });
+    // Paste collapses the TipTap selection in happy-dom. Click again so the
+    // format bubble menu can attach before Ctrl+A.
+    await user.click(input);
     await user.keyboard("{Control>}a{/Control}");
     await user.click(await screen.findByRole("button", { name: "Bold" }));
 

--- a/web_src/src/pages/home/index.spec.tsx
+++ b/web_src/src/pages/home/index.spec.tsx
@@ -545,12 +545,15 @@ describe("HomePage canvas folders", () => {
 
   it("opens a folder-scoped installed app when folder membership update fails", async () => {
     const user = userEvent.setup();
-    const fetchMock = vi.fn();
-    fetchMock
-      .mockResolvedValueOnce(new Response(JSON.stringify({ integrations: [], installParams: [] }), { status: 200 }))
-      .mockResolvedValueOnce(
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = typeof input === "string" ? input : input instanceof Request ? input.url : String(input);
+      if (String(url).includes("/apps/install/preview")) {
+        return Promise.resolve(new Response(JSON.stringify({ integrations: [], installParams: [] }), { status: 200 }));
+      }
+      return Promise.resolve(
         new Response(JSON.stringify({ canvasId: "canvas-installed", organizationId: "org-123" }), { status: 200 }),
       );
+    });
     vi.stubGlobal("fetch", fetchMock);
     mutationMocks.updateCanvasFolderMembership.mockRejectedValue(new Error("Failed to fetch"));
     useCanvases.mockReturnValue({ data: [], isLoading: false, error: null });

--- a/web_src/src/test/domMatrixReadOnly.spec.ts
+++ b/web_src/src/test/domMatrixReadOnly.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-describe("jsdom DOMMatrixReadOnly", () => {
+describe("DOMMatrixReadOnly polyfill", () => {
   it("exposes a constructor so React Flow can read viewport zoom", () => {
     const matrix = new window.DOMMatrixReadOnly("matrix(0.8, 0, 0, 0.8, 10, 20)");
 

--- a/web_src/src/test/nodeName.spec.ts
+++ b/web_src/src/test/nodeName.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+describe("Node.prototype.nodeName", () => {
+  it("returns the element tag when read through the base getter", () => {
+    const getter = Object.getOwnPropertyDescriptor(Node.prototype, "nodeName")?.get;
+    const element = document.createElement("div");
+
+    expect(getter?.call(element)).toBe("DIV");
+  });
+});

--- a/web_src/src/test/setup.ts
+++ b/web_src/src/test/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 
-// jsdom doesn't ship ResizeObserver; several UI primitives depend on it.
+// Some test DOMs omit ResizeObserver; several UI primitives depend on it.
 // Provide a no-op so every test file gets it for free instead of having to
 // declare it locally.
 if (typeof globalThis.ResizeObserver === "undefined") {
@@ -11,7 +11,7 @@ if (typeof globalThis.ResizeObserver === "undefined") {
   };
 }
 
-// jsdom does not implement DOMMatrixReadOnly. React Flow reads viewport zoom
+// Some test DOMs omit DOMMatrixReadOnly. React Flow reads viewport zoom
 // with `new DOMMatrixReadOnly(style.transform)` when node internals update.
 if (typeof window.DOMMatrixReadOnly !== "function") {
   class DOMMatrixReadOnlyStub {
@@ -59,7 +59,7 @@ function parseCssMatrix2d(init: string | undefined): number[] | undefined {
   return values;
 }
 
-// jsdom doesn't implement matchMedia; ThemeProvider reads it to resolve
+// Some test DOMs omit matchMedia; ThemeProvider reads it to resolve
 // "system" theme preference. Tests can override this per file when needed.
 if (typeof window.matchMedia === "undefined") {
   Object.defineProperty(window, "matchMedia", {
@@ -78,6 +78,14 @@ if (typeof window.matchMedia === "undefined") {
   });
 }
 
+// happy-dom owns Window.fetch. Tests stub globalThis.fetch; route window.fetch
+// through that binding so `vi.stubGlobal("fetch", ...)` applies to both.
+Object.defineProperty(window, "fetch", {
+  configurable: true,
+  writable: true,
+  value: ((...args: Parameters<typeof fetch>) => globalThis.fetch(...args)) as typeof fetch,
+});
+
 Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
   configurable: true,
   writable: true,
@@ -86,3 +94,42 @@ Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
     measureText: (text: string) => ({ width: text.length * 7 }),
   }),
 });
+
+// happy-dom hardcodes Node.prototype.nodeName to "" and shadows it on Element.
+// DOMPurify reads the base getter to resist clobbering, so every tag looks
+// empty and the allow-list misfires. Delegate to the instance getter.
+patchHappyDomNodeName();
+
+function patchHappyDomNodeName(): void {
+  const nodeProto = globalThis.Node?.prototype;
+  if (!nodeProto || !document) {
+    return;
+  }
+
+  const baseDesc = Object.getOwnPropertyDescriptor(nodeProto, "nodeName");
+  if (!baseDesc?.get || !baseDesc.configurable) {
+    return;
+  }
+
+  const probe = document.createElement("div");
+  if (baseDesc.get.call(probe) === probe.nodeName) {
+    return;
+  }
+
+  const baseGet = baseDesc.get;
+  Object.defineProperty(nodeProto, "nodeName", {
+    configurable: true,
+    enumerable: baseDesc.enumerable,
+    get(this: Node) {
+      let proto: object | null = Object.getPrototypeOf(this);
+      while (proto && proto !== nodeProto) {
+        const desc = Object.getOwnPropertyDescriptor(proto, "nodeName");
+        if (desc?.get) {
+          return desc.get.call(this);
+        }
+        proto = Object.getPrototypeOf(proto);
+      }
+      return baseGet.call(this);
+    },
+  });
+}

--- a/web_src/src/test/setup.ts
+++ b/web_src/src/test/setup.ts
@@ -95,6 +95,23 @@ Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
   }),
 });
 
+// happy-dom follows <a href> clicks as navigations, including download links.
+// That replaces location.href (often with a blob: URL) and breaks later
+// `new URL("/account", location.href)` fixture matching.
+window.addEventListener(
+  "click",
+  (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+    if (target.closest("a[download]")) {
+      event.preventDefault();
+    }
+  },
+  true,
+);
+
 // happy-dom hardcodes Node.prototype.nodeName to "" and shadows it on Element.
 // DOMPurify reads the base getter to resist clobbering, so every tag looks
 // empty and the allow-list misfires. Delegate to the instance getter.

--- a/web_src/vitest.config.ts
+++ b/web_src/vitest.config.ts
@@ -11,7 +11,16 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    environment: "jsdom",
+    environment: "happy-dom",
+    environmentOptions: {
+      happyDOM: {
+        settings: {
+          disableJavaScriptFileLoading: true,
+          disableCSSFileLoading: true,
+          disableIframePageLoading: true,
+        },
+      },
+    },
     setupFiles: ["./src/test/setup.ts"],
     coverage: {
       provider: "v8",

--- a/web_src/vitest.config.ts
+++ b/web_src/vitest.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
         },
       },
     },
+    // happy-dom rejects with an Event whose target is SCRIPT when a
+    // <script src> cannot load. Canvas pages inject those tags.
+    onUnhandledError(error) {
+      return !isHappyDomScriptLoadError(error);
+    },
     setupFiles: ["./src/test/setup.ts"],
     coverage: {
       provider: "v8",
@@ -34,3 +39,14 @@ export default defineConfig({
     },
   },
 });
+
+function isHappyDomScriptLoadError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const target = (error as { target?: unknown }).target;
+  if (typeof HTMLScriptElement !== "undefined" && target instanceof HTMLScriptElement) {
+    return true;
+  }
+  return target === "SCRIPT";
+}


### PR DESCRIPTION
Not ready yet, just wanted to run all tests in CI to check



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63425762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge, with non-blocking test-reliability concerns around broad script-error suppression and the still-permissive homepage fetch mock.

<sub>Reviews (2) · Last reviewed commit: ["fix a few more mismatches"](https://github.com/superplanehq/superplane/commit/9edda67f3b1afec3ad8c84f24a99b3f73dfb5f3c)</sub>

<!-- /greptile_comment -->