### PR TITLE
chore: silence Recharts zero-size warnings in tests

### DIFF
--- a/web_src/src/test/setup.ts
+++ b/web_src/src/test/setup.ts
@@ -1,4 +1,20 @@
+import { createElement, type ReactNode } from "react";
+import { vi } from "vitest";
+
 import "@testing-library/jest-dom/vitest";
+
+// jsdom has no CSS layout. Recharts ResponsiveContainer then reads
+// getBoundingClientRect after mount, overwrites initialDimension with 0x0,
+// and warns that the chart width and height must be greater than 0.
+// A numeric size skips that measure so every chart test stays quiet.
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: ReactNode }) =>
+      createElement(actual.ResponsiveContainer, { width: 760, height: 240 }, children),
+  };
+});
 
 // jsdom doesn't ship ResizeObserver; several UI primitives depend on it.
 // Provide a no-op so every test file gets it for free instead of having to

--- a/web_src/src/test/setup.ts
+++ b/web_src/src/test/setup.ts
@@ -1,4 +1,5 @@
 import { createElement, type ReactNode } from "react";
+import type * as Recharts from "recharts";
 import { vi } from "vitest";
 
 import "@testing-library/jest-dom/vitest";
@@ -8,11 +9,11 @@ import "@testing-library/jest-dom/vitest";
 // and warns that the chart width and height must be greater than 0.
 // A numeric size skips that measure so every chart test stays quiet.
 vi.mock("recharts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("recharts")>();
+  const actual = await importOriginal<typeof Recharts>();
   return {
     ...actual,
     ResponsiveContainer: ({ children }: { children: ReactNode }) =>
-      createElement(actual.ResponsiveContainer, { width: 760, height: 240 }, children),
+      createElement(actual.ResponsiveContainer, { width: 760, height: 240, children }),
   };
 });
 


### PR DESCRIPTION
jsdom does not calculate CSS layout. Recharts then measures a 0x0 box and writes a warning to stderr.
The warning is not a product defect. It appears in every unit test that mounts a chart.
This change gives ResponsiveContainer a numeric size in the shared Vitest setup. Chart tests stay quiet. Specs that already mock Recharts keep their local mock.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63427211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR appears safe to merge because the shared test mock preserves chart rendering behavior and introduces no actionable issues.

<sub>Reviews (2) · Last reviewed commit: ["fix build and eslint warnings"](https://github.com/superplanehq/superplane/commit/0bcec5844c30c14638335d4189aaa8e56afc1d6a)</sub>

<!-- /greptile_comment -->